### PR TITLE
Mediawiki: Raise exception if response is error

### DIFF
--- a/social_core/backends/mediawiki.py
+++ b/social_core/backends/mediawiki.py
@@ -62,6 +62,10 @@ class MediaWiki(BaseOAuth1):
             ),
             method=self.REQUEST_TOKEN_METHOD
         )
+
+        if response.content.decode().startswith('Error'):
+            raise AuthException(self, response.content.decode())
+
         return response.content.decode()
 
     def oauth_authorization_request(self, token):


### PR DESCRIPTION
If an error occurs during the initial handshake, the error
message is currently not visible to developers.
This commit checks if the response starts with an error
message and raises an exception.