### PR TITLE
Pass access token via Authorization header to google user data url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Updated Azure B2C to extract first email from list if it's a list
+- Pass access token via Authorization header to Google user data url
 
 ## [2.0.0](https://github.com/python-social-auth/social-core/releases/tag/2.0.0) - 2018-10-28
 

--- a/social_core/backends/google.py
+++ b/social_core/backends/google.py
@@ -54,10 +54,9 @@ class BaseGoogleOAuth2API(BaseGoogleAuth):
         """Return user data from Google API"""
         return self.get_json(
             'https://www.googleapis.com/plus/v1/people/me',
-            params={
-                'access_token': access_token,
-                'alt': 'json'
-            }
+            headers={
+                'Authorization': 'Bearer %s' % access_token,
+            },
         )
 
     def revoke_token_params(self, token, uid):

--- a/social_core/tests/backends/test_google.py
+++ b/social_core/tests/backends/test_google.py
@@ -78,6 +78,14 @@ class GoogleOAuth2Test(OAuth2Test):
 
     def test_login(self):
         self.do_login()
+        last_request = HTTPretty.last_request
+        self.assertEqual(last_request.method, 'GET')
+        self.assertTrue(self.user_data_url.endswith(last_request.path))
+        self.assertEqual(
+            last_request.headers['Authorization'],
+            'Bearer foobar',
+        )
+        self.assertEqual(last_request.querystring, {})
 
     def test_partial_pipeline(self):
         self.do_partial_pipeline()


### PR DESCRIPTION
i.e. the "default" OAuth2 method of presenting the access token to the
resource server. Which is of course supported by both:

- https://www.googleapis.com/plus/v1/people/me (current user data url)
- https://www.googleapis.com/oauth2/v3/userinfo (see #301)

Passing secrets via GET query params is not great. Resource server
access logs usually retain the entire url including the GET query
params. `requests` library when used with DEBUG logging level will also
log the entire request url including the query params on the OAuth
client side.

This also drops the unnecessary `alt=json` query param.

This change should be compatible with #301.