### PR TITLE
Allow renaming of user field names

### DIFF
--- a/social_core/pipeline/user.py
+++ b/social_core/pipeline/user.py
@@ -76,7 +76,7 @@ def create_user(strategy, details, backend, user=None, *args, **kwargs):
     }
 
 
-def user_details(strategy, details, user=None, *args, **kwargs):
+def user_details(strategy, details, backend, user=None, *args, **kwargs):
     """Update user details using data from provider."""
     if not user:
         return
@@ -89,7 +89,10 @@ def user_details(strategy, details, user=None, *args, **kwargs):
     # provider. Update on some attributes is disabled by default, for
     # example username and id fields. It's also possible to disable update
     # on fields defined in SOCIAL_AUTH_PROTECTED_USER_FIELDS.
+    field_mapping = strategy.setting('USER_FIELD_MAPPING', {}, backend)
     for name, value in details.items():
+        # Convert to existing user field if mapping exists
+        name = field_mapping.get(name, name)
         if value is None or not hasattr(user, name) or name in protected:
             continue
 


### PR DESCRIPTION
The field names produced by psa might not map directly to the field names existing on a user model/schema. A mapping could be set in the settings that maps psa fields to program fields if a 1 to 1 mapping exists.

The committed change to `user_details` solves my immediate problem (map "fullname" to a field that exists in my `User` object), but there are other ways of doing it: instead of doing it in the `user_details` pipeline it could probably be done in the `social_details` pipeline, and instead of doing it in code it could be mentioned in the documentation that adapting psa field names to user model field names can be done in x, y, z ways. Regardless, how to do this should be documented/pointed to wherever custom users are mentioned.

Settings name: *_USER_FIELD_MAPPING.

This is one possible solution to #421. 