### PR TITLE
Try to validate the correct Apple key

### DIFF
--- a/social_core/backends/apple.py
+++ b/social_core/backends/apple.py
@@ -87,17 +87,17 @@ class AppleIdAuth(BaseOAuth2):
         return client_id, client_secret
 
     def get_apple_jwk(self, kid=None):
+        '''Return requested Apple public key or all available.'''
         keys = self.get_json(url=self.JWK_URL).get("keys")
 
         if not isinstance(keys, list) or not keys:
             raise AuthCanceled("Invalid jwk response")
         
-        # Return requested key instead of the last one
         if kid:
             return json.dumps([key for key in keys if key['kid'] == kid][0])
+        else:
+            return (json.dumps(key) for key in keys)
         
-        return json.dumps(keys.pop())
-
     def decode_id_token(self, id_token):
         '''Decode and validate JWT token from apple and return payload including user data.'''
         if not id_token:

--- a/social_core/backends/apple.py
+++ b/social_core/backends/apple.py
@@ -104,7 +104,7 @@ class AppleIdAuth(BaseOAuth2):
             raise AuthCanceled("Missing id_token parameter")
 
 
-        kid = jwt.get_unverified_header(id_token).get('kid', None)
+        kid = jwt.get_unverified_header(id_token).get('kid')
         public_key = RSAAlgorithm.from_jwk(self.get_apple_jwk(kid))
         try:
             decoded = jwt.decode(id_token, key=public_key,


### PR DESCRIPTION
It improves the key validation process trying to get just the requested `kid` (key id) instead of trying all available keys (https://appleid.apple.com/auth/keys).

It's better and safer try to validate using the signing key for this jwt.

Currently, all available Apple public keys are iterated trying to validate the jwt. 