### PR TITLE
Add Discourse backend - Issue 383

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Support for SAML Single Logout
 - SimpleLogin backend
+- Discourse backend
 
 ### Changed
 - Update test runner to PyTest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support for SAML Single Logout
 - SimpleLogin backend
 - Discourse backend
+- Add `get` and `delete` class methods for `NonceMixin`
 
 ### Changed
 - Update test runner to PyTest

--- a/social_core/backends/discourse.py
+++ b/social_core/backends/discourse.py
@@ -1,5 +1,5 @@
 from .base import BaseAuth
-from ..exceptions import (AuthException, AuthTokenError)
+from ..exceptions import AuthException, AuthTokenError
 import hmac
 from base64 import b64encode, b64decode
 from hashlib import sha256
@@ -9,12 +9,8 @@ import time
 
 
 class DiscourseAuth(BaseAuth):
-    name = 'discourse'
-    EXTRA_DATA = [
-        'username',
-        'name',
-        'avatar_url',
-    ]
+    name = "discourse"
+    EXTRA_DATA = ["username", "name", "avatar_url"]
 
     def auth_url(self):
         """Return redirect url"""
@@ -22,57 +18,69 @@ class DiscourseAuth(BaseAuth):
         nonce = self.strategy.random_string(64)
         self.add_nonce(nonce)
 
-        payload = "nonce="+nonce+"&return_sso_url="+returnUrl
+        payload = "nonce=" + nonce + "&return_sso_url=" + returnUrl
         base64Payload = b64encode(payload)
-        payloadSignature = hmac.new(self.setting("SOCIAL_AUTH_DISCOURSE_AUTH_SECRET"), base64Payload,
-                                    sha256).hexdigest()
-        encodedParams = urllib.urlencode({'sso': base64Payload, 'sig': payloadSignature})
-        return self.setting("SOCIAL_AUTH_DISCOURSE_AUTH_SERVER_URL") + "/session/sso_provider?" + encodedParams
+        payloadSignature = hmac.new(
+            self.setting("SOCIAL_AUTH_DISCOURSE_AUTH_SECRET"), base64Payload, sha256
+        ).hexdigest()
+        encodedParams = urllib.urlencode(
+            {"sso": base64Payload, "sig": payloadSignature}
+        )
+        return (
+            self.setting("SOCIAL_AUTH_DISCOURSE_AUTH_SERVER_URL")
+            + "/session/sso_provider?"
+            + encodedParams
+        )
 
     def get_user_id(self, details, response):
-        return response['email']
+        return response["email"]
 
     def get_user_details(self, response):
         results = {
-            'username': response.get('username'),
-            'email': response.get('email'),
-            'name': response.get('name'),
-            'groups': response.get('groups', '').split(','),
-            'is_staff': response.get('admin') == 'true' or response.get('moderator') == 'true',
-            'is_superuser': response.get('admin') == 'true',
+            "username": response.get("username"),
+            "email": response.get("email"),
+            "name": response.get("name"),
+            "groups": response.get("groups", "").split(","),
+            "is_staff": response.get("admin") == "true"
+            or response.get("moderator") == "true",
+            "is_superuser": response.get("admin") == "true",
         }
         return results
 
     def add_nonce(self, nonce):
-        self.strategy.storage.nonce.use(self.setting("SOCIAL_AUTH_DISCOURSE_AUTH_SERVER_URL"), time.time(), nonce)
+        self.strategy.storage.nonce.use(
+            self.setting("SOCIAL_AUTH_DISCOURSE_AUTH_SERVER_URL"), time.time(), nonce
+        )
 
     def get_nonce(self, nonce):
         try:
             return self.strategy.storage.nonce.objects.get(
                 server_url=self.setting("SOCIAL_AUTH_DISCOURSE_AUTH_SERVER_URL"),
-                salt=nonce
+                salt=nonce,
             )
         except IndexError:
             pass
 
     def auth_complete(self, request, *args, **kwargs):
-        ssoParams = request.GET.get('sso')
-        ssoSignature = request.GET.get('sig')
-        paramSignature = hmac.new(self.setting("SOCIAL_AUTH_DISCOURSE_AUTH_SECRET"), ssoParams, sha256).hexdigest()
+        ssoParams = request.GET.get("sso")
+        ssoSignature = request.GET.get("sig")
+        paramSignature = hmac.new(
+            self.setting("SOCIAL_AUTH_DISCOURSE_AUTH_SECRET"), ssoParams, sha256
+        ).hexdigest()
 
         if not hmac.compare_digest(str(ssoSignature), str(paramSignature)):
-            raise AuthException('Could not verify discourse login')
+            raise AuthException("Could not verify discourse login")
 
         decodedParams = b64decode(ssoParams)
 
         # Validate the nonce to ensure the request was not modified
         response = parse_qs(decodedParams)
