### PR TITLE
[bugfix] Yandex backend: Do not fail when no email is present

### DIFF
--- a/social_core/backends/yandex.py
+++ b/social_core/backends/yandex.py
@@ -42,9 +42,12 @@ class YandexOAuth2(BaseOAuth2):
         fullname, first_name, last_name = self.get_user_names(
             response.get('real_name') or response.get('display_name') or ''
         )
+        email = response.get('default_email')
+        if not email:
+            emails = response.get('emails')
+            email = emails[0] if emails else ''
         return {'username': response.get('display_name'),
-                'email': response.get('default_email') or
-                         response.get('emails', [''])[0],
+                'email': email,
                 'fullname': fullname,
                 'first_name': first_name,
                 'last_name': last_name}
@@ -66,9 +69,12 @@ class YaruOAuth2(BaseOAuth2):
         fullname, first_name, last_name = self.get_user_names(
             response.get('real_name') or response.get('display_name') or ''
         )
+        email = response.get('default_email')
+        if not email:
+            emails = response.get('emails')
+            email = emails[0] if emails else ''
         return {'username': response.get('display_name'),
-                'email': response.get('default_email') or
-                         response.get('emails', [''])[0],
+                'email': email,
                 'fullname': fullname,
                 'first_name': first_name,
                 'last_name': last_name}

--- a/social_core/tests/backends/test_yandex.py
+++ b/social_core/tests/backends/test_yandex.py
@@ -25,3 +25,31 @@ class YandexOAuth2Test(OAuth2Test):
 
     def test_partial_pipeline(self):
         self.do_partial_pipeline()
+
+
+class YandexOAuth2TestEmptyEmail(OAuth2Test):
+    """
+    When user log in to yandex service with social network account (e.g.
+    vk.com), they `default_email` could be empty.
+    """
+    backend_path = 'social_core.backends.yandex.YandexOAuth2'
+    user_data_url = 'https://login.yandex.ru/info'
+    expected_username = 'foobar'
+    access_token_body = json.dumps({
+        'access_token': 'foobar',
+        'token_type': 'bearer'
+    })
+    user_data_body = json.dumps({
+        'display_name': 'foobar',
+        'real_name': 'Foo Bar',
+        'sex': None,
+        'id': '101010101',
+        'default_email': '',
+        'emails': []
+    })
+
+    def test_login(self):
+        self.do_login()
+
+    def test_partial_pipeline(self):
+        self.do_partial_pipeline()


### PR DESCRIPTION
When user log in to yandex service with social network account (e.g. vk.com), they `default_email` (and `emails` accordingly) could be empty. When it occurs, auth process fails with an error:

```
...
  File "/home/advent/site/repo/backend/auth/backend.py", line 17, in get_user_details
    response.get('emails', [''])[0],
IndexError: list index out of range
```