### PR TITLE
Allow to ignore default protected user fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Support for SAML Single Logout
 - SimpleLogin backend
+- Allow ignoring of default protected user fields with option `SOCIAL_AUTH_NO_DEFAULT_PROTECTED_USER_FIELDS`
 
 ### Changed
 - Update test runner to PyTest

--- a/social_core/pipeline/user.py
+++ b/social_core/pipeline/user.py
@@ -82,8 +82,15 @@ def user_details(strategy, details, user=None, *args, **kwargs):
         return
 
     changed = False  # flag to track changes
-    protected = ('username', 'id', 'pk', 'email') + \
-                tuple(strategy.setting('PROTECTED_USER_FIELDS', []))
+
+    # Default protected user fields (username, id, pk and email) can be ignored
+    # by setting the SOCIAL_AUTH_NO_DEFAULT_PROTECTED_USER_FIELDS to True
+    if strategy.setting('NO_DEFAULT_PROTECTED_USER_FIELDS') is True:
+        protected = ()
+    else:
+        protected = ('username', 'id', 'pk', 'email')
+
+    protected = protected + tuple(strategy.setting('PROTECTED_USER_FIELDS', []))
 
     # Update user model attributes with the new data sent by the current
     # provider. Update on some attributes is disabled by default, for


### PR DESCRIPTION
This tiny PR allows developers to ignore default protected user fields: username, id, pk and email

To fully ignore them, set SOCIAL_AUTH_NO_DEFAULT_PROTECTED_USER_FIELDS to True.

Of course, you can add your own protected fiels by setting them in  `SOCIAL_AUTH_PROTECTED_USER_FIELDS`.

This PR will help me, removing my uggly workaround here: umap-project/umap#754

This PR is related to :

- #348
- #263
- #432