-        nonce_obj = self.get_nonce(response.get('nonce'))
+        nonce_obj = self.get_nonce(response.get("nonce"))
         if nonce_obj:
             nonce_obj.delete()
         else:
-            raise AuthTokenError(self, 'Incorrect id_token: nonce')
+            raise AuthTokenError(self, "Incorrect id_token: nonce")
 
-        kwargs.update({'sso': '', 'sig': '', 'backend': self, 'response': response})
+        kwargs.update({"sso": "", "sig": "", "backend": self, "response": response})
 
         return self.strategy.authenticate(*args, **kwargs)

--- a/social_core/backends/discourse.py
+++ b/social_core/backends/discourse.py
@@ -1,11 +1,12 @@
-from .base import BaseAuth
-from ..exceptions import AuthException, AuthTokenError
 import hmac
+import time
+import urllib
 from base64 import b64encode, b64decode
 from hashlib import sha256
-import urllib
+
+from .base import BaseAuth
+from ..exceptions import AuthException, AuthTokenError
 from ..utils import parse_qs
-import time
 
 
 class DiscourseAuth(BaseAuth):

--- a/social_core/backends/discourse.py
+++ b/social_core/backends/discourse.py
@@ -1,0 +1,78 @@
+from .base import BaseAuth
+from ..exceptions import (AuthException, AuthTokenError)
+import hmac
+from base64 import b64encode, b64decode
+from hashlib import sha256
+import urllib
+from ..utils import parse_qs
+import time
+
+
+class DiscourseAuth(BaseAuth):
+    name = 'discourse'
+    EXTRA_DATA = [
+        'username',
+        'name',
+        'avatar_url',
+    ]
+
+    def auth_url(self):
+        """Return redirect url"""
+        returnUrl = self.redirect_uri
+        nonce = self.strategy.random_string(64)
+        self.add_nonce(nonce)
+
+        payload = "nonce="+nonce+"&return_sso_url="+returnUrl
+        base64Payload = b64encode(payload)
+        payloadSignature = hmac.new(self.setting("SOCIAL_AUTH_DISCOURSE_AUTH_SECRET"), base64Payload,
+                                    sha256).hexdigest()
+        encodedParams = urllib.urlencode({'sso': base64Payload, 'sig': payloadSignature})
+        return self.setting("SOCIAL_AUTH_DISCOURSE_AUTH_SERVER_URL") + "/session/sso_provider?" + encodedParams
+
+    def get_user_id(self, details, response):
+        return response['email']
+
+    def get_user_details(self, response):
+        results = {
+            'username': response.get('username'),
+            'email': response.get('email'),
+            'name': response.get('name'),
+            'groups': response.get('groups', '').split(','),
+            'is_staff': response.get('admin') == 'true' or response.get('moderator') == 'true',
+            'is_superuser': response.get('admin') == 'true',
+        }
+        return results
+
+    def add_nonce(self, nonce):
+        self.strategy.storage.nonce.use(self.setting("SOCIAL_AUTH_DISCOURSE_AUTH_SERVER_URL"), time.time(), nonce)
+
+    def get_nonce(self, nonce):
+        try:
+            return self.strategy.storage.nonce.objects.get(
+                server_url=self.setting("SOCIAL_AUTH_DISCOURSE_AUTH_SERVER_URL"),
+                salt=nonce
+            )
+        except IndexError:
+            pass
+
+    def auth_complete(self, request, *args, **kwargs):
+        ssoParams = request.GET.get('sso')
+        ssoSignature = request.GET.get('sig')
+        paramSignature = hmac.new(self.setting("SOCIAL_AUTH_DISCOURSE_AUTH_SECRET"), ssoParams, sha256).hexdigest()
+
+        if not hmac.compare_digest(str(ssoSignature), str(paramSignature)):
+            raise AuthException('Could not verify discourse login')
+
+        decodedParams = b64decode(ssoParams)
+
+        # Validate the nonce to ensure the request was not modified
+        response = parse_qs(decodedParams)
+        nonce_obj = self.get_nonce(response.get('nonce'))
+        if nonce_obj:
+            nonce_obj.delete()
+        else:
+            raise AuthTokenError(self, 'Incorrect id_token: nonce')
+
+        kwargs.update({'sso': '', 'sig': '', 'backend': self, 'response': response})
+
+        return self.strategy.authenticate(*args, **kwargs)

--- a/social_core/storage.py
+++ b/social_core/storage.py
@@ -207,6 +207,16 @@ class NonceMixin(object):
         """Create a Nonce instance"""
         raise NotImplementedError('Implement in subclass')
 
+    @classmethod
+    def get(cls, server_url, salt):
+        """Retrieve a Nonce instance"""
+        raise NotImplementedError('Implement in subclass')
+
+    @classmethod
+    def delete(cls, nonce):
+        """Delete a Nonce instance"""
+        raise NotImplementedError('Implement in subclass')
+
 
 class AssociationMixin(object):
     """OpenId account association"""

