### PR TITLE
Add aliased extra_data field on refresh_token

### DIFF
--- a/social_core/backends/base.py
+++ b/social_core/backends/base.py
@@ -139,7 +139,7 @@ class BaseAuth(object):
                 elif size == 1:
                     name = alias = entry[0]
                     discard = False
-                value = response.get(name) or details.get(name)
+                value = response.get(name) or details.get(name) or details.get(alias)
                 if discard and not value:
                     continue
                 data[alias] = value


### PR DESCRIPTION
When updating extra_data in `UserMixin.refresh_token`, some fields with data get overridden with `None`, because they are stored with the alias and not the original name (like `expires_in` → `expires` and `id` → `user_id` for google plus).

So this should fix those cases.