### PR TITLE
Remove additional 'redirect_state' parameter from GitHub backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/python-social-auth/social-core/commits/master)
 
+### Changed
+- GitHub backend now uses `state` parameter instead of `redirect_state`
+
 ## [1.7.0](https://github.com/python-social-auth/social-core/releases/tag/1.7.0) - 2018-02-20
 
 ### Changed

--- a/social_core/backends/github.py
+++ b/social_core/backends/github.py
@@ -18,6 +18,8 @@ class GithubOAuth2(BaseOAuth2):
     ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token'
     ACCESS_TOKEN_METHOD = 'POST'
     SCOPE_SEPARATOR = ','
+    REDIRECT_STATE = False
+    STATE_PARAMETER = True
     EXTRA_DATA = [
         ('id', 'id'),
         ('expires', 'expires'),


### PR DESCRIPTION
GitHub understands the `state` parameter on their OAuth flows:
https://developer.github.com/apps/building-oauth-apps/authorization-options-for-oauth-apps/#web-application-flow

The current configuration using `redirect_state` actually breaks OAuth flows using GitHub Apps as they [don't support any extra parameters in the redirect URI](https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/)