### PR TITLE
Sending profile fetch calls to OAuth2 API instead of Google+ API

### DIFF
--- a/social_core/backends/google.py
+++ b/social_core/backends/google.py
@@ -53,7 +53,7 @@ class BaseGoogleOAuth2API(BaseGoogleAuth):
     def user_data(self, access_token, *args, **kwargs):
         """Return user data from Google API"""
         return self.get_json(
-            'https://www.googleapis.com/plus/v1/people/me',
+            'https://www.googleapis.com/userinfo/v2/me',
             params={
                 'access_token': access_token,
                 'alt': 'json'


### PR DESCRIPTION
As Google+ API is getting depreciated. The call for fetching user info could be sent to: https://www.googleapis.com/userinfo/v2/me 
instead of:
https://www.googleapis.com/plus/v1/people/me