### PR TITLE
Remove unnecessary blocker for refresh_token in BitBucketOAuth2 backend

### DIFF
--- a/social_core/backends/bitbucket.py
+++ b/social_core/backends/bitbucket.py
@@ -81,10 +81,6 @@ class BitbucketOAuth2(BitbucketOAuthBase, BaseOAuth2):
         return self.get_json('https://api.bitbucket.org/2.0/user/emails',
                              params={'access_token': access_token})
 
-    def refresh_token(self, *args, **kwargs):
-        raise NotImplementedError('Refresh tokens for Bitbucket have '
-                                  'not been implemented')
-
 
 class BitbucketOAuth(BitbucketOAuthBase, BaseOAuth1):
     """Bitbucket OAuth authentication backend"""


### PR DESCRIPTION
Removal of the blocking method with `NotImplementedError` makes the backend work with refreshing tokens. Tested with
```python
def get_token(user):
    social = user.social_auth.get(provider='bitbucket-oauth2')
    if social.access_token_expired():
        # social.refresh_token()
        strategy=load_strategy()
        backend=social.get_backend(strategy)
        instance=social.get_backend_instance(strategy)
        data = super(backend, instance).refresh_token(social.extra_data['refresh_token'])
        data.update({'auth_time': datetime.now().timestamp()})
        data['expires']=data.pop('expires_in')
   return social.access_token

token=get_token(user)
print(token)
```