### PR TITLE
Add long_description_content_type for PyPi rendering

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(
         'social_core.tests.backends.data'
     ],
     long_description=long_description() or LONG_DESCRIPTION,
+    long_description_content_type="text/markdown",
     install_requires=requirements,
     extras_require={
         'openidconnect': [requirements_openidconnect],


### PR DESCRIPTION
Fixes #342 

Defines the content type of the long description as Markdown so that PyPI will render it correctly.

See https://setuptools.readthedocs.io/en/latest/setuptools.html?highlight=long_description_content_type for details on the definition of `long_description_content_type`. I use it on a personal repository so that I can write my README in markdown but get the benefits of RST in PyPI rendering. 

Here's an example:
- Definition in setup.py: https://github.com/ryanwilsonperkin/circleci-flaky/blob/master/setup.py#L16
- Rendered: https://pypi.org/project/circleci-flaky/

P.S. If this seems like an approach you'd like to take, I can send similar PRs for the other repos in this org.