### PR TITLE
Implement an OIDC-based backend for uc-cdis/fence

### DIFF
--- a/social_core/backends/fence.py
+++ b/social_core/backends/fence.py
@@ -1,0 +1,38 @@
+
+from six.moves.urllib.parse import urljoin
+
+from social_core.utils import cache
+
+from ..utils import append_slash
+from .open_id_connect import OpenIdConnectAuth
+
+
+class Fence(OpenIdConnectAuth):
+
+    name = 'fence'
+    ID_KEY = 'username'
+    ACCESS_TOKEN_METHOD = 'POST'
+    DEFAULT_SCOPE = ['openid', 'user']
+    JWT_DECODE_OPTIONS = {'verify_at_hash': False}
+
+    def _url(self, path):
+        return urljoin(append_slash(self.setting('URL')), path)
+
+    def authorization_url(self):
+        return self._url("oauth2/authorize")
+
+    def access_token_url(self):
+        return self._url("oauth2/token")
+
+    @cache(ttl=86400)
+    def oidc_config(self):
+        return self.get_json(self._url(".well-known/openid-configuration"))
+
+    def get_user_details(self, response):
+        return {
+            'username': response.get('preferred_username'),
+            'email': response.get('username'),
+            'fullname': response.get('name'),
+            'first_name': response.get('given_name'),
+            'last_name': response.get('family_name'),
+        }


### PR DESCRIPTION
Fence repo: https://github.com/uc-cdis/fence

TODOs:
- [ ] Fence does not support `nonce` (see https://github.com/uc-cdis/fence/issues/600 )---a required claim by psa (and oidc specifications)---that results in `AuthTokenError` exception:

    https://github.com/python-social-auth/social-core/blob/000f8e5c8b505f2215e25deebf670b708a0578f4/social_core/backends/open_id_connect.py#L134-L143

    Hence, either psa should make `nonce` optional (https://github.com/python-social-auth/social-core/issues/315) or Fence implement it. IMHO, based on OIDC-specs (see the following quote), the latter is preferred. 

    > If present in the Authentication Request, Authorization Servers MUST include a nonce Claim in the ID Token with the Claim Value being the nonce value sent in the Authentication Request.
    ([Ref](https://openid.net/specs/openid-connect-core-1_0.html#IDToken))