### PR TITLE
Update Azure AD B2C base url to the latest url as stated in the Microsoft docs

### DIFF
--- a/social_core/backends/azuread_b2c.py
+++ b/social_core/backends/azuread_b2c.py
@@ -54,11 +54,11 @@ from .azuread import AzureADOAuth2
 class AzureADB2COAuth2(AzureADOAuth2):
     name = 'azuread-b2c-oauth2'
 
-    BASE_URL = 'https://login.microsoftonline.com/{tenant_id}'
+    BASE_URL = 'https://{tenant_name}.b2clogin.com/{tenant_name}.onmicrosoft.com/{policy}'
     AUTHORIZATION_URL = '{base_url}/oauth2/v2.0/authorize'
-    OPENID_CONFIGURATION_URL = '{base_url}/v2.0/.well-known/openid-configuration?p={policy}'
-    ACCESS_TOKEN_URL = '{base_url}/oauth2/v2.0/token?p={policy}'
-    JWKS_URL = '{base_url}/discovery/v2.0/keys?p={policy}'
+    OPENID_CONFIGURATION_URL = '{base_url}/v2.0/.well-known/openid-configuration'
+    ACCESS_TOKEN_URL = '{base_url}/oauth2/v2.0/token'
+    JWKS_URL = '{base_url}/discovery/v2.0/keys'
     DEFAULT_SCOPE = ['openid', 'email']
     EXTRA_DATA = [
         ('access_token', 'access_token'),
@@ -74,8 +74,8 @@ class AzureADB2COAuth2(AzureADOAuth2):
     ]
 
     @property
-    def tenant_id(self):
-        return self.setting('TENANT_ID', 'common')
+    def tenant_name(self):
+        return self.setting('TENANT_NAME', 'common')
 
     @property
     def policy(self):
@@ -87,23 +87,20 @@ class AzureADB2COAuth2(AzureADOAuth2):
 
     @property
     def base_url(self):
-        return self.BASE_URL.format(tenant_id=self.tenant_id)
+        return self.BASE_URL.format(tenant_name=self.tenant_name, policy=self.policy)
 
     def openid_configuration_url(self):
-        return self.OPENID_CONFIGURATION_URL.format(base_url=self.base_url,
-                                                    policy=self.policy)
+        return self.OPENID_CONFIGURATION_URL.format(base_url=self.base_url)
 
     def authorization_url(self):
         # Policy is required, but added later by `auth_extra_arguments()`
         return self.AUTHORIZATION_URL.format(base_url=self.base_url)
 
     def access_token_url(self):
-        return self.ACCESS_TOKEN_URL.format(base_url=self.base_url,
-                                            policy=self.policy)
+        return self.ACCESS_TOKEN_URL.format(base_url=self.base_url)
 
     def jwks_url(self):
-        return self.JWKS_URL.format(base_url=self.base_url,
-                                    policy=self.policy)
+        return self.JWKS_URL.format(base_url=self.base_url)
 
     def request_access_token(self, *args, **kwargs):
         """

--- a/social_core/tests/backends/test_azuread_b2c.py
+++ b/social_core/tests/backends/test_azuread_b2c.py
@@ -95,7 +95,7 @@ class AzureADOAuth2Test(OAuth2Test):
                 'family_name': 'Bar',
                 'given_name': 'Foo',
                 'iat': AUTH_TIME,
-                'iss': 'https://login.microsoftonline.com/9a9a9a9a-1111-5555-0000-bc24adfdae00/v2.0/',
+                'iss': 'https://footenant.b2clogin.com/99999999-0000-0000-0000-999999999999/v2.0/',
                 'name': 'FooBar',
                 'nbf': AUTH_TIME,
                 'oid': '11223344-5566-7788-9999-aabbccddeeff',
@@ -103,7 +103,7 @@ class AzureADOAuth2Test(OAuth2Test):
                 'sub': '11223344-5566-7788-9999-aabbccddeeff',
                 'tfp': 'B2C_1_SignIn',
                 'ver': '1.0',
-        }).decode('ascii'),
+            }).decode('ascii'),
         'expires_in': EXPIRES_IN,
         'expires_on': EXPIRES_ON,
         'not_before': AUTH_TIME,
@@ -114,14 +114,14 @@ class AzureADOAuth2Test(OAuth2Test):
         settings.update({
             'SOCIAL_AUTH_' + self.name + '_POLICY': 'b2c_1_signin',
             'SOCIAL_AUTH_' + self.name + '_KEY': self.AUTH_KEY,
-            'SOCIAL_AUTH_' + self.name + '_TENANT_ID': 'footenant.onmicrosoft.com',
+            'SOCIAL_AUTH_' + self.name + '_TENANT_NAME': 'footenant',
         })
         return settings
 
     def setUp(self):
         super(AzureADOAuth2Test, self).setUp()
 
-        keys_url = 'https://login.microsoftonline.com/footenant.onmicrosoft.com/discovery/v2.0/keys?p=b2c_1_signin'
+        keys_url = 'https://footenant.b2clogin.com/footenant.onmicrosoft.com/b2c_1_signin/discovery/v2.0/keys'
         keys_body = json.dumps({
             'keys': [{
                 # Dummy public key that pairs with `access_token_body` key:
@@ -136,7 +136,7 @@ class AzureADOAuth2Test(OAuth2Test):
                      'EHg8lhzwOHrtIQbS0FVbb9k3-tVTU4fg_3L_vniUFAKwuCLqKnS2BYwdq_'
                      'mzSnbLY7h_qixoR7jig3__kRhuaxwUkRz5iaiQkqgc5gHdrNP5zw',
                 'e': 'AQAB',
-        }],
+            }],
         })
         HTTPretty.register_uri(HTTPretty.GET, keys_url, status=200, body=keys_body)
 


### PR DESCRIPTION
<!--
    Pull request template based on the following templates:
    * https://raw.githubusercontent.com/ionic-team/ionic/master/.github/PULL_REQUEST_TEMPLATE.md
    * https://raw.githubusercontent.com/appium/appium/master/.github/PULL_REQUEST_TEMPLATE.md
-->

## Proposed changes

Using login.microsoftonline.com for Azure AD B2C has been deprecated and it will be removed later this year. See [Deprecation notice](https://docs.microsoft.com/en-us/azure/active-directory-b2c/b2clogin). Even though login.microsoftonline.com is still being supported by Microsoft I was not able to get it working for a new Azure AD B2C Tenant. Updating the BASE_URL to the new url and moving the policy to the url itself instead of a query parameter works correctly. This is how it's stated in the latest [docs for Azure AD B2C OpenID Connect](https://docs.microsoft.com/en-us/azure/active-directory-b2c/openid-connect).

## Types of changes

Please check the type of change your PR introduces:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Other information

SOCIAL_AUTH_AZUREAD_B2C_OAUTH2_TENANT_ID was changed to SOCIAL_AUTH_AZUREAD_B2C_OAUTH2_TENANT_NAME since only the tenant name is needed now.
