### PR TITLE
Protect attribute access against empty lists

### DIFF
--- a/social_core/backends/saml.py
+++ b/social_core/backends/saml.py
@@ -76,7 +76,10 @@ class SAMLIdentityProvider(object):
         key = self.conf.get(conf_key, default_attribute)
         value = attributes[key] if key in attributes else None
         if isinstance(value, list):
-            value = value[0]
+            if len(value):
+                value = value[0]
+            else:
+                value = None
         return value
 
     @property


### PR DESCRIPTION
If the IDP returns an empty list, return None rather than throwing.