### PR TITLE
Fix header being set to pass the token in the LinkedIn OAuth2 back-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Update EvenOnline token expiration key
+- Fix LinkedIn backend to send the oauth_token as `Authorization` header
 
 ## [1.6.0](https://github.com/python-social-auth/social-core/releases/tag/1.6.0) - 2017-12-22
 

--- a/social_core/backends/linkedin.py
+++ b/social_core/backends/linkedin.py
@@ -82,7 +82,7 @@ class LinkedinOAuth2(BaseLinkedinAuth, BaseOAuth2):
 
     def user_data(self, access_token, *args, **kwargs):
         headers = self.user_data_headers() or {}
-        headers['oauth_token'] = access_token
+        headers['Authorization'] = "Bearer {access_token}".format(access_token=access_token)
         return self.get_json(
             self.user_details_url(),
             params={'format': 'json'},


### PR DESCRIPTION
Fixes #173

As per [the LinkedIn docs](https://developer.linkedin.com/docs/oauth2), the OAuth token should be passed back to LinkedIn as a request header. It should be as `Authorization: Bearer ...`, though, instead of `oauth_token`. The latter makes LinkedIn crash with an internal server error.