### PR TITLE
Remove discontinued GoogleOpenId backend

### DIFF
--- a/social_core/backends/google.py
+++ b/social_core/backends/google.py
@@ -169,16 +169,3 @@ class GoogleOAuth(BaseGoogleAuth, BaseOAuth1):
         if key_secret == (None, None):
             key_secret = ('anonymous', 'anonymous')
         return key_secret
-
-
-class GoogleOpenId(OpenIdAuth):
-    name = 'google'
-    URL = 'https://www.google.com/accounts/o8/id'
-
-    def get_user_id(self, details, response):
-        """
-        Return user unique id provided by service. For google user email
-        is unique enought to flag a single user. Email comes from schema:
-        http://axschema.org/contact/email
-        """
-        return details['email']

--- a/social_core/tests/backends/test_google.py
+++ b/social_core/tests/backends/test_google.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 import unittest2
 
@@ -10,7 +9,6 @@ from ...actions import do_disconnect
 
 from ..models import User
 from .oauth import OAuth1Test, OAuth2Test
-from .open_id import OpenIdTest
 from .open_id_connect import OpenIdConnectTestMixin
 
 
@@ -93,100 +91,6 @@ class GoogleOAuth1Test(OAuth1Test):
             'SOCIAL_AUTH_GOOGLE_OAUTH_SECRET': None
         })
         self.do_login()
-
-
-JANRAIN_NONCE = datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')
-
-
-class GoogleOpenIdTest(OpenIdTest):
-    backend_path = 'social_core.backends.google.GoogleOpenId'
-    expected_username = 'FooBar'
-    discovery_body = ''.join([
-        '<?xml version="1.0" encoding="UTF-8"?>',
-        '<xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)">',
-        '<XRD>',
-        '<Service priority="0">',
-        '<Type>http://specs.openid.net/auth/2.0/signon</Type>',
-        '<Type>http://openid.net/srv/ax/1.0</Type>',
-        '<Type>http://specs.openid.net/extensions/ui/1.0/mode/popup</Type>',
-        '<Type>http://specs.openid.net/extensions/ui/1.0/icon</Type>',
-        '<Type>http://specs.openid.net/extensions/pape/1.0</Type>',
-        '<URI>https://www.google.com/accounts/o8/ud</URI>',
-        '</Service>',
-        '<Service priority="10">',
-        '<Type>http://specs.openid.net/auth/2.0/signon</Type>',
-        '<Type>http://openid.net/srv/ax/1.0</Type>',
-        '<Type>http://specs.openid.net/extensions/ui/1.0/mode/popup</Type>',
-        '<Type>http://specs.openid.net/extensions/ui/1.0/icon</Type>',
-        '<Type>http://specs.openid.net/extensions/pape/1.0</Type>',
-        '<URI>https://www.google.com/accounts/o8/ud?source=mail</URI>',
-        '</Service>',
-        '<Service priority="10">',
-        '<Type>http://specs.openid.net/auth/2.0/signon</Type>',
-        '<Type>http://openid.net/srv/ax/1.0</Type>',
-        '<Type>http://specs.openid.net/extensions/ui/1.0/mode/popup</Type>',
-        '<Type>http://specs.openid.net/extensions/ui/1.0/icon</Type>',
-        '<Type>http://specs.openid.net/extensions/pape/1.0</Type>',
-        '<URI>https://www.google.com/accounts/o8/ud?source=gmail.com</URI>',
-        '</Service>',
-        '<Service priority="10">',
-        '<Type>http://specs.openid.net/auth/2.0/signon</Type>',
-        '<Type>http://openid.net/srv/ax/1.0</Type>',
-        '<Type>http://specs.openid.net/extensions/ui/1.0/mode/popup</Type>',
-        '<Type>http://specs.openid.net/extensions/ui/1.0/icon</Type>',
-        '<Type>http://specs.openid.net/extensions/pape/1.0</Type>',
-        '<URI>',
-        'https://www.google.com/accounts/o8/ud?source=googlemail.com',
-        '</URI>',
-        '</Service>',
-        '<Service priority="10">',
-        '<Type>http://specs.openid.net/auth/2.0/signon</Type>',
-        '<Type>http://openid.net/srv/ax/1.0</Type>',
-        '<Type>http://specs.openid.net/extensions/ui/1.0/mode/popup</Type>',
-        '<Type>http://specs.openid.net/extensions/ui/1.0/icon</Type>',
-        '<Type>http://specs.openid.net/extensions/pape/1.0</Type>',
-        '<URI>https://www.google.com/accounts/o8/ud?source=profiles</URI>',
-        '</Service>',
-        '</XRD>',
-        '</xrds:XRDS>'
-    ])
-    server_response = urlencode({
-        'janrain_nonce': JANRAIN_NONCE,
-        'openid.assoc_handle': 'assoc-handle',
-        'openid.claimed_id': 'https://www.google.com/accounts/o8/id?'
-                             'id=some-google-id',
-        'openid.ext1.mode': 'fetch_response',
-        'openid.ext1.type.email': 'http://axschema.org/contact/email',
-        'openid.ext1.type.first_name': 'http://axschema.org/namePerson/first',
-        'openid.ext1.type.last_name': 'http://axschema.org/namePerson/last',
-        'openid.ext1.type.old_email': 'http://schema.openid.net/contact/email',
-        'openid.ext1.value.email': 'foo@bar.com',
-        'openid.ext1.value.first_name': 'Foo',
-        'openid.ext1.value.last_name': 'Bar',
-        'openid.ext1.value.old_email': 'foo@bar.com',
-        'openid.identity': 'https://www.google.com/accounts/o8/id?'
-                           'id=some-google-id',
-        'openid.mode': 'id_res',
-        'openid.ns': 'http://specs.openid.net/auth/2.0',
-        'openid.ns.ext1': 'http://openid.net/srv/ax/1.0',
-        'openid.op_endpoint': 'https://www.google.com/accounts/o8/ud',
-        'openid.response_nonce': JANRAIN_NONCE + 'by95cT34vX7p9g',
-        'openid.return_to': 'http://myapp.com/complete/google/?'
-                            'janrain_nonce=' + JANRAIN_NONCE,
-        'openid.sig': 'brT2kmu3eCzb1gQ1pbaXdnWioVM=',
-        'openid.signed': 'op_endpoint,claimed_id,identity,return_to,'
-                         'response_nonce,assoc_handle,ns.ext1,ext1.mode,'
-                         'ext1.type.old_email,ext1.value.old_email,'
-                         'ext1.type.first_name,ext1.value.first_name,'
-                         'ext1.type.last_name,ext1.value.last_name,'
-                         'ext1.type.email,ext1.value.email'
-    })
-
-    def test_login(self):
-        self.do_login()
-
-    def test_partial_pipeline(self):
-        self.do_partial_pipeline()
 
 
 class GoogleRevokeTokenTest(GoogleOAuth2Test):


### PR DESCRIPTION
## Proposed changes

The Google OpenID backend was discontinued on the server side in 2015, in favor of OpenID Connect (our `GoogleOpenIdConnect` backend).

https://support.google.com/accounts/answer/6206245

Fixes #462. Fixes #472.

This is needed to get Travis passing again.

## Types of changes

Please check the type of change your PR introduces:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Other information

Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
