### PR TITLE
Make WHITELIST_* settings properly case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Improve Python 3.9 compatibility
 - Send proxies in request
 - Improve error handling in Apple backend
+- Properly support case insensitive matching of whitelist settings
 
 ## [3.3.3](https://github.com/python-social-auth/social-core/releases/tag/3.3.3) - 2020-04-16
 

--- a/social_core/backends/base.py
+++ b/social_core/backends/base.py
@@ -150,9 +150,10 @@ class BaseAuth(object):
         default check if email is whitelisted (if there's a whitelist)"""
         emails = [email.lower() for email in self.setting('WHITELISTED_EMAILS', [])]
         domains = [domain.lower() for domain in self.setting('WHITELISTED_DOMAINS', [])]
+        email = details.get('email')
         allowed = True
         if email and (emails or domains):
-            email = details.get('email').lower()
+            email = email.lower()
             domain = email.split('@', 1)[1]
             allowed = email in emails or domain in domains
         return allowed

--- a/social_core/backends/base.py
+++ b/social_core/backends/base.py
@@ -148,24 +148,12 @@ class BaseAuth(object):
     def auth_allowed(self, response, details):
         """Return True if the user should be allowed to authenticate, by
         default check if email is whitelisted (if there's a whitelist)"""
-        def lower_email_domain(email):
-            """Lowercase an email safely by leaving the local-part alone and
-            only lowercasing the domain."""
-            if email is None:
-                return
-
-            try:
-                local_part, domain = email.split('@', 1)
-            except ValueError:
-                return email  # the email is malformed, pass it through unchanged
-            return '@'.join([local_part, domain.lower()])
-
-        emails = [lower_email_domain(email) for email in self.setting('WHITELISTED_EMAILS', [])]
+        emails = [email.lower() for email in self.setting('WHITELISTED_EMAILS', [])]
         domains = [domain.lower() for domain in self.setting('WHITELISTED_DOMAINS', [])]
-        email = lower_email_domain(details.get('email'))
         allowed = True
         if email and (emails or domains):
-            domain = email.split('@', 1)[1].lower()
+            email = details.get('email').lower()
+            domain = email.split('@', 1)[1]
             allowed = email in emails or domain in domains
         return allowed
 

--- a/social_core/tests/backends/test_dummy.py
+++ b/social_core/tests/backends/test_dummy.py
@@ -98,14 +98,13 @@ class WhitelistEmailsTest(DummyOAuth2Test):
         with self.assertRaises(AuthForbidden):
             self.do_login()
 
-    def test_invalid_login_case_sensitive_local_part(self):
+    def test_login_case_sensitive_local_part(self):
         self.strategy.set_settings({
             'SOCIAL_AUTH_WHITELISTED_EMAILS': ['fOo@bar.com']
         })
-        with self.assertRaises(AuthForbidden):
-            self.do_login()
+        self.do_login()
 
-    def test_invalid_login_case_sensitive_domain(self):
+    def test_login_case_sensitive_domain(self):
         self.strategy.set_settings({
             'SOCIAL_AUTH_WHITELISTED_EMAILS': ['foo@bAR.com']
         })

--- a/social_core/tests/backends/test_dummy.py
+++ b/social_core/tests/backends/test_dummy.py
@@ -58,7 +58,7 @@ class DummyOAuth2Test(OAuth2Test):
         'url': 'http://dummy.com/user/foobar',
         'first_name': 'Foo',
         'last_name': 'Bar',
-        'email': 'foo@bar.com'
+        'email': 'foo@bAr.coM'  # mixed case domain for testing case sensitivity
     })
 
     def test_login(self):
@@ -98,6 +98,18 @@ class WhitelistEmailsTest(DummyOAuth2Test):
         with self.assertRaises(AuthForbidden):
             self.do_login()
 
+    def test_invalid_login_case_sensitive_local_part(self):
+        self.strategy.set_settings({
+            'SOCIAL_AUTH_WHITELISTED_EMAILS': ['fOo@bar.com']
+        })
+        with self.assertRaises(AuthForbidden):
+            self.do_login()
+
+    def test_invalid_login_case_sensitive_domain(self):
+        self.strategy.set_settings({
+            'SOCIAL_AUTH_WHITELISTED_EMAILS': ['foo@bAR.com']
+        })
+        self.do_login()
 
 class WhitelistDomainsTest(DummyOAuth2Test):
     def test_valid_login(self):


### PR DESCRIPTION
<!--
    Pull request template based on the following templates:
    * https://raw.githubusercontent.com/ionic-team/ionic/master/.github/PULL_REQUEST_TEMPLATE.md
    * https://raw.githubusercontent.com/appium/appium/master/.github/PULL_REQUEST_TEMPLATE.md
-->

## Proposed changes

With a setting of `SOCIAL_AUTH_WHITELISTED_DOMAINS` set to `gmail.com`, a separate system storing
the domain as `Gmail.com` would be rejected. According to [RFC 1035](https://tools.ietf.org/html/rfc1035) the domain should be checked in a case insensitive manner.

This applies only to the domain portion of whitelisted email addresses as well, e.g. `foo@bar.com` is distinct from `FOO@bar.com`.

I was unable to make the change as cleanly as I would have liked, since it appears that misconfiguring the `SOCIAL_AUTH_WHITELISTED_EMAILS` setting by giving it a domain instead of a valid email is implicitly supported, see https://github.com/python-social-auth/social-core/blob/dddb1784fa54468a09f552ca299f60017f4f6aa9/social_core/tests/backends/test_dummy.py#L111.

## Types of changes

Please check the type of change your PR introduces:

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [ ] Lint and unit tests pass locally with my changes
	I was unable to get everything passing locally before I made the change. But no additional tests fail.
- [X] I have added tests that prove my fix is effective or that my feature works
