### PR TITLE
gitlab: use api v4

### DIFF
--- a/social_core/backends/gitlab.py
+++ b/social_core/backends/gitlab.py
@@ -53,6 +53,6 @@ class GitLabOAuth2(BaseOAuth2):
 
     def user_data(self, access_token, *args, **kwargs):
         """Loads user data from service"""
-        return self.get_json(self.api_url('/api/v3/user'), params={
+        return self.get_json(self.api_url('/api/v4/user'), params={
             'access_token': access_token
         })


### PR DESCRIPTION
https://docs.gitlab.com/ce/api/v3_to_v4.html:

> API V3 will be removed in GitLab 9.5, to be released on August 22, 2017. In the meantime, we advise you to make any necessary changes to applications that use V3. The V3 API documentation is still available.