### PR TITLE
Use params instead of data in token request, if the method is GET.

### DIFF
--- a/social_core/backends/oauth.py
+++ b/social_core/backends/oauth.py
@@ -386,10 +386,16 @@ class BaseOAuth2(OAuthAuth):
         """Completes login process, must return user instance"""
         self.process_error(self.data)
         state = self.validate_state()
+        data, params = None, None
+        if self.ACCESS_TOKEN_METHOD == 'GET':
+            params = self.auth_complete_params(state)
+        else:
+            data = self.auth_complete_params(state)
 
         response = self.request_access_token(
             self.access_token_url(),
-            data=self.auth_complete_params(state),
+            data=data,
+            params=params,
             headers=self.auth_headers(),
             auth=self.auth_complete_credentials(),
             method=self.ACCESS_TOKEN_METHOD


### PR DESCRIPTION
I had a case of 411 (Content-Length required) on Jive because the parameters were sent as data. #185 