### PR TITLE
Update azuread_tenant.py to fix NoneType error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Updated Azure B2C to extract first email from list if it's a list
+- Updated Azure Tenant to fix Nonetype error
 
 ## [2.0.0](https://github.com/python-social-auth/social-core/releases/tag/2.0.0) - 2018-10-28
 

--- a/social_core/backends/azuread_tenant.py
+++ b/social_core/backends/azuread_tenant.py
@@ -88,6 +88,10 @@ class AzureADTenantOAuth2(AzureADOAuth2):
         return load_pem_x509_certificate(certificate.encode(),
                                          default_backend())
 
+    def get_user_id(self, details, response):
+        """Use subject (sub) claim as unique id."""
+        return response.get('sub')
+
     def user_data(self, access_token, *args, **kwargs):
         response = kwargs.get('response')
         id_token = response.get('id_token')


### PR DESCRIPTION
Override the get_user_id function from AzureADOAuth2 as the uid does not exist in the azure ad tenant response and produces a "None" UID within the social authentication.  See issue #70 . The Azureb2c backend has the exact same override function. Have tested locally and the changes work as expected.