### PR TITLE
Allow extra arguments for azuread backend.

### DIFF
--- a/social_core/backends/azuread.py
+++ b/social_core/backends/azuread.py
@@ -85,10 +85,10 @@ class AzureADOAuth2(BaseOAuth2):
     def auth_extra_arguments(self):
         """Return extra arguments needed on auth process. The defaults can be
         overriden by GET parameters."""
-        extra_arguments = {}
+        extra_arguments =  super(AzureADOAuth2, self).auth_extra_arguments()
         resource = self.setting('RESOURCE')
         if resource:
-            extra_arguments = {'resource': resource}
+            extra_arguments.update({'resource': resource})
         return extra_arguments
 
     def extra_data(self, user, uid, response, details=None, *args, **kwargs):


### PR DESCRIPTION
Calling the `auth_extra_arguments()` method of the parent class allows to add extra params to the request. Handy to include `login_hint` and `domain_hint` among others.

Azure AD oauth call docs: https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-oauth-code#request-an-authorization-code