### PR TITLE
Updated BaseAuth.authenticate() to prefer kwargs

### DIFF
--- a/social_core/backends/base.py
+++ b/social_core/backends/base.py
@@ -70,8 +70,8 @@ class BaseAuth(object):
            'strategy' not in kwargs or 'response' not in kwargs:
             return None
 
-        self.strategy = self.strategy or kwargs.get('strategy')
-        self.redirect_uri = self.redirect_uri or kwargs.get('redirect_uri')
+        self.strategy = kwargs.get('strategy') or self.strategy
+        self.redirect_uri = kwargs.get('redirect_uri') or self.redirect_uri
         self.data = self.strategy.request_data()
         kwargs.setdefault('is_new', False)
         pipeline = self.strategy.get_pipeline(self)


### PR DESCRIPTION
The strategy and redirect_uri passed as kwargs are now preferred to those values set in the constructor. The primary goal of this change is to ensure that the strategy has a request attached so that downstream code can make use of the request.

Fixes #73