### PR TITLE
Including testkey.pem

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 global-include *.py
 
-include *.txt CHANGELOG.md LICENSE README.md
+include *.txt CHANGELOG.md LICENSE README.md social_core/tests/testkey.pem
 recursive-include social_core/tests *.txt
 
 graft examples

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
         'Programming Language :: Python :: 3'
     ],
     package_data={
-        'social_core/tests': ['social_core/tests/*.txt']
+        'social_core/tests': ['social_core/tests/*.txt', 'social_core/tests/testkey.pem']
     },
     include_package_data=True,
     tests_require=tests_requirements,

--- a/social_core/tests/backends/open_id_connect.py
+++ b/social_core/tests/backends/open_id_connect.py
@@ -35,8 +35,8 @@ class OpenIdConnectTestMixin(object):
 
     def setUp(self):
         super(OpenIdConnectTestMixin, self).setUp()
-        here = os.path.dirname(__file__)
-        self.key = RSAKey(kid='testkey').load(os.path.join(here, '../testkey.pem'))
+        test_root = os.path.dirname(os.path.dirname(__file__))
+        self.key = RSAKey(kid='testkey').load(os.path.join(test_root, 'testkey.pem'))
         HTTPretty.register_uri(HTTPretty.GET,
           self.backend.OIDC_ENDPOINT + '/.well-known/openid-configuration',
           status=200,


### PR DESCRIPTION
This file is needed by OpenIdConnectTestMixin. Any packages/projects wanting to use the mixin need the test key.