### PR TITLE
Remove backend.name from error msg for already-associated accounts

### DIFF
--- a/social_core/pipeline/social_auth.py
+++ b/social_core/pipeline/social_auth.py
@@ -19,7 +19,7 @@ def social_user(backend, uid, user=None, *args, **kwargs):
     social = backend.strategy.storage.user.get_social_auth(provider, uid)
     if social:
         if user and social.user != user:
-            msg = 'This {0} account is already in use.'.format(provider)
+            msg = 'This account is already in use.'
             raise AuthAlreadyAssociated(backend, msg)
         elif not user:
             user = social.user

--- a/social_core/tests/actions/test_associate.py
+++ b/social_core/tests/actions/test_associate.py
@@ -83,5 +83,5 @@ class AlreadyAssociatedErrorTest(BaseActionTest):
         self.do_login()
         self.user = User(username='foobar2', email='foo2@bar2.com')
         with self.assertRaisesRegexp(AuthAlreadyAssociated,
-                                     'This github account is already in use.'):
+                                     'This account is already in use.'):
             self.do_login()


### PR DESCRIPTION
Fixes #281 by simply removing the backend.name from the msg string, under the assumption that it will be clear to a user what service they were attempting to associate. 

Certainly can imagine that I'm missing cases in which this information is necessary in the msg string, so feel free to reject. 