### PR TITLE
Fix Issue #133: Constant time compare for state validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Fix using the entire SAML2 nameid string
+- Prevent timing attacks against state token  
 
 ### Added
 - Added support for Bungie.net OAuth2 backend

--- a/social_core/backends/oauth.py
+++ b/social_core/backends/oauth.py
@@ -5,7 +5,7 @@ from oauthlib.oauth1 import SIGNATURE_TYPE_AUTH_HEADER
 
 from six.moves.urllib_parse import urlencode, unquote
 
-from ..utils import url_add_parameters, parse_qs, handle_http_errors
+from ..utils import url_add_parameters, parse_qs, handle_http_errors, constant_time_compare
 from ..exceptions import AuthFailed, AuthCanceled, AuthUnknownError, \
                          AuthMissingParameter, AuthStateMissing, \
                          AuthStateForbidden, AuthTokenError
@@ -87,7 +87,7 @@ class OAuthAuth(BaseAuth):
             raise AuthMissingParameter(self, 'state')
         elif not state:
             raise AuthStateMissing(self, 'state')
-        elif not request_state == state:
+        elif not constant_time_compare(request_state, state):
             raise AuthStateForbidden(self)
         else:
             return state


### PR DESCRIPTION
Issue #133 fixed:
Use the `constant_time_compare` method from the `social_core.utils` package to prevent [timing attacks](https://cryptocoding.net/index.php/Coding_rules#Compare_secret_strings_in_constant_time) against the state token during the state token validation.