### PR TITLE
Avoid reusing verification codes

### DIFF
--- a/social_core/strategy.py
+++ b/social_core/strategy.py
@@ -139,6 +139,8 @@ class BaseStrategy(object):
             return False
         elif verification_code.email != email:
             return False
+        elif verification_code.verified:
+            return False
         else:
             verification_code.verify()
             return True


### PR DESCRIPTION
Once the code has been used, it should not validate the address again.

Maybe I'm missing something in the code, but it seems that the verified attribute is not really used and because of this the validation codes are valid even after they have been used and it's possible to reuse the partial URLs.