### PR TITLE
Added LinkedIn mobile authentication backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Update EvenOnline token expiration key
 - Update OpenStreetMap URL to `https`
 - Fix LinkedIn backend to send the oauth_token as `Authorization` header
+- Added LinkedinMobileOAuth2 backend
 
 ## [1.6.0](https://github.com/python-social-auth/social-core/releases/tag/1.6.0) - 2017-12-22
 

--- a/social_core/backends/linkedin.py
+++ b/social_core/backends/linkedin.py
@@ -98,3 +98,19 @@ class LinkedinOAuth2(BaseLinkedinAuth, BaseOAuth2):
         return super(LinkedinOAuth2, self).request_access_token(
             *args, **kwargs
         )
+
+
+class LinkedinMobileOAuth2(LinkedinOAuth2):
+    name = 'linkedin-mobile-oauth2'
+
+    def user_data(self, access_token, *args, **kwargs):
+        headers = self.user_data_headers()
+        if not headers:
+            headers = {}
+        headers['Authorization'] = 'Bearer ' + access_token
+        headers['x-li-src'] = 'msdk'
+        return self.get_json(
+            self.user_details_url(),
+            params={'format': 'json'},
+            headers=headers
+        )

--- a/social_core/tests/backends/test_linkedin.py
+++ b/social_core/tests/backends/test_linkedin.py
@@ -38,3 +38,7 @@ class LinkedinOAuth1Test(BaseLinkedinTest, OAuth1Test):
 
 class LinkedinOAuth2Test(BaseLinkedinTest, OAuth2Test):
     backend_path = 'social_core.backends.linkedin.LinkedinOAuth2'
+
+
+class LinkedinMobileOAuth2Test(BaseLinkedinTest, OAuth2Test):
+    backend_path = 'social_core.backends.linkedin.LinkedinMobileOAuth2'


### PR DESCRIPTION
LinkedIn uses 2 separate access tokens for their mobile sdk client and the web client.

Currently python-social-auth uses the web client. This means that in a project which has user account registrations possible from both a web view and a mobile client, when the user registers in the mobile client, he will not be able to make authentication requests to the web server, since the mobile access key doesn't work for web requests.

This merge request solves the issue by adding a separate authentication backend which imitates LinkedIn mobile SDK requests.

https://stackoverflow.com/a/39032743/2529583
https://stackoverflow.com/a/41221636/2529583

Please tell me if there are any improvements required.