### PR TITLE
Store all data in order to save Google ID token.

### DIFF
--- a/social_core/backends/google_openidconnect.py
+++ b/social_core/backends/google_openidconnect.py
@@ -12,6 +12,7 @@ class GoogleOpenIdConnect(GoogleOAuth2, OpenIdConnectAuth):
     # differs from value in discovery document
     # http://openid.net/specs/openid-connect-core-1_0.html#rfc.section.15.6.2
     ID_TOKEN_ISSUER = 'accounts.google.com'
+    GET_ALL_EXTRA_DATA = True
 
     def user_data(self, access_token, *args, **kwargs):
         """Return user data from Google API"""


### PR DESCRIPTION
Store all the data received from Google OpenID Connect backend, in order to save ID token. 