### PR TITLE
Update get_attr to use the entire value if an attribute is single-valued

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Speed up authorization process for VKAppOAuth2
 - Apply same sanitization as on connect to disconnect.
 - Disable `redirect_state` usage on Disqus backend
+- Fix using the entire SAML2 nameid string
 
 ### Added
 - Added Udata OAuth2 backend

--- a/social_core/backends/saml.py
+++ b/social_core/backends/saml.py
@@ -73,7 +73,10 @@ class SAMLIdentityProvider(object):
         another attribute to use.
         """
         key = self.conf.get(conf_key, default_attribute)
-        return attributes[key][0] if key in attributes else None
+        value = attributes[key] if key in attributes else None
+        if isinstance(value, list):
+            value = value[0]
+        return value
 
     @property
     def entity_id(self):


### PR DESCRIPTION
NameID is a single-valued value, which means that when [0] is applied to it, we grab
just the first letter instead of the full nameid.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>

Fixes #101 