### PR TITLE
Clean up the right `partial_token` in the session

### DIFF
--- a/social_core/strategy.py
+++ b/social_core/strategy.py
@@ -92,7 +92,9 @@ class BaseStrategy(object):
 
     def clean_partial_pipeline(self, token):
         self.storage.partial.destroy(token)
-        self.session_pop(PARTIAL_TOKEN_SESSION_NAME)
+        current_token_in_session = self.session_get(PARTIAL_TOKEN_SESSION_NAME)
+        if current_token_in_session == token:
+            self.session_pop(PARTIAL_TOKEN_SESSION_NAME)
 
     def openid_store(self):
         return OpenIdStore(self)


### PR DESCRIPTION
# Proposed changes

The `clean_partial_pipeline` process consists cleans the token from two places:
- The database
- The session

The clean up process is database works seamlessly since the `Partial` object is used to perform the clean up. The clean up from the session however inadvertently removes the `partial_token` for the **new** partial function instead of the old one because it doesn't check that the session token actually matches the `partial_token`.

This PR checks the `partial_token` in the session before popping it.

This fixes #454 

## Types of changes

Please check the type of change your PR introduces:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works