--- a/social_core/tests/backends/test_discourse.py
+++ b/social_core/tests/backends/test_discourse.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+import requests
+from httpretty import HTTPretty
+from six.moves.urllib_parse import urlparse, parse_qs
+
+from .base import BaseBackendTest
+from ...exceptions import AuthException
+
+
+class DiscourseTest(BaseBackendTest):
+    backend_path = "social_core.backends.discourse.DiscourseAuth"
+    expected_username = "beepboop"
+    raw_complete_url = "/complete/{0}/"
+
+    def post_start(self):
+        pass
+
+    def do_start(self):
+        self.post_start()
+        start = self.backend.start()
+        start_url = start.url
+        return_url = self.backend.redirect_uri
+        # NOTE: This is how we generated sso:
+        # sso = b64encode(urlencode({
+        #     "email": "user@example.com",
+        #     "username": "beepboop",
+        #     'nonce': '6YRje7xlXhpyeJ6qtvBeTUjHkXo1UCTQmCrzN8GXfja3AoAFk2CieDRYgSqMYi4W',
+        #     'return_sso_url': 'http://myapp.com'
+        # }))
+        sso = "dXNlcm5hbWU9YmVlcGJvb3Ambm9uY2U9NllSamU3eGxYaHB5ZUo2cXR2QmVUVWpIa1hvMVVDVFFtQ3J6TjhHWGZqYTNBb0FGazJDaWVEUllnU3FNWWk0VyZlbWFpbD11c2VyJTQwZXhhbXBsZS5jb20mcmV0dXJuX3Nzb191cmw9aHR0cCUzQSUyRiUyRm15YXBwLmNvbQ=="
+        # NOTE: the signature was verified using the "foo" key, like so:
+        # hmac.new("foo", sso, sha256).hexdigest()
+        sig = "04063f17c99a97b1a765c1e0d7bbb61afb8471d79a39ddcd6af5ba3c93eb10e1"
+        response_query_params = "sso={0}&sig={1}".format(sso, sig)
+
+        response_url = "{0}?{1}".format(return_url, response_query_params)
+        HTTPretty.register_uri(
+            HTTPretty.GET, start_url, status=301, location=response_url
+        )
+        HTTPretty.register_uri(
+            HTTPretty.GET,
+            return_url,
+            status=200,
+            body={"email": "test@test.org"},
+            content_type="text/html",
+        )
+
+        response = requests.get(start_url)
+        query_values = dict(
+            (k, v[0]) for k, v in parse_qs(urlparse(response.url).query).items()
+        )
+        self.strategy.set_request_data(query_values, self.backend)
+
+        return self.backend.complete()
+
+    def test_login(self):
+        """Test that we can authenticate with the Discourse IdP"""
+        # pretend we've started with a URL like /login/discourse:
+        self.strategy.set_settings(
+            {"SERVER_URL": "http://example.com", "SECRET": "foo"}
+        )
+        self.do_login()
+
+    def test_failed_login(self):
+        """Test that authentication fails when our request is signed with a
+        different secret than our payload"""
+        self.strategy.set_settings(
+            {"SERVER_URL": "http://example.com", "SECRET": "bar"}
+        )
+        with self.assertRaises(AuthException):
+            self.do_login()

--- a/social_core/tests/backends/test_discourse.py
+++ b/social_core/tests/backends/test_discourse.py
@@ -41,7 +41,6 @@ class DiscourseTest(BaseBackendTest):
             HTTPretty.GET,
             return_url,
             status=200,
-            body={"email": "test@test.org"},
             content_type="text/html",
         )
 

--- a/social_core/tests/models.py
+++ b/social_core/tests/models.py
@@ -147,6 +147,15 @@ class TestNonce(NonceMixin, BaseModel):
         TestNonce.cache[server_url] = nonce
         return nonce
 
+    @classmethod
+    def get(cls, server_url, salt):
+        return TestNonce.cache[server_url]
+
+    @classmethod
+    def delete(cls, nonce):
+        server_url = nonce.server_url
+        del TestNonce.cache[server_url]
+
 
 class TestAssociation(AssociationMixin, BaseModel):
     NEXT_ID = 1


### PR DESCRIPTION
Resolves https://github.com/python-social-auth/social-core/issues/383

I have one question, detailed in the comments below, where I resorted to using Django's api for handling the Nonce because I couldn't find the right api to use. Any feedback on this would be great :)

I haven't added tests or docs yet, but I'm happy to do so if a Discourse backend sounds useful.

---

Update:

Thanks for the review! Here are some PR's related to this PR:

 - Update the docs with the Discourse backend: https://github.com/python-social-auth/social-docs/pull/63
 - Update Social Auth App Django to implement the new `NonceMixin` class methods: https://github.com/python-social-auth/social-app-django/pull/213

I also added a test for the Discourse backend, and fixed the Django abstraction issues.