### PR TITLE
More generically detect cancelling in oauth2 process_error

### DIFF
--- a/social_core/backends/oauth.py
+++ b/social_core/backends/oauth.py
@@ -374,7 +374,7 @@ class BaseOAuth2(OAuthAuth):
 
     def process_error(self, data):
         if data.get('error'):
-            if data['error'] == 'denied' or data['error'] == 'access_denied':
+            if 'denied' in data['error'] or 'cancelled' in data['error']:
                 raise AuthCanceled(self, data.get('error_description', ''))
             raise AuthFailed(self, data.get('error_description') or
                                    data['error'])


### PR DESCRIPTION
This e.g. fixes the flow with linkedin: https://developer.linkedin.com/docs/oauth2#
They either raise `user_cancelled_login` or `user_cancelled_authorize` which are both caught by this change. I would argue, that I did not overgeneralize, but if that's an issue, the error code matching could be narrowed down further.