### PR TITLE
response content of QQ should be decoded first

### DIFF
--- a/social_core/backends/qq.py
+++ b/social_core/backends/qq.py
@@ -50,7 +50,8 @@ class QQOAuth2(BaseOAuth2):
         response = self.request(self.OPENID_URL, params={
             'access_token': access_token
         })
-        data = json.loads(response.content[10:-3])
+        content = response.content.decode()
+        data = json.loads(content[10:-3])
         return data['openid']
 
     def user_data(self, access_token, *args, **kwargs):


### PR DESCRIPTION
I have to decode response content first, as the type of response.content is 'bytes' but the JSON object requires 'str'.
