### PR TITLE
Fix DisqusOAuth2 backend since the callback URL is now validated

### DIFF
--- a/social_core/backends/disqus.py
+++ b/social_core/backends/disqus.py
@@ -10,6 +10,7 @@ class DisqusOAuth2(BaseOAuth2):
     AUTHORIZATION_URL = 'https://disqus.com/api/oauth/2.0/authorize/'
     ACCESS_TOKEN_URL = 'https://disqus.com/api/oauth/2.0/access_token/'
     ACCESS_TOKEN_METHOD = 'POST'
+    REDIRECT_STATE = False
     SCOPE_SEPARATOR = ','
     EXTRA_DATA = [
         ('avatar', 'avatar'),


### PR DESCRIPTION
Disqus now returns the following error if redirect_state is used:

Invalid Request: Invalid parameter: redirect_uri (should match predefined callback URI)