### PR TITLE
Add Python 3.9 compatibility.

### DIFF
--- a/social_core/tests/backends/open_id_connect.py
+++ b/social_core/tests/backends/open_id_connect.py
@@ -7,6 +7,7 @@ import unittest2
 import base64
 from calendar import timegm
 
+import six
 from jose import jwt
 from jose.jwk import RSAKey
 from httpretty import HTTPretty
@@ -138,7 +139,10 @@ class OpenIdConnectTestMixin(object):
         if tamper_message:
             header, msg, sig = body['id_token'].split('.')
             id_token['sub'] = '1235'
-            msg = base64.encodestring(json.dumps(id_token).encode()).decode()
+            if six.PY3:
+                msg = base64.encodebytes(json.dumps(id_token).encode()).decode()
+            else:
+                msg = base64.encodestring(json.dumps(id_token).encode()).decode()
             body['id_token'] = '.'.join([header, msg, sig])
 
         return json.dumps(body)

--- a/social_core/tests/backends/test_vk.py
+++ b/social_core/tests/backends/test_vk.py
@@ -21,7 +21,7 @@ class VKOAuth2Test(OAuth2Test):
             'last_name': 'Дуров',
             'screen_name': 'durov',
             'nickname': '',
-            'photo': "http:\/\/cs7003.vk.me\/v7003815\/22a1\/xgG9fb-IJ3Y.jpg"
+            'photo': r"http:\/\/cs7003.vk.me\/v7003815\/22a1\/xgG9fb-IJ3Y.jpg"
         }]
     })
 

--- a/social_core/tests/models.py
+++ b/social_core/tests/models.py
@@ -1,5 +1,7 @@
 import base64
 
+import six
+
 from ..storage import UserMixin, NonceMixin, AssociationMixin, \
                       CodeMixin, PartialMixin, BaseStorage
 
@@ -166,7 +168,10 @@ class TestAssociation(AssociationMixin, BaseModel):
         if assoc is None:
             assoc = TestAssociation(server_url=server_url,
                                     handle=association.handle)
-        assoc.secret = base64.encodestring(association.secret)
+        if six.PY3:
+            assoc.secret = base64.encodebytes(association.secret)
+        else:
+            assoc.secret = base64.encodestring(association.secret)
         assoc.issued = association.issued
         assoc.lifetime = association.lifetime
         assoc.assoc_type = association.assoc_type

--- a/social_core/utils.py
+++ b/social_core/utils.py
@@ -2,10 +2,14 @@ import re
 import sys
 import time
 import unicodedata
-import collections
 import functools
 import hmac
 import logging
+
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
 
 import six
 import requests
@@ -111,7 +115,7 @@ def sanitize_redirect(hosts, redirect_to):
 
 def user_is_authenticated(user):
     if user and hasattr(user, 'is_authenticated'):
-        if isinstance(user.is_authenticated, collections.Callable):
+        if isinstance(user.is_authenticated, Callable):
             authenticated = user.is_authenticated()
         else:
             authenticated = user.is_authenticated
@@ -124,7 +128,7 @@ def user_is_authenticated(user):
 
 def user_is_active(user):
     if user and hasattr(user, 'is_active'):
-        if isinstance(user.is_active, collections.Callable):
+        if isinstance(user.is_active, Callable):
             is_active = user.is_active()
         else:
             is_active = user.is_active

--- a/social_core/utils.py
+++ b/social_core/utils.py
@@ -115,7 +115,7 @@ def sanitize_redirect(hosts, redirect_to):
 
 def user_is_authenticated(user):
     if user and hasattr(user, 'is_authenticated'):
-        if isinstance(user.is_authenticated, Callable):
+        if callable(user.is_authenticated):
             authenticated = user.is_authenticated()
         else:
             authenticated = user.is_authenticated


### PR DESCRIPTION
* Import ABC from collections.abc instead of collections for Python 3.9 compatibility.
* Fix warnings regarding invalid escape sequences and base64.

Fixes #423 