### PR TITLE
updated code to fallback on userPrincipalName for email - Microsoft backend

### DIFF
--- a/social_core/backends/microsoft.py
+++ b/social_core/backends/microsoft.py
@@ -46,9 +46,13 @@ class MicrosoftOAuth2(BaseOAuth2):
     def get_user_details(self, response):
         """Return user details from Microsoft online account"""
         email = response.get('mail')
+        username = response.get('userPrincipalName')
         if not email and '@' in response.get('userPrincipalName'):
             email = response.get('userPrincipalName')
-        return {'username': response.get('displayName', ''),
+        if '@' in username:
+            username = username.split('@')[0]
+
+        return {'username': username,
                 'email': email,
                 'fullname': response.get('displayName', ''),
                 'first_name': response.get('givenName', ''),

--- a/social_core/backends/microsoft.py
+++ b/social_core/backends/microsoft.py
@@ -45,8 +45,11 @@ class MicrosoftOAuth2(BaseOAuth2):
 
     def get_user_details(self, response):
         """Return user details from Microsoft online account"""
+        email = response.get('mail')
+        if not email and '@' in response.get('userPrincipalName'):
+            email = response.get('userPrincipalName')
         return {'username': response.get('displayName', ''),
-                'email': response.get('mail'),
+                'email': email,
                 'fullname': response.get('displayName', ''),
                 'first_name': response.get('givenName', ''),
                 'last_name': response.get('surname', '')}


### PR DESCRIPTION
'`mail`' field is often null when the accounts are not native Microsoft one, and in those cases, `userPrincipalName` field is used. You can find some more information on [here](https://stackoverflow.com/questions/47344384/microsoft-azure-ad-graph-api-how-do-i-retrieve-a-users-email-address). With this change it tries to get `email` from `userPrincipalname` if the `mail` field is empty. (The check for the type of `userPrincipalName` can be improved, although if `userPrincipalName` is not email, in that case, you can expect that value of `mail` will be there. )