### PR TITLE
Added PayPal OAuth backend support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased](https://github.com/python-social-auth/social-core/commits/master)
+
+### Added
+- PayPal backend
+
 ## [3.4.0](https://github.com/python-social-auth/social-core/releases/tag/3.4.0) - 2020-06-21
 
 ### Added

--- a/social_core/backends/paypal.py
+++ b/social_core/backends/paypal.py
@@ -34,7 +34,7 @@ class PayPalOAuth2(BaseOAuth2):
             response.get("family_name", ""),
         )
         emails = response.get("emails", [])
-        email = self._get_primary_email(emails)
+        email = self.get_email(emails)
         return {
             "username": username,
             "email": email,
@@ -57,9 +57,9 @@ class PayPalOAuth2(BaseOAuth2):
         return {"refresh_token": token, "grant_type": "refresh_token"}
 
     @staticmethod
-    def _get_primary_email(emails):
+    def get_email(emails):
         return (
-            next(filter(lambda e: e.get("primary"), emails), emails[0])
+            next(filter(lambda e: e.get("primary"), emails), emails[0]).get("value")
             if emails
             else ""
         )

--- a/social_core/backends/paypal.py
+++ b/social_core/backends/paypal.py
@@ -1,0 +1,74 @@
+import base64
+
+from .oauth import BaseOAuth2
+
+
+class PayPalOAuth2(BaseOAuth2):
+    """
+    PayPal OAuth2 backend, docs at:
+        https://developer.paypal.com/docs/connect-with-paypal/integrate/
+    """
+
+    name = "paypal-oauth2"
+    ID_KEY = "user_id"
+    AUTHORIZATION_URL = "https://www.paypal.com/connect"
+    ACCESS_TOKEN_URL = "https://api.paypal.com/v1/oauth2/token"
+    USER_DATA_URL = (
+        "https://api.paypal.com/v1/identity/oauth2/userinfo?schema=paypalv1.1"
+    )
+    DEFAULT_SCOPE = ["openid", "profile"]
+    ACCESS_TOKEN_METHOD = "POST"
+    REFRESH_TOKEN_METHOD = "POST"
+    REDIRECT_STATE = False
+
+    def user_data(self, access_token, *args, **kwargs):
+        auth_header = {"Authorization": "Bearer %s" % access_token}
+        response = self.get_json(self.USER_DATA_URL, headers=auth_header)
+        return response
+
+    def get_user_details(self, response):
+        username = response.get(self.ID_KEY).split("/")[-1]
+        fullname, first_name, last_name = self.get_user_names(
+            response.get("name", ""),
+            response.get("given_name", ""),
+            response.get("family_name", ""),
+        )
+        emails = response.get("emails", [])
+        email = self._get_primary_email(emails)
+        return {
+            "username": username,
+            "email": email,
+            "fullname": fullname,
+            "first_name": first_name,
+            "last_name": last_name,
+        }
+
+    def auth_complete_params(self, state=None):
+        return {
+            "grant_type": "authorization_code",
+            "code": self.data.get("code", ""),
+        }
+
+    def auth_headers(self):
+        auth = ("%s:%s" % self.get_key_and_secret()).encode()
+        return {"Authorization": b"Basic " + base64.urlsafe_b64encode(auth)}
+
+    def refresh_token_params(self, token, *args, **kwargs):
+        return {"refresh_token": token, "grant_type": "refresh_token"}
+
+    @staticmethod
+    def _get_primary_email(emails):
+        return (
+            next(filter(lambda e: e.get("primary"), emails), emails[0])
+            if emails
+            else ""
+        )
+
+
+class PayPalOAuth2Sandbox(PayPalOAuth2):
+    name = "paypal-oauth2-sandbox"
+    AUTHORIZATION_URL = "https://www.sandbox.paypal.com/connect"
+    ACCESS_TOKEN_URL = "https://api.sandbox.paypal.com/v1/oauth2/token"
+    USER_DATA_URL = (
+        "https://api.sandbox.paypal.com/v1/identity/oauth2/userinfo?schema=paypalv1.1"
+    )

--- a/social_core/backends/paypal.py
+++ b/social_core/backends/paypal.py
@@ -58,11 +58,11 @@ class PayPalOAuth2(BaseOAuth2):
 
     @staticmethod
     def get_email(emails):
-        return (
-            next(filter(lambda e: e.get("primary"), emails), emails[0]).get("value")
-            if emails
-            else ""
-        )
+        if not emails:
+            return ""
+        primary_emails = (email for email in emails if email.get("primary", False))
+        primary_or_first = next(primary_emails, emails[0])
+        return primary_or_first.get("value")
 
 
 class PayPalOAuth2Sandbox(PayPalOAuth2):

--- a/social_core/tests/backends/test_paypal.py
+++ b/social_core/tests/backends/test_paypal.py
@@ -58,8 +58,8 @@ class PayPalOAuth2Test(OAuth2Test):
 
     def test_get_email_no_emails(self):
         emails = []
-        primary_email = PayPalOAuth2.get_email(emails)
-        self.assertEqual(primary_email, "")
+        email = PayPalOAuth2.get_email(emails)
+        self.assertEqual(email, "")
 
     def test_get_email_multiple_emails(self):
         expected_email = "mail2@example.com"
@@ -67,8 +67,8 @@ class PayPalOAuth2Test(OAuth2Test):
             {"value": "mail1@example.com", "primary": False},
             {"value": expected_email, "primary": True},
         ]
