### PR TITLE
Fixed literal warnings in slugify

### DIFF
--- a/social_core/utils.py
+++ b/social_core/utils.py
@@ -138,8 +138,8 @@ def slugify(value):
     value = unicodedata.normalize('NFKD', six.text_type(value)) \
                        .encode('ascii', 'ignore') \
                        .decode('ascii')
-    value = re.sub('[^\w\s-]', '', value).strip().lower()
-    return re.sub('[-\s]+', '-', value)
+    value = re.sub(r'[^\w\s-]', '', value).strip().lower()
+    return re.sub(r'[-\s]+', '-', value)
 
 
 def first(func, items):


### PR DESCRIPTION
Running my test with enabled warnings I have
```bash
../lib/social_core/utils.py:138: DeprecationWarning: invalid escape sequence \w
  value = re.sub('[^\w\s-]', '', value).strip().lower()
../lib/social_core/utils.py:139: DeprecationWarning: invalid escape sequence \s
  return re.sub('[-\s]+', '-', value)
```
This PR uses raw strings.