### PR TITLE
Instagram backend refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Updated list of default user protected fields to include admin flags and password
+- Instagram: Update to use the latest Graph API v3.2
 
 ## [3.3.2](https://github.com/python-social-auth/social-core/releases/tag/3.3.2) - 2020-03-25
 

--- a/social_core/backends/facebook.py
+++ b/social_core/backends/facebook.py
@@ -149,8 +149,8 @@ class FacebookOAuth2(BaseOAuth2):
         if self.data.get('denied_scopes'):
             data['denied_scopes'] = self.data['denied_scopes'].split(',')
 
-        kwargs.update({'backend': self, 'response': data})
-        return self.strategy.authenticate(*args, **kwargs)
+        kwargs.update({'response': data})
+        return self.strategy.authenticate(self,*args, **kwargs)
 
     def revoke_token_url(self, token, uid):
         version = self.setting('API_VERSION', API_VERSION)

--- a/social_core/backends/instagram.py
+++ b/social_core/backends/instagram.py
@@ -60,7 +60,7 @@ class InstagramOAuth2(BaseOAuth2):
             raise AuthMissingParameter(self, 'code')
         state = self.validate_state()
         key, secret = self.get_key_and_secret()
-        response = self.request(ACCESS_TOKEN_URL, params={
+        response = self.request(self.ACCESS_TOKEN_URL, params={
             'client_id': key,
             'client_secret': secret,
             'code': self.data['code'],

--- a/social_core/backends/instagram.py
+++ b/social_core/backends/instagram.py
@@ -28,11 +28,6 @@ class InstagramOAuth2(BaseOAuth2):
             uri = url_add_parameters(uri, {'state': state})
         return uri
 
-    def auth_params(self, state=None):
-        params = super(InstagramOAuth2, self).auth_params(state)
-        params['return_scopes'] = 'true'
-        return params
-
     def get_user_id(self, details, response):
         # https://developers.facebook.com/docs/instagram-basic-display-api/reference/me
         user_id = response.get('id') or {}

--- a/social_core/backends/instagram.py
+++ b/social_core/backends/instagram.py
@@ -8,7 +8,7 @@ import json
 from hashlib import sha256
 
 from .oauth import BaseOAuth2
-from ..utils import handle_http_errors
+from ..utils import handle_http_errors, parse_qs
 from ..exceptions import AuthCanceled, AuthMissingParameter
 
 
@@ -71,6 +71,13 @@ class InstagramOAuth2(BaseOAuth2):
             },
             method=self.ACCESS_TOKEN_METHOD
         )
+        # API v2.3 returns a JSON, according to the documents linked at issue
+        # #592, but it seems that this needs to be enabled(?), otherwise the
+        # usual querystring type response is returned.
+        try:
+            response = response.json()
+        except ValueError:
+            response = parse_qs(response.text)
         access_token = response['access_token']
         return self.do_auth(access_token, response, *args, **kwargs)
 

--- a/social_core/backends/instagram.py
+++ b/social_core/backends/instagram.py
@@ -27,7 +27,7 @@ class InstagramOAuth2(BaseOAuth2):
         """Return user details from Instagram account"""
         # https://developers.facebook.com/docs/instagram-basic-display-api/reference/me
         fullname, first_name, last_name = self.get_user_names(
-            user.get('full_name', '')
+            response.get('full_name', '')
         )
         return {'username': response.get('username', response.get('name')),
                 'email': response.get('email', ''),

--- a/social_core/backends/instagram.py
+++ b/social_core/backends/instagram.py
@@ -12,21 +12,13 @@ from .oauth import BaseOAuth2
 class InstagramOAuth2(BaseOAuth2):
     name = 'instagram'
     RESPONSE_TYPE = None
+    REDIRECT_STATE = False
     SCOPE_SEPARATOR = ','
     AUTHORIZATION_URL = 'https://api.instagram.com/oauth/authorize'
     ACCESS_TOKEN_URL = 'https://api.instagram.com/oauth/access_token'
     USER_DATA_URL = 'https://graph.instagram.com/me/'
     REFRESH_TOKEN_URL = 'https://graph.instagram.com/refresh_access_token'
     ACCESS_TOKEN_METHOD = 'POST'
-
-    def get_redirect_uri(self, state=None):
-        """Build redirect with redirect_state parameter."""
-        # Facebook and Instagram redirect_uri can accept states now 
-        # but the key must be 'state' or it'll cancel authentication
-        uri = self.redirect_uri
-        if self.REDIRECT_STATE and state:
-            uri = url_add_parameters(uri, {'state': state})
-        return uri
 
     def get_user_id(self, details, response):
         # https://developers.facebook.com/docs/instagram-basic-display-api/reference/me

--- a/social_core/backends/instagram.py
+++ b/social_core/backends/instagram.py
@@ -3,10 +3,13 @@ Instagram OAuth2 backend, docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/instagram.html
 """
 import hmac
+import json
 
 from hashlib import sha256
 
 from .oauth import BaseOAuth2
+from ..utils import handle_http_errors
+from ..exceptions import AuthCanceled, AuthMissingParameter
 
 
 class InstagramOAuth2(BaseOAuth2):

--- a/social_core/backends/instagram.py
+++ b/social_core/backends/instagram.py
@@ -22,10 +22,6 @@ class InstagramOAuth2(BaseOAuth2):
     REFRESH_TOKEN_URL = 'https://graph.instagram.com/refresh_access_token'
     ACCESS_TOKEN_METHOD = 'POST'
 
-    def get_user_id(self, details, response):
-        # https://developers.facebook.com/docs/instagram-basic-display-api/reference/me
-        user_id = response.get('id') or {}
-        return user_id
 
     def get_user_details(self, response):
         """Return user details from Instagram account"""
@@ -60,8 +56,8 @@ class InstagramOAuth2(BaseOAuth2):
         response.update(data or {})
         if 'access_token' not in response:
             response['access_token'] = access_token
-        kwargs.update({'response': response})
-        return self.strategy.authenticate(backend=self, *args, **kwargs)
+        kwargs.update({'backend': self, 'response': data})
+        return self.strategy.authenticate(*args, **kwargs)
 
     @handle_http_errors
     def auth_complete(self, *args, **kwargs):

--- a/social_core/backends/instagram.py
+++ b/social_core/backends/instagram.py
@@ -53,6 +53,17 @@ class InstagramOAuth2(BaseOAuth2):
                                      data.get('error_code'))
 
     @handle_http_errors
+    def do_auth(self, access_token, *args, **kwargs):
+        """Finish the auth process once the access_token was retrieved"""
+        data = self.user_data(access_token, *args, **kwargs)
+        response = kwargs.get('response') or {}
+        response.update(data or {})
+        if 'access_token' not in response:
+            response['access_token'] = access_token
+        kwargs.update({'response': response})
+        return self.strategy.authenticate(backend=self, *args, **kwargs)
+
+    @handle_http_errors
     def auth_complete(self, *args, **kwargs):
         """Completes login process, must return user instance"""
         self.process_error(self.data)

--- a/social_core/backends/instagram.py
+++ b/social_core/backends/instagram.py
@@ -70,7 +70,7 @@ class InstagramOAuth2(BaseOAuth2):
             'client_id': key,
             'client_secret': secret,
             'code': self.data['code'],
-            'grant_type': 'authorization_code'
+            'grant_type': 'authorization_code',
             'redirect_uri': self.get_redirect_uri(state),
         })
         access_token = response['access_token']

--- a/social_core/backends/instagram.py
+++ b/social_core/backends/instagram.py
@@ -56,8 +56,9 @@ class InstagramOAuth2(BaseOAuth2):
         response.update(data or {})
         if 'access_token' not in response:
             response['access_token'] = access_token
-        kwargs.update({'backend': self, 'response': data})
-        return self.strategy.authenticate(*args, **kwargs)
+        kwargs.update({'response': data})
+        backend=self
+        return self.strategy.authenticate(backend, *args, **kwargs)
 
     @handle_http_errors
     def auth_complete(self, *args, **kwargs):

--- a/social_core/backends/instagram.py
+++ b/social_core/backends/instagram.py
@@ -14,7 +14,6 @@ from ..exceptions import AuthCanceled, AuthMissingParameter
 
 class InstagramOAuth2(BaseOAuth2):
     name = 'instagram'
-    RESPONSE_TYPE = None
     REDIRECT_STATE = False
     SCOPE_SEPARATOR = ','
     AUTHORIZATION_URL = 'https://api.instagram.com/oauth/authorize'

--- a/social_core/backends/instagram.py
+++ b/social_core/backends/instagram.py
@@ -49,17 +49,6 @@ class InstagramOAuth2(BaseOAuth2):
                                      data.get('error_code'))
 
     @handle_http_errors
-    def do_auth(self, access_token, *args, **kwargs):
-        """Finish the auth process once the access_token was retrieved"""
-        data = self.user_data(access_token, *args, **kwargs)
-        response = kwargs.get('response') or {}
-        response.update(data or {})
-        if 'access_token' not in response:
-            response['access_token'] = access_token
-        kwargs.update({'response': data})
-        return self.strategy.authenticate(self, *args, **kwargs)
-
-    @handle_http_errors
     def auth_complete(self, *args, **kwargs):
         """Completes login process, must return user instance"""
         self.process_error(self.data)
@@ -86,7 +75,7 @@ class InstagramOAuth2(BaseOAuth2):
         except ValueError:
             response = parse_qs(response.text)
         access_token = response['access_token']
-        return self.do_auth(access_token, response, *args, **kwargs)
+        return self.do_auth(access_token, response=response, *args, **kwargs)
 
 
     def refresh_token_params(self, token, *args, **kwargs):

--- a/social_core/backends/instagram.py
+++ b/social_core/backends/instagram.py
@@ -60,13 +60,17 @@ class InstagramOAuth2(BaseOAuth2):
             raise AuthMissingParameter(self, 'code')
         state = self.validate_state()
         key, secret = self.get_key_and_secret()
-        response = self.request(self.ACCESS_TOKEN_URL, params={
-            'client_id': key,
-            'client_secret': secret,
-            'code': self.data['code'],
-            'grant_type': 'authorization_code',
-            'redirect_uri': self.get_redirect_uri(state),
-        })
+        response = self.request(
+            self.ACCESS_TOKEN_URL, 
+            params={
+                'client_id': key,
+                'client_secret': secret,
+                'code': self.data['code'],
+                'grant_type': 'authorization_code',
+                'redirect_uri': self.get_redirect_uri(state),
+            },
+            method=self.ACCESS_TOKEN_METHOD
+        )
         access_token = response['access_token']
         return self.do_auth(access_token, response, *args, **kwargs)
 

--- a/social_core/backends/instagram.py
+++ b/social_core/backends/instagram.py
@@ -62,7 +62,7 @@ class InstagramOAuth2(BaseOAuth2):
         key, secret = self.get_key_and_secret()
         response = self.request(
             self.ACCESS_TOKEN_URL, 
-            params={
+            data={
                 'client_id': key,
                 'client_secret': secret,
                 'code': self.data['code'],

--- a/social_core/backends/instagram.py
+++ b/social_core/backends/instagram.py
@@ -57,8 +57,7 @@ class InstagramOAuth2(BaseOAuth2):
         if 'access_token' not in response:
             response['access_token'] = access_token
         kwargs.update({'response': data})
-        backend=self
-        return self.strategy.authenticate(backend, *args, **kwargs)
+        return self.strategy.authenticate(self, *args, **kwargs)
 
     @handle_http_errors
     def auth_complete(self, *args, **kwargs):


### PR DESCRIPTION
<!--
    Pull request template based on the following templates:
    * https://raw.githubusercontent.com/ionic-team/ionic/master/.github/PULL_REQUEST_TEMPLATE.md
    * https://raw.githubusercontent.com/appium/appium/master/.github/PULL_REQUEST_TEMPLATE.md
-->

## Proposed changes

Instagram has deprecated most of the endpoints on api.instagram and moved all data access to graph.instagram. 
**Short story**: Instagram Basic Display is no longer an authentication solution. 
**Long story**: Instagram Basic Display only works on accounts that are not creator or business accounts and the endpoint will not return data (email, etc) that can be used to authenticate users. However, for creator and business accounts, the facebook backend is the authentication solution. I propose that we keep the Instagram backend for users who want to associate Instagram personal (non-creator and non-business) accounts with authenticated users. It is important to note that Facebook does not verify apps (social_core library users) that use this as an authentication method.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Other information

