### PR TITLE
MediaWiki: get_user_details should return more details

### DIFF
--- a/social_core/backends/mediawiki.py
+++ b/social_core/backends/mediawiki.py
@@ -172,7 +172,14 @@ class MediaWiki(BaseOAuth1):
 
         return {
             'username': identity['username'],
-            'userID': identity['sub']
+            'userID': identity['sub'],
+            'email': identity['email'],
+            'confirmed_email': identity['confirmed_email'],
+            'editcount': identity['editcount'],
+            'rights': identity['rights'],
+            'groups': identity['groups'],
+            'registered': identity['registered'],
+            'blocked': identity['blocked']
         }
 
     def get_user_id(self, details, response):

--- a/social_core/backends/mediawiki.py
+++ b/social_core/backends/mediawiki.py
@@ -173,13 +173,13 @@ class MediaWiki(BaseOAuth1):
         return {
             'username': identity['username'],
             'userID': identity['sub'],
-            'email': identity['email'],
-            'confirmed_email': identity['confirmed_email'],
-            'editcount': identity['editcount'],
-            'rights': identity['rights'],
-            'groups': identity['groups'],
-            'registered': identity['registered'],
-            'blocked': identity['blocked']
+            'email': identity.get('email'),
+            'confirmed_email': identity.get('confirmed_email'),
+            'editcount': identity.get('editcount'),
+            'rights': identity.get('rights'),
+            'groups': identity.get('groups'),
+            'registered': identity.get('registered'),
+            'blocked': identity.get('blocked')
         }
 
     def get_user_id(self, details, response):


### PR DESCRIPTION
get_user_details should return more things from MediaWiki instance:

* email
* confirmed_email
* editcount
* rights
* groups
* registered (time when user registered)
* blocked