### PR TITLE
Fix assert depercations.

### DIFF
--- a/social_core/tests/actions/test_associate.py
+++ b/social_core/tests/actions/test_associate.py
@@ -82,6 +82,6 @@ class AlreadyAssociatedErrorTest(BaseActionTest):
         self.user = self.user1
         self.do_login()
         self.user = User(username='foobar2', email='foo2@bar2.com')
-        with self.assertRaisesRegexp(AuthAlreadyAssociated,
+        with self.assertRaisesRegex(AuthAlreadyAssociated,
                                      'This account is already in use.'):
             self.do_login()

--- a/social_core/tests/backends/open_id_connect.py
+++ b/social_core/tests/backends/open_id_connect.py
@@ -147,7 +147,7 @@ class OpenIdConnectTestMixin(object):
         self.access_token_body = self.prepare_access_token_body(
             **access_token_kwargs
         )
-        with self.assertRaisesRegexp(AuthTokenError, expected_message):
+        with self.assertRaisesRegex(AuthTokenError, expected_message):
             self.do_login()
 
     def test_invalid_signature(self):

--- a/social_core/tests/backends/test_broken.py
+++ b/social_core/tests/backends/test_broken.py
@@ -17,21 +17,21 @@ class BrokenBackendTest(unittest.TestCase):
         self.backend = None
 
     def test_auth_url(self):
-        with self.assertRaisesRegexp(NotImplementedError,
+        with self.assertRaisesRegex(NotImplementedError,
                                      'Implement in subclass'):
             self.backend.auth_url()
 
     def test_auth_html(self):
-        with self.assertRaisesRegexp(NotImplementedError,
+        with self.assertRaisesRegex(NotImplementedError,
                                      'Implement in subclass'):
             self.backend.auth_html()
 
     def test_auth_complete(self):
-        with self.assertRaisesRegexp(NotImplementedError,
+        with self.assertRaisesRegex(NotImplementedError,
                                      'Implement in subclass'):
             self.backend.auth_complete()
 
     def test_get_user_details(self):
-        with self.assertRaisesRegexp(NotImplementedError,
+        with self.assertRaisesRegex(NotImplementedError,
                                      'Implement in subclass'):
             self.backend.get_user_details(None)

--- a/social_core/tests/backends/test_twitter.py
+++ b/social_core/tests/backends/test_twitter.py
@@ -255,7 +255,7 @@ class TwitterOAuth1IncludeEmailTest(OAuth1Test):
 
     def test_login(self):
         user = self.do_login()
-        self.assertEquals(user.email, 'foo@bar.bas')
+        self.assertEqual(user.email, 'foo@bar.bas')
 
     def test_partial_pipeline(self):
         self.do_partial_pipeline()

--- a/social_core/tests/backends/test_utils.py
+++ b/social_core/tests/backends/test_utils.py
@@ -40,7 +40,7 @@ class GetBackendTest(BaseBackendUtilsTest):
         self.assertEqual(backend, GithubOAuth2)
 
     def test_get_missing_backend(self):
-        with self.assertRaisesRegexp(MissingBackend,
+        with self.assertRaisesRegex(MissingBackend,
                                      'Missing backend "foobar" entry'):
             get_backend(('social_core.backends.github.GithubOAuth2',
                          'social_core.backends.facebook.FacebookOAuth2',

--- a/social_core/tests/test_storage.py
+++ b/social_core/tests/test_storage.py
@@ -50,35 +50,35 @@ class BrokenUserTests(unittest.TestCase):
         self.user = None
 
     def test_get_username(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.user.get_username(User('foobar'))
 
     def test_user_model(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.user.user_model()
 
     def test_username_max_length(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.user.username_max_length()
 
     def test_get_user(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.user.get_user(1)
 
     def test_get_social_auth(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.user.get_social_auth('foo', 1)
 
     def test_get_social_auth_for_user(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.user.get_social_auth_for_user(User('foobar'))
 
     def test_create_social_auth(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.user.create_social_auth(User('foobar'), 1, 'foo')
 
     def test_disconnect(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.user.disconnect(BrokenUser())
 
 
@@ -90,15 +90,15 @@ class BrokenAssociationTests(unittest.TestCase):
         self.association = None
 
     def test_store(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.association.store('http://foobar.com', BrokenAssociation())
 
     def test_get(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.association.get()
 
     def test_remove(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.association.remove([1, 2, 3])
 
 
@@ -110,7 +110,7 @@ class BrokenNonceTests(unittest.TestCase):
         self.nonce = None
 
     def test_use(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.nonce.use('http://foobar.com', 1364951922, 'foobar123')
 
 
@@ -122,7 +122,7 @@ class BrokenCodeTest(unittest.TestCase):
         self.code = None
 
     def test_get_code(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.code.get_code('foobar')
 
 
@@ -134,56 +134,56 @@ class BrokenStrategyTests(unittest.TestCase):
         self.strategy = None
 
     def test_redirect(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.strategy.redirect('http://foobar.com')
 
     def test_get_setting(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.strategy.get_setting('foobar')
 
     def test_html(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.strategy.html('<p>foobar</p>')
 
     def test_request_data(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.strategy.request_data()
 
     def test_request_host(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.strategy.request_host()
 
     def test_session_get(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.strategy.session_get('foobar')
 
     def test_session_set(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.strategy.session_set('foobar', 123)
 
     def test_session_pop(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.strategy.session_pop('foobar')
 
     def test_build_absolute_uri(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.strategy.build_absolute_uri('/foobar')
 
     def test_render_html_with_tpl(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.strategy.render_html('foobar.html', context={})
 
     def test_render_html_with_html(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.strategy.render_html(html='<p>foobar</p>', context={})
 
     def test_render_html_with_none(self):
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'Missing template or html parameters'):
             self.strategy.render_html()
 
     def test_is_integrity_error(self):
-        with self.assertRaisesRegexp(NotImplementedError, NOT_IMPLEMENTED_MSG):
+        with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.strategy.storage.is_integrity_error(None)
 
     def test_random_string(self):


### PR DESCRIPTION
```
social_core/tests/backends/test_twitter.py::TwitterOAuth1IncludeEmailTest::test_login
  /home/travis/build/asherf/social-core/social_core/tests/backends/test_twitter.py:258: PendingDeprecationWarning: Please use assertEqual instead.
    self.assertEquals(user.email, 'foo@bar.bas')
social_core/tests/backends/test_utils.py::GetBackendTest::test_get_missing_backend
  /home/travis/build/asherf/social-core/social_core/tests/backends/test_utils.py:44: PendingDeprecationWarning: Please use assertRaisesRegex instead.
    'Missing backend "foobar" entry'):
```