### PR TITLE
Allow for cases where SAML user_permanent_id is not a list

### DIFF
--- a/social_core/backends/saml.py
+++ b/social_core/backends/saml.py
@@ -42,9 +42,10 @@ class SAMLIdentityProvider(object):
         If you want to use the NameID, it's available via
         attributes['name_id']
         """
-        return attributes[
-            self.conf.get('attr_user_permanent_id', OID_USERID)
-        ][0]
+        uid = attributes[self.conf.get('attr_user_permanent_id', OID_USERID)]
+        if isinstance(uid, list):
+            uid = uid[0]
+        return uid
 
     # Attributes processing:
     def get_user_details(self, attributes):


### PR DESCRIPTION
In that case, the method as originally given returns the first character of the UID string instead of the full UID.