### PR TITLE
fix weixin default scope

### DIFF
--- a/social_core/backends/weixin.py
+++ b/social_core/backends/weixin.py
@@ -17,6 +17,7 @@ class WeixinOAuth2(BaseOAuth2):
     AUTHORIZATION_URL = 'https://open.weixin.qq.com/connect/qrconnect'
     ACCESS_TOKEN_URL = 'https://api.weixin.qq.com/sns/oauth2/access_token'
     ACCESS_TOKEN_METHOD = 'POST'
+    DEFAULT_SCOPE = 'snsapi_login'
     REDIRECT_STATE = False
     EXTRA_DATA = [
         ('nickname', 'username'),


### PR DESCRIPTION
Weixin oauth api doc requires an additional paramter: 'scope': 'snsapi_login'.
Otherwise, it would not work.