### PR TITLE
Fix Atlassian API url

### DIFF
--- a/social_core/backends/atlassian.py
+++ b/social_core/backends/atlassian.py
@@ -5,7 +5,7 @@ class AtlassianOAuth2(BaseOAuth2):
     name = 'atlassian'
     AUTHORIZATION_URL = 'https://auth.atlassian.com/authorize'
     ACCESS_TOKEN_METHOD = 'POST'
-    ACCESS_TOKEN_URL = 'https://api.atlassian.com/oauth/token'
+    ACCESS_TOKEN_URL = 'https://auth.atlassian.com/oauth/token'
     DEFAULT_SCOPE = ['read:jira-user', 'offline_access']
     ID_KEY = 'accountId'
     EXTRA_DATA = [

--- a/social_core/backends/atlassian.py
+++ b/social_core/backends/atlassian.py
@@ -3,7 +3,7 @@ from social_core.backends.oauth import BaseOAuth2
 
 class AtlassianOAuth2(BaseOAuth2):
     name = 'atlassian'
-    AUTHORIZATION_URL = 'https://accounts.atlassian.com/authorize'
+    AUTHORIZATION_URL = 'https://auth.atlassian.com/authorize'
     ACCESS_TOKEN_METHOD = 'POST'
     ACCESS_TOKEN_URL = 'https://api.atlassian.com/oauth/token'
     DEFAULT_SCOPE = ['read:jira-user', 'offline_access']


### PR DESCRIPTION
According to the API documentation here https://developer.atlassian.com/cloud/jira/platform/oauth-2-authorization-code-grants-3lo-for-apps/ the Auth URL is auth.atlassian.com, and my own attempts to use this did not work until I changed the URL to that.