### PR TITLE
Move away from Google+ API usage in google-oauth2 backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Updated Azure B2C to extract first email from list if it's a list
+- Replace deprecated Google+ API usage with https://www.googleapis.com/oauth2/v3/userinfo
 
 ## [2.0.0](https://github.com/python-social-auth/social-core/releases/tag/2.0.0) - 2018-10-28
 

--- a/social_core/backends/google.py
+++ b/social_core/backends/google.py
@@ -12,7 +12,10 @@ class BaseGoogleAuth(object):
     def get_user_id(self, details, response):
         """Use google email as unique id"""
         if self.setting('USE_UNIQUE_USER_ID', False):
-            return response['id']
+            if 'sub' in response:
+                return response['sub']
+            else:
+                return response['id']
         else:
             return details['email']
 
@@ -20,24 +23,14 @@ class BaseGoogleAuth(object):
         """Return user details from Google API account"""
         if 'email' in response:
             email = response['email']
-        elif 'emails' in response:
-            email = response['emails'][0]['value']
         else:
             email = ''
 
-        if isinstance(response.get('name'), dict):
-            names = response.get('name') or {}
-            name, given_name, family_name = (
-                response.get('displayName', ''),
-                names.get('givenName', ''),
-                names.get('familyName', '')
-            )
-        else:
-            name, given_name, family_name = (
-                response.get('name', ''),
-                response.get('given_name', ''),
-                response.get('family_name', '')
-            )
+        name, given_name, family_name = (
+            response.get('name', ''),
+            response.get('given_name', ''),
+            response.get('family_name', ''),
+        )
 
         fullname, first_name, last_name = self.get_user_names(
             name, given_name, family_name
@@ -53,7 +46,7 @@ class BaseGoogleOAuth2API(BaseGoogleAuth):
     def user_data(self, access_token, *args, **kwargs):
         """Return user data from Google API"""
         return self.get_json(
-            'https://www.googleapis.com/plus/v1/people/me',
+            'https://www.googleapis.com/oauth2/v3/userinfo',
             params={
                 'access_token': access_token,
                 'alt': 'json'

--- a/social_core/tests/backends/test_google.py
+++ b/social_core/tests/backends/test_google.py
@@ -16,64 +16,23 @@ from .open_id_connect import OpenIdConnectTestMixin, NO_JWKEST
 
 class GoogleOAuth2Test(OAuth2Test):
     backend_path = 'social_core.backends.google.GoogleOAuth2'
-    user_data_url = 'https://www.googleapis.com/plus/v1/people/me'
+    user_data_url = 'https://www.googleapis.com/oauth2/v3/userinfo'
     expected_username = 'foo'
     access_token_body = json.dumps({
         'access_token': 'foobar',
         'token_type': 'bearer'
     })
     user_data_body = json.dumps({
-        'aboutMe': 'About me text',
-        'cover': {
-            'coverInfo': {
-                'leftImageOffset': 0,
-                'topImageOffset': 0
-            },
-            'coverPhoto': {
-                'height': 629,
-                'url': 'https://lh5.googleusercontent.com/-ui-GqpNh5Ms/'
-                       'AAAAAAAAAAI/AAAAAAAAAZw/a7puhHMO_fg/photo.jpg',
-                'width': 940
-            },
-            'layout': 'banner'
-        },
-        'displayName': 'Foo Bar',
-        'emails': [{
-            'type': 'account',
-            'value': 'foo@bar.com'
-        }],
-        'etag': '"e-tag string"',
-        'gender': 'male',
-        'id': '101010101010101010101',
-        'image': {
-            'url': 'https://lh5.googleusercontent.com/-ui-GqpNh5Ms/'
+        'profile': 'https://plus.google.com/101010101010101010101',
+        'family_name': 'Bar',
+        'sub': '101010101010101010101',
+        'picture': 'https://lh5.googleusercontent.com/-ui-GqpNh5Ms/'
                    'AAAAAAAAAAI/AAAAAAAAAZw/a7puhHMO_fg/photo.jpg',
-        },
-        'isPlusUser': True,
-        'kind': 'plus#person',
-        'language': 'en',
-        'name': {
-            'familyName': 'Bar',
-            'givenName': 'Foo'
-        },
-        'objectType': 'person',
-        'occupation': 'Software developer',
-        'organizations': [{
-            'name': 'Org name',
-            'primary': True,
-            'type': 'school'
-        }],
-        'placesLived': [{
-            'primary': True,
-            'value': 'Anyplace'
-        }],
-        'url': 'https://plus.google.com/101010101010101010101',
-        'urls': [{
-            'label': 'http://foobar.com',
-            'type': 'otherProfile',
-            'value': 'http://foobar.com',
-        }],
-        'verified': False
+        'locale': 'en',
+        'email_verified': True,
+        'given_name': 'Foo',
+        'email': 'foo@bar.com',
+        'name': 'Foo Bar',
     })
 
     def test_login(self):


### PR DESCRIPTION
Fix for #300.

Google+ APIs will be shut down on March 7, 2019. More details here
https://developers.google.com/+/api-shutdown

> This will be a progressive shutdown, with intermittent failures
> starting as early as January 28, 2019.

Replacing the G+ endpoint with
https://www.googleapis.com/oauth2/v3/userinfo works for the
google-oauth2 backend with almost no extra changes.

This new endpoint is currently used by
[Google's OpenID Connect](https://developers.google.com/identity/protocols/OpenIDConnect)
implementation as OpenID Connect `userinfo_endpoint`. It might not be
the best idea to hard code it like that in the long term. But this was
the one endpoint that is actually mentioned in some Google
documentation as far as I could find. Please feel free to propose better
alternatives if you can find them.

`GooglePlusAuth` backend is affected by this change too.
However according to https://developers.google.com/+/web/signin/
the Google+ Sign-in feature is also fully deprecated and will be shut
down on March 7, 2019. I'd expect for the changes related
dropping/deprecating `GooglePlusAuth` backend in this library to be done
in a separate change. This change makes sure `google-oauth2` backend
will continue to work during and after Google+ APIs deprecation.

After this change this note from the docs can be removed too I believe:

> the application requires Google+ API to be enabled in the Google
> console dashboard

At least as far as the `google-oauth2` backend goes.