### PR TITLE
Maintain `attributes` key when sending in response for SAML

### DIFF
--- a/social_core/backends/saml.py
+++ b/social_core/backends/saml.py
@@ -312,7 +312,7 @@ class SAMLAuth(BaseAuth):
 
     def extra_data(self, user, uid, response, details=None, *args, **kwargs):
         return super(SAMLAuth, self).extra_data(user, uid,
-                                                response['attributes'],
+                                                {'attributes': response['attributes']},
                                                 details=details,
                                                 *args, **kwargs)
 


### PR DESCRIPTION
Without this, one cannot eventually retrieve `attributes` by referencing the key because it's already dereferenced. It's hard to get what you want through the [base `extra_data` method](https://github.com/python-social-auth/social-core/blob/master/social_core/backends/base.py#L113) when your [`EXTRA_DATA`](https://github.com/python-social-auth/social-core/blob/master/social_core/backends/saml.py#L172) list has to specify all the specific received keys, instead of just specifying "`attributes`".

Either this, or make the internal `EXTRA_DATA` have "attributes" as an element and make the method just pass in `response` without any dereferencing, like so:

```python
EXTRA_DATA = ['attributes']

...

def extra_data(self, user, uid, response, details=None, *args, **kwargs):
    return super(SAMLAuth, self).extra_data(user, uid, response, details=details,
                                            *args, **kwargs)
```