### PR TITLE
Raise AuthForbidden on 401.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/python-social-auth/social-core/commits/master)
 
+### Changed
+- Raise AuthForbidden when provider returns 401.
+
 ## [1.3.0](https://github.com/python-social-auth/social-core/releases/tag/1.3.0) - 2017-05-06
 
 ### Added

--- a/social_core/utils.py
+++ b/social_core/utils.py
@@ -16,7 +16,7 @@ from six.moves.urllib_parse import urlparse, urlunparse, urlencode, \
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.poolmanager import PoolManager
 
-from .exceptions import AuthCanceled, AuthUnreachableProvider
+from .exceptions import AuthCanceled, AuthForbidden, AuthUnreachableProvider
 
 
 SETTING_PREFIX = 'SOCIAL_AUTH'
@@ -253,6 +253,8 @@ def handle_http_errors(func):
         except requests.HTTPError as err:
             if err.response.status_code == 400:
                 raise AuthCanceled(args[0], response=err.response)
+            elif err.response.status_code == 401:
+                raise AuthForbidden(args[0])
             elif err.response.status_code == 503:
                 raise AuthUnreachableProvider(args[0])
             else:


### PR DESCRIPTION
This causes middlewere to catch the exception,
which prevents the server error, for example when
user presses back button on browser and repeaats the request
with already used grant code.