### PR TITLE
Allow to get all extra data in a response through setting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added Udata OAuth2 backend
 - Added ORCID backend
+- Added feature to get all extra data from backend through `GET_ALL_EXTRA_DATA` boolean flag.
 
 ## [1.3.0](https://github.com/python-social-auth/social-core/releases/tag/1.3.0) - 2017-05-06
 

--- a/social_core/backends/base.py
+++ b/social_core/backends/base.py
@@ -13,6 +13,7 @@ class BaseAuth(object):
     supports_inactive_user = False  # Django auth
     ID_KEY = None
     EXTRA_DATA = None
+    GET_ALL_EXTRA_DATA = False
     REQUIRES_EMAIL_VALIDATION = False
     SEND_USER_AGENT = False
     SSL_PROTOCOL = None
@@ -116,7 +117,12 @@ class BaseAuth(object):
             # store the last time authentication toke place
             'auth_time': int(time.time())
         }
-        for entry in (self.EXTRA_DATA or []) + self.setting('EXTRA_DATA', []):
+        extra_data_entries = []
+        if self.GET_ALL_EXTRA_DATA or self.setting('GET_ALL_EXTRA_DATA', False):
+            extra_data_entries = response.keys()
+        else:
+            extra_data_entries = (self.EXTRA_DATA or []) + self.setting('EXTRA_DATA', [])
+        for entry in extra_data_entries:
             if not isinstance(entry, (list, tuple)):
                 entry = (entry,)
             size = len(entry)


### PR DESCRIPTION
The idea is from [@haikuginger](https://github.com/python-social-auth/social-core/pull/84#issuecomment-303146208) and answers [Issue #85](https://github.com/python-social-auth/social-core/issues/85).

We allow the user to get all extra data without having to specify each key explicitly in an `EXTRA_DATA` setting; this has many use cases and is backwards compatible by virtue of defaulting to `False`.

P.S. @omab If this looks good, I can add the necessary documentation in the docs repo. Excited to continue contributing to this lib.