### PR TITLE
bugfix: github backend need `SEND_USER_AGENT`

### DIFF
--- a/social_core/backends/github.py
+++ b/social_core/backends/github.py
@@ -20,6 +20,7 @@ class GithubOAuth2(BaseOAuth2):
     SCOPE_SEPARATOR = ','
     REDIRECT_STATE = False
     STATE_PARAMETER = True
+    SEND_USER_AGENT = True
     EXTRA_DATA = [
         ('id', 'id'),
         ('expires', 'expires'),


### PR DESCRIPTION
From the [document](https://developer.github.com/v3/#user-agent-required):

> All API requests MUST include a valid User-Agent header. Requests with no User-Agent header will be rejected. We request that you use your GitHub username, or the name of your application, for the User-Agent header value. This allows us to contact you if there are problems.

I got 403 forbidden when login with github.

> Your access to this site has been restricted.

![image](https://user-images.githubusercontent.com/9675939/55094029-85486c80-50f0-11e9-8393-c83971ea271c.png)

It turns out that if add User-Agent then everything is fine.
