### PR TITLE
Replace deprecated Google+ API usage in GoogleOpenIdConnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/python-social-auth/social-core/commits/master)
 
+### Changed
+- Replace deprecated Google+ API usage in GoogleOpenIdConnect
+
 ## [3.1.0](https://github.com/python-social-auth/social-core/releases/tag/3.1.0) - 2019-02-20
 
 ### Added

--- a/social_core/backends/google_openidconnect.py
+++ b/social_core/backends/google_openidconnect.py
@@ -16,6 +16,6 @@ class GoogleOpenIdConnect(GoogleOAuth2, OpenIdConnectAuth):
     def user_data(self, access_token, *args, **kwargs):
         """Return user data from Google API"""
         return self.get_json(
-            'https://www.googleapis.com/plus/v1/people/me/openIdConnect',
+            'https://openidconnect.googleapis.com/v1/userinfo',
             params={'access_token': access_token, 'alt': 'json'}
         )


### PR DESCRIPTION
GoogleOpenIdConnect was still using the deprecated Google+ API. This PR updates the URL to be the currently supported version and adds a changelog entry.