-        primary_email = PayPalOAuth2.get_email(emails)
-        self.assertEqual(primary_email, expected_email)
+        email = PayPalOAuth2.get_email(emails)
+        self.assertEqual(email, expected_email)
 
     def test_get_email_multiple_emails_no_primary(self):
         expected_email = "mail1@example.com"
@@ -76,5 +76,5 @@ class PayPalOAuth2Test(OAuth2Test):
             {"value": expected_email, "primary": False},
             {"value": "mail2@example.com", "primary": False},
         ]
-        primary_email = PayPalOAuth2.get_email(emails)
-        self.assertEqual(primary_email, expected_email)
+        email = PayPalOAuth2.get_email(emails)
+        self.assertEqual(email, expected_email)

--- a/social_core/tests/backends/test_paypal.py
+++ b/social_core/tests/backends/test_paypal.py
@@ -1,6 +1,7 @@
 import json
 
 from .oauth import OAuth2Test
+from social_core.backends.paypal import PayPalOAuth2
 
 
 class PayPalOAuth2Test(OAuth2Test):
@@ -54,3 +55,26 @@ class PayPalOAuth2Test(OAuth2Test):
         user, social = self.do_refresh_token()
         self.assertEqual(user.username, self.expected_username)
         self.assertEqual(social.extra_data["access_token"], "foobar-new-token")
+
+    def test_get_email_no_emails(self):
+        emails = []
+        primary_email = PayPalOAuth2.get_email(emails)
+        self.assertEqual(primary_email, "")
+
+    def test_get_email_multiple_emails(self):
+        expected_email = "mail2@example.com"
+        emails = [
+            {"value": "mail1@example.com", "primary": False},
+            {"value": expected_email, "primary": True},
+        ]
+        primary_email = PayPalOAuth2.get_email(emails)
+        self.assertEqual(primary_email, expected_email)
+
+    def test_get_email_multiple_emails_no_primary(self):
+        expected_email = "mail1@example.com"
+        emails = [
+            {"value": expected_email, "primary": False},
+            {"value": "mail2@example.com", "primary": False},
+        ]
+        primary_email = PayPalOAuth2.get_email(emails)
+        self.assertEqual(primary_email, expected_email)

--- a/social_core/tests/backends/test_paypal.py
+++ b/social_core/tests/backends/test_paypal.py
@@ -1,0 +1,56 @@
+import json
+
+from .oauth import OAuth2Test
+
+
+class PayPalOAuth2Test(OAuth2Test):
+    backend_path = "social_core.backends.paypal.PayPalOAuth2"
+    user_data_url = (
+        "https://api.paypal.com/v1/identity/oauth2/userinfo?schema=paypalv1.1"
+    )
+    expected_username = "mWq6_1sU85v5EG9yHdPxJRrhGHrnMJ-1PQKtX6pcsmA"
+    access_token_body = json.dumps(
+        {
+            "token_type": "Bearer",
+            "expires_in": 28800,
+            "refresh_token": "foobar-refresh-token",
+            "access_token": "foobar-token",
+        }
+    )
+    user_data_body = json.dumps(
+        {
+            "user_id": "https://www.paypal.com/webapps/auth/identity/user/mWq6_1sU85v5EG9yHdPxJRrhGHrnMJ-1PQKtX6pcsmA",
+            "name": "identity test",
+            "given_name": "identity",
+            "family_name": "test",
+            "payer_id": "WDJJHEBZ4X2LY",
+            "address": {
+                "street_address": "1 Main St",
+                "locality": "San Jose",
+                "region": "CA",
+                "postal_code": "95131",
+                "country": "US",
+            },
+            "verified_account": True,
+            "emails": [{"value": "user1@example.com", "primary": True}],
+        }
+    )
+    refresh_token_body = json.dumps(
+        {
+            "access_token": "foobar-new-token",
+            "token_type": "Bearer",
+            "refresh_token": "foobar-new-refresh-token",
+            "expires_in": 28800,
+        }
+    )
+
+    def test_login(self):
+        self.do_login()
+
+    def test_partial_pipeline(self):
+        self.do_partial_pipeline()
+
+    def test_refresh_token(self):
+        user, social = self.do_refresh_token()
+        self.assertEqual(user.username, self.expected_username)
+        self.assertEqual(social.extra_data["access_token"], "foobar-new-token")


### PR DESCRIPTION
<!--
    Pull request template based on the following templates:
    * https://raw.githubusercontent.com/ionic-team/ionic/master/.github/PULL_REQUEST_TEMPLATE.md
    * https://raw.githubusercontent.com/appium/appium/master/.github/PULL_REQUEST_TEMPLATE.md
-->

## Proposed changes

Add PayPal and PayPal Sandbox backend support. Fixes https://github.com/python-social-auth/social-core/issues/329.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Other information

I tested integration with [social-app-django](https://github.com/python-social-auth/social-app-django). Even though I didn't find it strictly necessary, it is recommended adding the following to settings.py to exactly match PayPal's authorization URL.

Paypal backend
`SOCIAL_AUTH_PAYPAL_OAUTH2_AUTH_EXTRA_ARGUMENTS = {"flowEntry": "static"}`

PayPal Sandbox backend
`SOCIAL_AUTH_PAYPAL_OAUTH2_SANDBOX_AUTH_EXTRA_ARGUMENTS = {"flowEntry": "static"}`
