### PR TITLE
fix slack backend get_user_details

### DIFF
--- a/social_core/backends/slack.py
+++ b/social_core/backends/slack.py
@@ -40,7 +40,7 @@ class SlackOAuth2(BaseOAuth2):
 
         if self.setting('USERNAME_WITH_TEAM', True) and team and \
            'name' in team:
-            name = '{0}@{1}'.format(name, response['team']['name'])
+            username = '{0}@{1}'.format(username, response['team']['name'])
 
         return {
             'username': username,


### PR DESCRIPTION
contract correct username when USERNAME_WITH_TEAM settings enabled