### PR TITLE
Mailru backend issue 403 - close403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Support for SAML Single Logout
 - SimpleLogin backend
+- MRG backend
 
 ### Changed
 - Update test runner to PyTest

--- a/social_core/backends/mailru.py
+++ b/social_core/backends/mailru.py
@@ -46,7 +46,7 @@ class MailruOAuth2(BaseOAuth2):
                              params=data)[0]
 
 
-class MainMailruOAuth2(BaseOAuth2):
+class MRGOAuth2(BaseOAuth2):
 
     name = 'mailru'
     ID_KEY = 'email'

--- a/social_core/backends/mailru.py
+++ b/social_core/backends/mailru.py
@@ -44,3 +44,31 @@ class MailruOAuth2(BaseOAuth2):
         ).hexdigest()
         return self.get_json('http://www.appsmail.ru/platform/api',
                              params=data)[0]
+
+
+class MainMailruOAuth2(BaseOAuth2):
+
+    name = 'mailru'
+    ID_KEY = 'email'
+    AUTHORIZATION_URL = 'https://oauth.mail.ru/login'
+    ACCESS_TOKEN_URL = 'https://oauth.mail.ru/token'
+    ACCESS_TOKEN_METHOD = 'POST'
+    EXTRA_DATA = [('refresh_token', 'refresh_token'),
+                  ('expires_in', 'expires')]
+    REDIRECT_STATE = False
+
+    def get_user_details(self, response):
+        return {
+            'gender': response.get('gender'),
+            'fullname': response.get('name'),
+            'first_name': response.get('first_name'),
+            'last_name': response.get('last_name'),
+            'locale': response.get('locale'),
+            'email': response.get('email'),
+            'address': response.get('address'),
+            'birthday': response.get('birthday'),
+            'image': response.get('image'),
+        }
+
+    def user_data(self, access_token, *args, **kwargs):
+        return self.get_json('https://oauth.mail.ru/userinfo', params={'access_token': access_token})

--- a/social_core/tests/backends/test_mailru.py
+++ b/social_core/tests/backends/test_mailru.py
@@ -3,8 +3,8 @@ import json
 from .oauth import OAuth2Test
 
 
-class MainMailruOAuth2Test(OAuth2Test):
-    backend_path = 'social_core.backends.mailru.MainMailruOAuth2'
+class MRGOAuth2Test(OAuth2Test):
+    backend_path = 'social_core.backends.mailru.MRGOAuth2'
     user_data_url = 'https://oauth.mail.ru/userinfo'
     expected_username = 'FooBar'
     access_token_body = json.dumps({


### PR DESCRIPTION
There is already backend for mailru:
https://python-social-auth.readthedocs.io/en/latest/backends/mailru.html
https://github.com/python-social-auth/social-core/blob/master/social_core/backends/mailru.py

which basically use https://my.mail.ru/ - old social network for authentication.
I think it is a good idea to do a new backend for the new mail.ru Oauth - https://oauth.mail.ru/docs