### PR TITLE
Add email_verified to user details

### DIFF
--- a/social_core/backends/auth0.py
+++ b/social_core/backends/auth0.py
@@ -45,6 +45,7 @@ class Auth0OAuth2(BaseOAuth2):
         fullname, first_name, last_name = self.get_user_names(payload['name'])
         return {'username': payload['nickname'],
                 'email': payload['email'],
+                'email_verified': payload['email_verified'],
                 'fullname': fullname,
                 'first_name': first_name,
                 'last_name': last_name,

--- a/social_core/backends/auth0.py
+++ b/social_core/backends/auth0.py
@@ -45,7 +45,7 @@ class Auth0OAuth2(BaseOAuth2):
         fullname, first_name, last_name = self.get_user_names(payload['name'])
         return {'username': payload['nickname'],
                 'email': payload['email'],
-                'email_verified': payload['email_verified'],
+                'email_verified': payload.get('email_verified', False),
                 'fullname': fullname,
                 'first_name': first_name,
                 'last_name': last_name,


### PR DESCRIPTION
It's useful to know if the user's email address has been verified. In my case, I'm using this field in a pipeline to require a verified email before merging to an existing user.