### PR TITLE
Unpin the test requirements and use unittest2 for Python 3

### DIFF
--- a/social_core/tests/requirements-python2.txt
+++ b/social_core/tests/requirements-python2.txt
@@ -1,3 +1,3 @@
 -r requirements-base.txt
-unittest2==0.5.1
-mock==1.0.1
+unittest2
+mock

--- a/social_core/tests/requirements-python3.txt
+++ b/social_core/tests/requirements-python3.txt
@@ -1,2 +1,2 @@
 -r requirements-base.txt
-unittest2py3k==0.5.1
+unittest2


### PR DESCRIPTION
unittest2 now supports Python 3 and the old unittest2py3k package is
abandoned: https://pypi.org/project/unittest2/.