### PR TITLE
Removed the deprecated usage of user.is_authenticated()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use `unidecode` to cleanup usernames from unicode characters
 - Update Twitch API support from v3 to v5
 - Properly setup `pytest` version for Python2 and Python3
+- Removed usage of `user.is_authenticated()`
 
 ## [3.2.0](https://github.com/python-social-auth/social-core/releases/tag/3.2.0) - 2019-05-30
 

--- a/social_core/tests/test_utils.py
+++ b/social_core/tests/test_utils.py
@@ -71,6 +71,7 @@ class UserIsAuthenticatedTest(unittest.TestCase):
 
     def test_user_has_is_authenticated_callable(self):
         class User(object):
+            @property
             def is_authenticated(self):
                 return True
         self.assertEqual(user_is_authenticated(User()), True)

--- a/social_core/utils.py
+++ b/social_core/utils.py
@@ -112,7 +112,7 @@ def sanitize_redirect(hosts, redirect_to):
 def user_is_authenticated(user):
     if user and hasattr(user, 'is_authenticated'):
         if isinstance(user.is_authenticated, collections.Callable):
-            authenticated = user.is_authenticated()
+            authenticated = user.is_authenticated
         else:
             authenticated = user.is_authenticated
     elif user:


### PR DESCRIPTION
removed the usage of `user.is_authenticated()` to replace it to use a property instead to fix 

> RemovedInDjango20Warning

details in issue #439 