### PR TITLE
fix qq bug when get access token

### DIFF
--- a/social_core/backends/qq.py
+++ b/social_core/backends/qq.py
@@ -67,5 +67,10 @@ class QQOAuth2(BaseOAuth2):
         return response
 
     def request_access_token(self, url, data, *args, **kwargs):
-        response = self.request(url, params=data, *args, **kwargs)
+	#it'll occur to error if the data is None.so should add the judgement.
+	# the request will add the param automatically,which contains the post data.
+	if kwargs.has_key("params") and data is None:
+	    response = self.request(url,*args,**kwargs)
+	else:
+            response = self.request(url, params=data, *args, **kwargs)
         return parse_qs(response.content)


### PR DESCRIPTION
when getting access token for qq,it'll raise exception if the data is None.
so we should take a judgement before sending post request.
