### PR TITLE
Update google_openidconnect to use non-deprecated APIs

### DIFF
--- a/social_core/backends/google_openidconnect.py
+++ b/social_core/backends/google_openidconnect.py
@@ -12,10 +12,3 @@ class GoogleOpenIdConnect(GoogleOAuth2, OpenIdConnectAuth):
     # differs from value in discovery document
     # http://openid.net/specs/openid-connect-core-1_0.html#rfc.section.15.6.2
     ID_TOKEN_ISSUER = 'accounts.google.com'
-
-    def user_data(self, access_token, *args, **kwargs):
-        """Return user data from Google API"""
-        return self.get_json(
-            'https://www.googleapis.com/plus/v1/people/me/openIdConnect',
-            params={'access_token': access_token, 'alt': 'json'}
-        )


### PR DESCRIPTION
In the last PR that updated GoogleOAuth2 to use the non-deprecated APIs
instead of the Google+ ones, google_openidconnect was left on the old
deprecated APIs. I've updated the config now, and tested that this
works locally on our project.