### PR TITLE
Updated LinkedinOAuth2 to use v2 APIs #310

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/python-social-auth/social-core/commits/master)
 
+### Changed
+- Updated Linkedin backend to v2 API
+
 ## [3.1.0](https://github.com/python-social-auth/social-core/releases/tag/3.1.0) - 2019-02-20
 
 ### Added

--- a/social_core/backends/linkedin.py
+++ b/social_core/backends/linkedin.py
@@ -20,9 +20,8 @@ class LinkedinOAuth2(BaseOAuth2):
     EXTRA_DATA = [
         ('id', 'id'),
         ('expires_in', 'expires'),
-        ('firstName', 'first_name', True),
-        ('lastName', 'last_name', True),
-        ('emailAddress', 'email')
+        ('firstName', 'first_name'),
+        ('lastName', 'last_name')
     ]
 
     def user_details_url(self):

--- a/social_core/backends/linkedin.py
+++ b/social_core/backends/linkedin.py
@@ -17,6 +17,7 @@ class LinkedinOAuth2(BaseOAuth2):
                       '?q=members&projection=(elements*(handle~))'
     ACCESS_TOKEN_METHOD = 'POST'
     REDIRECT_STATE = False
+    DEFAULT_SCOPE = ['r_liteprofile']
     EXTRA_DATA = [
         ('id', 'id'),
         ('expires_in', 'expires'),

--- a/social_core/backends/linkedin.py
+++ b/social_core/backends/linkedin.py
@@ -2,23 +2,109 @@
 LinkedIn OAuth1 and OAuth2 backend, docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/linkedin.html
 """
-from .oauth import BaseOAuth1, BaseOAuth2
+from social_core.exceptions import AuthCanceled
+from .oauth import BaseOAuth2
+
+API_VERSION = 2
 
 
-class BaseLinkedinAuth(object):
-    EXTRA_DATA = [('id', 'id'),
-                  ('expires_in', 'expires'),
-                  ('first-name', 'first_name', True),
-                  ('last-name', 'last_name', True),
-                  ('firstName', 'first_name', True),
-                  ('lastName', 'last_name', True)]
-    USER_DETAILS = 'https://api.linkedin.com/v1/people/~:({0})'
+class LinkedinOAuth2(BaseOAuth2):
+    name = 'linkedin-oauth2'
+    AUTHORIZATION_URL = \
+        'https://www.linkedin.com/oauth/v{version}/authorization'
+    ACCESS_TOKEN_URL = 'https://www.linkedin.com/oauth/v{version}/accessToken'
+    USER_DETAILS_URL = \
+        'https://api.linkedin.com/v{version}/me?projection=({projection})'
+    USER_EMAILS_URL = 'https://api.linkedin.com/v{version}/emailAddress' \
+                      '?q=members&projection=(elements*(handle~))'
+    ACCESS_TOKEN_METHOD = 'POST'
+    REDIRECT_STATE = False
+    EXTRA_DATA = [
+        ('id', 'id'),
+        ('expires_in', 'expires'),
+        ('firstName', 'first_name', True),
+        ('lastName', 'last_name', True)
+    ]
+
+    def authorization_url(self):
+        version = self.setting('API_VERSION', API_VERSION)
+        return self.AUTHORIZATION_URL.format(version=version)
+
+    def access_token_url(self):
+        version = self.setting('API_VERSION', API_VERSION)
+        return self.ACCESS_TOKEN_URL.format(version=version)
+
+    def user_details_url(self):
+        # use set() since LinkedIn fails when values are duplicated
+        fields_selectors = list(set(['id', 'firstName', 'lastName'] +
+                                    self.setting('FIELD_SELECTORS', [])))
+        # user sort to ease the tests URL mocking
+        fields_selectors.sort()
+        fields_selectors = ','.join(fields_selectors)
+        version = self.setting('API_VERSION', API_VERSION)
+        return self.USER_DETAILS_URL.format(version=version,
+                                            projection=fields_selectors)
+
+    def user_emails_url(self):
+        version = self.setting('API_VERSION', API_VERSION)
+        return self.USER_EMAILS_URL.format(version=version)
+
+    def user_data(self, access_token, *args, **kwargs):
+        headers = self.user_data_headers() or {}
+        headers['Authorization'] = 'Bearer {access_token}'.format(
+            access_token=access_token)
+
+        user_details = self.get_json(
+            self.user_details_url(),
+            headers=headers
+        )
+
+        if 'emailAddress' in set(self.setting('FIELD_SELECTORS', [])):
+            emails = self.email_data(access_token, *args, **kwargs)
+            if emails:
+                user_details['emailAddress'] = emails[0]
+
+        return user_details
+
+    def email_data(self, access_token, *args, **kwargs):
+        headers = {'Authorization': 'Bearer {access_token}'.format(
+            access_token=access_token)}
+        response = self.get_json(
+            self.user_emails_url(),
+            headers=headers
+        )
+        email_addresses = []
+        for element in response.get('elements', []):
+            email_address = element.get('handle~', {}).get('emailAddress')
+            email_addresses.append(email_address)
+        return filter(None, email_addresses)
 
     def get_user_details(self, response):
         """Return user details from Linkedin account"""
+
+        def get_localized_name(name):
+            """
+            FirstName & Last Name object
+            {
+                  "localized":{
+                     "en_US":"Smith"
+                  },
+                  "preferredLocale":{
+                     "country":"US",
+                     "language":"en"
+                  }
+            }
+            :return the localizedName from the lastName object
+            """
+            locale = "{}_{}".format(
+                name["preferredLocale"]["language"],
+                name["preferredLocale"]["country"]
+            )
+            return name['localized'].get(locale, '')
+
         fullname, first_name, last_name = self.get_user_names(
-            first_name=response['firstName'],
-            last_name=response['lastName']
+            first_name=get_localized_name(response['firstName']),
+            last_name=get_localized_name(response['lastName'])
         )
         email = response.get('emailAddress', '')
         return {'username': first_name + last_name,
@@ -27,69 +113,13 @@ class BaseLinkedinAuth(object):
                 'last_name': last_name,
                 'email': email}
 
-    def user_details_url(self):
-        # use set() since LinkedIn fails when values are duplicated
-        fields_selectors = list(set(['first-name', 'id', 'last-name'] +
-                                self.setting('FIELD_SELECTORS', [])))
-        # user sort to ease the tests URL mocking
-        fields_selectors.sort()
-        fields_selectors = ','.join(fields_selectors)
-        return self.USER_DETAILS.format(fields_selectors)
-
     def user_data_headers(self):
         lang = self.setting('FORCE_PROFILE_LANGUAGE')
         if lang:
             return {
                 'Accept-Language': lang if lang is not True
-                                        else self.strategy.get_language()
+                else self.strategy.get_language()
             }
-
-
-class LinkedinOAuth(BaseLinkedinAuth, BaseOAuth1):
-    """Linkedin OAuth authentication backend"""
-    name = 'linkedin'
-    SCOPE_SEPARATOR = '+'
-    AUTHORIZATION_URL = 'https://www.linkedin.com/uas/oauth/authenticate'
-    REQUEST_TOKEN_URL = 'https://api.linkedin.com/uas/oauth/requestToken'
-    ACCESS_TOKEN_URL = 'https://api.linkedin.com/uas/oauth/accessToken'
-
-    def user_data(self, access_token, *args, **kwargs):
-        """Return user data provided"""
-        return self.get_json(
-            self.user_details_url(),
-            params={'format': 'json'},
-            auth=self.oauth_auth(access_token),
-            headers=self.user_data_headers()
-        )
-
-    def unauthorized_token(self):
-        """Makes first request to oauth. Returns an unauthorized Token."""
-        scope = self.get_scope() or ''
-        if scope:
-            scope = '?scope=' + self.SCOPE_SEPARATOR.join(scope)
-        return self.request(self.REQUEST_TOKEN_URL + scope,
-                            params=self.request_token_extra_arguments(),
-                            auth=self.oauth_auth()).text
-
-
-class LinkedinOAuth2(BaseLinkedinAuth, BaseOAuth2):
-    name = 'linkedin-oauth2'
-    SCOPE_SEPARATOR = ' '
-    AUTHORIZATION_URL = 'https://www.linkedin.com/uas/oauth2/authorization'
-    ACCESS_TOKEN_URL = 'https://www.linkedin.com/uas/oauth2/accessToken'
-    ACCESS_TOKEN_METHOD = 'POST'
-    REDIRECT_STATE = False
-
-    def user_data(self, access_token, *args, **kwargs):
-        headers = self.user_data_headers() or {}
-        headers['Authorization'] = 'Bearer {access_token}'.format(
-            access_token=access_token
-        )
-        return self.get_json(
-            self.user_details_url(),
-            params={'format': 'json'},
-            headers=headers
-        )
 
     def request_access_token(self, *args, **kwargs):
         # LinkedIn expects a POST request with querystring parameters, despite
@@ -98,6 +128,11 @@ class LinkedinOAuth2(BaseLinkedinAuth, BaseOAuth2):
         return super(LinkedinOAuth2, self).request_access_token(
             *args, **kwargs
         )
+
+    def process_error(self, data):
+        super(LinkedinOAuth2, self).process_error(data)
+        if data.get('serviceErrorCode'):
+            raise AuthCanceled(self, data.get('message') or data.get('status'))
 
 
 class LinkedinMobileOAuth2(LinkedinOAuth2):

--- a/social_core/backends/linkedin.py
+++ b/social_core/backends/linkedin.py
@@ -59,7 +59,7 @@ class LinkedinOAuth2(BaseOAuth2):
         for element in response.get('elements', []):
             email_address = element.get('handle~', {}).get('emailAddress')
             email_addresses.append(email_address)
-        return filter(None, email_addresses)
+        return list(filter(None, email_addresses))
 
     def get_user_details(self, response):
         """Return user details from Linkedin account"""

--- a/social_core/tests/backends/test_linkedin.py
+++ b/social_core/tests/backends/test_linkedin.py
@@ -1,12 +1,11 @@
 import json
 
 from .oauth import OAuth2Test
-from ...backends.linkedin import API_VERSION
 
 
 class BaseLinkedinTest(object):
-    user_data_url = 'https://api.linkedin.com/v{version}/me?projection=' \
-                    '(firstName,id,lastName)'.format(version=API_VERSION)
+    user_data_url = 'https://api.linkedin.com/v2/me' \
+                    '?projection=(firstName,id,lastName)'
     expected_username = 'FooBar'
     access_token_body = json.dumps({
         'access_token': 'foobar',

--- a/social_core/tests/backends/test_linkedin.py
+++ b/social_core/tests/backends/test_linkedin.py
@@ -1,23 +1,41 @@
 import json
 
-from six.moves.urllib_parse import urlencode
-
-
-from .oauth import OAuth1Test, OAuth2Test
+from .oauth import OAuth2Test
+from ...backends.linkedin import API_VERSION
 
 
 class BaseLinkedinTest(object):
-    user_data_url = 'https://api.linkedin.com/v1/people/~:' \
-                        '(first-name,id,last-name)'
+    user_data_url = 'https://api.linkedin.com/v{version}/me?projection=' \
+                    '(firstName,id,lastName)'.format(version=API_VERSION)
     expected_username = 'FooBar'
     access_token_body = json.dumps({
         'access_token': 'foobar',
         'token_type': 'bearer'
     })
+
+    # Reference:
+    # https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self
+    # -serve/sign-in-with-linkedin?context=linkedin/consumer/context#api-request
     user_data_body = json.dumps({
-        'lastName': 'Bar',
-        'id': '1010101010',
-        'firstName': 'Foo'
+        "id": '1010101010',
+        "firstName": {
+            "localized": {
+                "en_US": "Foo"
+            },
+            "preferredLocale": {
+                "country": "US",
+                "language": "en"
+            }
+        },
+        "lastName": {
+            "localized": {
+                "en_US": "Bar"
+            },
+            "preferredLocale": {
+                "country": "US",
+                "language": "en"
+            }
+        }
     })
 
     def test_login(self):
@@ -25,15 +43,6 @@ class BaseLinkedinTest(object):
 
     def test_partial_pipeline(self):
         self.do_partial_pipeline()
-
-
-class LinkedinOAuth1Test(BaseLinkedinTest, OAuth1Test):
-    backend_path = 'social_core.backends.linkedin.LinkedinOAuth'
-    request_token_body = urlencode({
-        'oauth_token_secret': 'foobar-secret',
-        'oauth_token': 'foobar',
-        'oauth_callback_confirmed': 'true'
-    })
 
 
 class LinkedinOAuth2Test(BaseLinkedinTest, OAuth2Test):


### PR DESCRIPTION
Recently, Linkedin announced that all the developers need to migration to Linkedin v2 API and OAuth2 by March 1st, 2019. 

This PR
- Added support for Linkedin OAuth2.0 using v2 API
- Removed unsupported Oauth1 from the Linkedin backend

These changes do not require any modification to the existing application built with python-social-core.

PS: Also updated the LinkedIn documentation on social-docs. [PR Link](https://github.com/python-social-auth/social-docs/pull/55)