### PR TITLE
Adds Patreon OAuth2 backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/python-social-auth/social-core/commits/master)
 
+- Added Patreon provider
+
 ### Changed
 - Fix path in import BaseOAuth2 for Monzo
 - Fix auth header formatting problem for Fitbit OAuth2

--- a/social_core/backends/patreon.py
+++ b/social_core/backends/patreon.py
@@ -1,0 +1,41 @@
+"""
+Patreon OAuth2 backend
+https://www.patreon.com/platform/documentation/oauth
+"""
+from .oauth import BaseOAuth2
+
+
+class PatreonOAuth2(BaseOAuth2):
+    """Patreon OAuth2 authentication backend"""
+    name = 'patreon'
+    AUTHORIZATION_URL = 'https://www.patreon.com/oauth2/authorize'
+    ACCESS_TOKEN_URL = 'https://api.patreon.com/oauth2/token'
+    REVOKE_TOKEN_URL = 'https://api.patreon.com/oauth2/revoke'
+    ACCESS_TOKEN_METHOD = 'POST'
+    REDIRECT_STATE = False
+    ID_KEY = 'id'
+    EXTRA_DATA = [
+        ('id', 'id'),
+    ]
+
+    def get_user_details(self, response):
+        details = response['attributes']
+        return {
+            'username': details.get('full_name'),
+            'email': details.get('email'),
+            'fullname': details.get('full_name'),
+            'first_name': details.get('first_name'),
+            'last_name': details.get('last_name'),
+        }
+
+    def user_data(self, access_token, *args, **kwargs):
+        return self.get_api(access_token, 'current_user')['data']
+
+    def get_api(self, access_token, suffix):
+        return self.get_json(
+            'https://api.patreon.com/oauth2/api/{}'.format(suffix),
+            headers=self.get_auth_header(access_token)
+        )
+
+    def get_auth_header(self, access_token):
+        return {'Authorization': 'Bearer {0}'.format(access_token)}

--- a/social_core/tests/backends/test_patreon.py
+++ b/social_core/tests/backends/test_patreon.py
@@ -6,7 +6,7 @@ from .oauth import OAuth2Test
 class PatreonOAuth2Test(OAuth2Test):
     backend_path = 'social_core.backends.patreon.PatreonOAuth2'
     user_data_url = 'https://api.patreon.com/oauth2/api/current_user'
-    expected_username = 'John Interwebs'
+    expected_username = 'JohnInterwebs'
     access_token_body = json.dumps({
         'access_token': 'foobar',
         'token_type': 'bearer',

--- a/social_core/tests/backends/test_patreon.py
+++ b/social_core/tests/backends/test_patreon.py
@@ -1,0 +1,65 @@
+import json
+
+from .oauth import OAuth2Test
+
+
+class PatreonOAuth2Test(OAuth2Test):
+    backend_path = 'social_core.backends.patreon.PatreonOAuth2'
+    user_data_url = 'https://api.patreon.com/oauth2/api/current_user'
+    expected_username = 'John Interwebs'
+    access_token_body = json.dumps({
+        'access_token': 'foobar',
+        'token_type': 'bearer',
+    })
+    user_data_body = json.dumps({
+        "data": {
+            "relationships": {
+                "pledges": {
+                    "data": [{
+                        "type": "pledge", "id": "123456"
+                    }]
+                }
+            },
+            "attributes": {
+                "last_name": "Interwebs",
+                "is_suspended": False,
+                "has_password": True,
+                "full_name": "John Interwebs",
+                "is_nuked": False,
+                "first_name": "John",
+                "social_connections": {
+                    "spotify": None,
+                    "discord": None,
+                    "twitter": None,
+                    "youtube": None,
+                    "facebook": None,
+                    "deviantart": None,
+                    "twitch": None
+                },
+                "twitter": None,
+                "is_email_verified": True,
+                "facebook_id": None,
+                "email": "john@example.com",
+                "facebook": None,
+                "thumb_url": "https://c8.patreon.com/100/123456",
+                "vanity": None,
+                "about": None,
+                "is_deleted": False,
+                "created": "2017-05-05T05:16:34+00:00",
+                "url": "https://www.patreon.com/user?u=123456",
+                "gender": 0,
+                "youtube": None,
+                "discord_id": None,
+                "image_url": "https://c8.patreon.com/400/123456",
+                "twitch": None
+            },
+            "type": "user",
+            "id": "123456"
+        }
+    })
+
+    def test_login(self):
+        self.do_login()
+
+    def test_partial_pipeline(self):
+        self.do_partial_pipeline()


### PR DESCRIPTION
As per documentation at https://www.patreon.com/platform/documentation/oauth

We were using this with an older python-social-auth (0.2.21), but I've ported this forward to social-core so upstream benefits and it's not stuck in our forked version.

Tests should pass - am having issues running tox locally, but will see what your CI (assuming Travis) does.