### PR TITLE
[Github] Pass access token in a header.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use `unidecode` to cleanup usernames from unicode characters
 - Update Twitch API support from v3 to v5
 - Properly setup `pytest` version for Python2 and Python3
+- Github: pass access token in a header instead of in a query parameter.
 
 ## [3.2.0](https://github.com/python-social-auth/social-core/releases/tag/3.2.0) - 2019-05-30
 

--- a/social_core/backends/github.py
+++ b/social_core/backends/github.py
@@ -65,7 +65,8 @@ class GithubOAuth2(BaseOAuth2):
 
     def _user_data(self, access_token, path=None):
         url = urljoin(self.api_url(), 'user{0}'.format(path or ''))
-        return self.get_json(url, params={'access_token': access_token})
+        headers = {"Authorization": "token {0}".format(access_token)}
+        return self.get_json(url, headers=headers)
 
 
 class GithubMemberOAuth2(GithubOAuth2):

--- a/social_core/backends/github.py
+++ b/social_core/backends/github.py
@@ -76,10 +76,9 @@ class GithubMemberOAuth2(GithubOAuth2):
         user_data = super(GithubMemberOAuth2, self).user_data(
             access_token, *args, **kwargs
         )
+        headers = {'Authorization': 'token {0}'.format(access_token)}
         try:
-            self.request(self.member_url(user_data), params={
-                'access_token': access_token
-            })
+            self.request(self.member_url(user_data), headers=headers)
         except HTTPError as err:
             # if the user is a member of the organization, response code
             # will be 204, see http://bit.ly/ZS6vFl

--- a/social_core/backends/github.py
+++ b/social_core/backends/github.py
@@ -65,8 +65,7 @@ class GithubOAuth2(BaseOAuth2):
 
     def _user_data(self, access_token, path=None):
         url = urljoin(self.api_url(), 'user{0}'.format(path or ''))
-        headers = {"Authorization": "token {0}".format(access_token)}
-        return self.get_json(url, headers=headers)
+        return self.get_json(url, headers={'Authorization': 'token {0}'.format(access_token)})
 
 
 class GithubMemberOAuth2(GithubOAuth2):


### PR DESCRIPTION
https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters
> GitHub is deprecating authentication to the GitHub API using query parameters, such as using a access_token query parameter .......

https://developer.github.com/v3/auth/#basic-authentication