### PR TITLE
The Steam backend should use steamid instead of personaname to identify users

### DIFF
--- a/social_core/backends/steam.py
+++ b/social_core/backends/steam.py
@@ -24,7 +24,7 @@ class SteamOpenId(OpenIdAuth):
         })
         if len(player['response']['players']) > 0:
             player = player['response']['players'][0]
-            details = {'username': player.get('personaname'),
+            details = {'username': player.get('steamid'),
                        'email': '',
                        'fullname': '',
                        'first_name': '',

--- a/social_core/tests/backends/test_steam.py
+++ b/social_core/tests/backends/test_steam.py
@@ -16,7 +16,7 @@ JANRAIN_NONCE = datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')
 
 class SteamOpenIdTest(OpenIdTest):
     backend_path = 'social_core.backends.steam.SteamOpenId'
-    expected_username = 'foobar'
+    expected_username = '123'
     discovery_body = ''.join([
       '<?xml version="1.0" encoding="UTF-8"?>',
       '<xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)">',


### PR DESCRIPTION
Use the correct attribute to identify Steam users.

Closes [#64](https://github.com/python-social-auth/social-core/issues/64)