### PR TITLE
Fix linked no firstname lastname key error

### DIFF
--- a/social_core/backends/linkedin.py
+++ b/social_core/backends/linkedin.py
@@ -17,8 +17,8 @@ class BaseLinkedinAuth(object):
     def get_user_details(self, response):
         """Return user details from Linkedin account"""
         fullname, first_name, last_name = self.get_user_names(
-            first_name=response['firstName'],
-            last_name=response['lastName']
+            first_name=response.get('firstName', ''),
+            last_name=response.get('lastName', '')
         )
         email = response.get('emailAddress', '')
         return {'username': first_name + last_name,


### PR DESCRIPTION
In our production environment we encounter users without a firstname/lastname set. Don't know how this is
possible but it would be nicer if this were handled more gracefully. So instead of breaking just retrieve
an empty string in both cases.

Any feedback would be greatly appreciated, including if this is a good idea or not ;)