### PR TITLE
Add udata/datagouvfr backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix auth header formatting problem for Fitbit OAuth2
 - Raise AuthForbidden when provider returns 401.
 
+### Added
+- Added Udata OAuth2 backend
+
 ## [1.3.0](https://github.com/python-social-auth/social-core/releases/tag/1.3.0) - 2017-05-06
 
 ### Added

--- a/social_core/backends/udata.py
+++ b/social_core/backends/udata.py
@@ -1,0 +1,37 @@
+"""
+Udata related backends.
+
+Docs at:
+    https://python-social-auth.readthedocs.io/en/latest/backends/udata.html
+"""
+from .oauth import BaseOAuth2
+
+
+class UdataBaseOAuth2(BaseOAuth2):
+    """Udata base OAuth authentication backend."""
+    SCOPE_SEPARATOR = ','
+    REDIRECT_STATE = False
+    DEFAULT_SCOPE = ['default']
+    ACCESS_TOKEN_METHOD = 'POST'
+
+    def get_user_details(self, response):
+        """Return user details from Udata account."""
+        return {
+            'username': response.get('first_name'),
+            'email': response.get('email') or '',
+            'first_name': response.get('first_name')
+        }
+
+    def user_data(self, access_token, *args, **kwargs):
+        """Load user data from service."""
+        return self.get_json(self.USER_DATA_URL, params={
+            'access_token': access_token
+        })
+
+
+class DatagouvfrOAuth2(UdataBaseOAuth2):
+    """Datagouvfr OAuth authentication backend."""
+    name = 'datagouv'
+    ACCESS_TOKEN_URL = 'https://www.data.gouv.fr/oauth/token'
+    AUTHORIZATION_URL = 'https://www.data.gouv.fr/oauth/authorize'
+    USER_DATA_URL = 'https://www.data.gouv.fr/api/1/me/'

--- a/social_core/tests/backends/test_udata.py
+++ b/social_core/tests/backends/test_udata.py
@@ -11,7 +11,9 @@ class DatagouvfrOAuth2Test(OAuth2Test):
     expected_username = 'foobar'
     access_token_body = json.dumps({
         'access_token': 'foobar',
-        'token_type': 'bearer'
+        'token_type': 'bearer',
+        'first_name': 'foobar',
+        'email': 'foobar@example.com'
     })
     request_token_body = urlencode({
         'oauth_token_secret': 'foobar-secret',

--- a/social_core/tests/backends/test_udata.py
+++ b/social_core/tests/backends/test_udata.py
@@ -1,0 +1,27 @@
+import json
+
+from six.moves.urllib_parse import urlencode
+
+from .oauth import OAuth2Test
+
+
+class DatagouvfrOAuth2Test(OAuth2Test):
+    backend_path = 'social_core.backends.udata.DatagouvfrOAuth2'
+    user_data_url = 'https://www.data.gouv.fr/api/1/me/'
+    expected_username = 'foobar'
+    access_token_body = json.dumps({
+        'access_token': 'foobar',
+        'token_type': 'bearer'
+    })
+    request_token_body = urlencode({
+        'oauth_token_secret': 'foobar-secret',
+        'oauth_token': 'foobar',
+        'oauth_callback_confirmed': 'true'
+    })
+    user_data_body = json.dumps({})
+
+    def test_login(self):
+        self.do_login()
+
+    def test_partial_pipeline(self):
+        self.do_partial_pipeline()


### PR DESCRIPTION
Add a generic base class for [udata](http://udata.readthedocs.io/en/latest/) backend, set as a base class given that French are not the only ones using that platform.

I need some help to understand how tests are working. I don't get how to set up the username for instance, do I have to create a dummy account on the platform?

(Incoming social-docs PR counter-part)