### PR TITLE
Fix apple and saml backend filling user_details with `None` values.

### DIFF
--- a/social_core/backends/apple.py
+++ b/social_core/backends/apple.py
@@ -142,10 +142,9 @@ class AppleIdAuth(BaseOAuth2):
 
         email = response.get('email', '')
         apple_id = response.get(self.ID_KEY, '')
-        # prevent updating User with empty strings
         user_details = {
-            'first_name': first_name or None,
-            'last_name': last_name or None,
+            'first_name': first_name,
+            'last_name': last_name,
             'email': email,
         }
         if email and self.setting('EMAIL_AS_USERNAME'):

--- a/social_core/backends/saml.py
+++ b/social_core/backends/saml.py
@@ -79,7 +79,7 @@ class SAMLIdentityProvider(object):
             if len(value):
                 value = value[0]
             else:
-                value = None
+                value = ''
         return value
 
     @property


### PR DESCRIPTION
<!--

    Pull request template based on the following templates:
    * https://raw.githubusercontent.com/ionic-team/ionic/master/.github/PULL_REQUEST_TEMPLATE.md
    * https://raw.githubusercontent.com/appium/appium/master/.github/PULL_REQUEST_TEMPLATE.md
-->

## Proposed changes
Fixes apple and saml backends filling user_details with values containing `None`. This project [generally uses `''` instead of `None`](https://github.com/python-social-auth/social-core/blob/master/social_core/backends/base.py#L176). Most other backends use `''`.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Other information

Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
