### PR TITLE
Update qq.py

### DIFF
--- a/social_core/backends/qq.py
+++ b/social_core/backends/qq.py
@@ -67,5 +67,5 @@ class QQOAuth2(BaseOAuth2):
         return response
 
     def request_access_token(self, url, data, *args, **kwargs):
-        response = self.request(url, params=data, *args, **kwargs)
+        response = self.request(url, *args, **kwargs)
         return parse_qs(response.content)


### PR DESCRIPTION
kwargs already has 'params'.  Current old code cause exception.

      File "/usr/local/lib/python2.7/dist-packages/social_core/backends/qq.py", line 70, in request_access_token
        response = self.request(url, params=data, *args, **kwargs)
    TypeError: request() got multiple values for keyword argument 'params