### PR TITLE
Fix auth header formatting problem. (fitbit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/python-social-auth/social-core/commits/master)
 
+### Changed
+- Fix auth header formatting problem for Fitbit OAuth2
+
 ## [1.3.0](https://github.com/python-social-auth/social-core/releases/tag/1.3.0) - 2017-05-06
 
 ### Added

--- a/social_core/backends/fitbit.py
+++ b/social_core/backends/fitbit.py
@@ -59,8 +59,9 @@ class FitbitOAuth2(BaseOAuth2):
         )['user']
 
     def auth_headers(self):
+        tokens = '{0}:{1}'.format(*self.get_key_and_secret())
+        tokens = base64.urlsafe_b64encode(tokens.encode())
+        tokens = tokens.decode()
         return {
-            'Authorization': 'Basic {0}'.format(base64.urlsafe_b64encode(
-                ('{0}:{1}'.format(*self.get_key_and_secret()).encode())
-            ))
+            'Authorization': 'Basic {0}'.format(tokens)
         }


### PR DESCRIPTION
Before the results was like:

`{'Authorization': 'Basic b"o9834yf0398efyq30br87fyb30f8u3hyb"'}`

There was the `b""` Python formating for byte strings. So I added a decode step.

Final result is like:

`{'Authorization': 'Basic o9834yf0398efyq30br87fyb30f8u3hyb'}`