### PR TITLE
allow to override JWT decode options in OIC backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Yandex: do not fail when no email is present
 - Mediawiki: do not fail when no email is present
 - Mediawiki: enhance `get_user_details` to return more details
++ Allow to override JWT decode options in Open ID Connect base backend
 
 ## [2.0.0](https://github.com/python-social-auth/social-core/releases/tag/2.0.0) - 2018-10-28
 

--- a/social_core/backends/open_id_connect.py
+++ b/social_core/backends/open_id_connect.py
@@ -43,6 +43,7 @@ class OpenIdConnectAuth(BaseOAuth2):
     REVOKE_TOKEN_URL = ''
     USERINFO_URL = ''
     JWKS_URI = ''
+    JWT_DECODE_OPTIONS = dict()
 
     def __init__(self, *args, **kwargs):
         self.id_token = None
@@ -167,7 +168,8 @@ class OpenIdConnectAuth(BaseOAuth2):
                 algorithms=[alg],
                 audience=client_id,
                 issuer=self.id_token_issuer(),
-                access_token=access_token
+                access_token=access_token,
+                options=self.JWT_DECODE_OPTIONS,
             )
         except ExpiredSignatureError:
             raise AuthTokenError(self, 'Signature has expired')


### PR DESCRIPTION
Sometimes, we don't want to verify some claims, which verification is often optional (like `sub`).
In current version it's impossible to parametrize `jwt.decode()` and that's the reason I am propsing to add attribute with all options specific to current `OpenIdConnectAuth` subclass, that will be simply passed to `jwt.decode()`.

Thank you for amazing project!