### PR TITLE
resolves #525 - Discord API endpoints migrating to discord.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- Updated Discord's API hostname from discordapp.com to discord.com
+
 ## [3.4.0](https://github.com/python-social-auth/social-core/releases/tag/3.4.0) - 2020-06-21
 
 ### Added

--- a/social_core/backends/discord.py
+++ b/social_core/backends/discord.py
@@ -1,16 +1,17 @@
 """
 Discord Auth OAuth2 backend, docs at:
-    https://discordapp.com/developers/docs/topics/oauth2
+    https://discord.com/developers/docs/topics/oauth2
 """
 from .oauth import BaseOAuth2
 
 
 class DiscordOAuth2(BaseOAuth2):
     name = 'discord'
-    AUTHORIZATION_URL = 'https://discordapp.com/api/oauth2/authorize'
-    ACCESS_TOKEN_URL = 'https://discordapp.com/api/oauth2/token'
+    HOSTNAME = 'discord.com'
+    AUTHORIZATION_URL = 'https://%s/api/oauth2/authorize' % HOSTNAME
+    ACCESS_TOKEN_URL = 'https://%s/api/oauth2/token' % HOSTNAME
     ACCESS_TOKEN_METHOD = 'POST'
-    REVOKE_TOKEN_URL = 'https://discordapp.com/api/oauth2/token/revoke'
+    REVOKE_TOKEN_URL = 'https://%s/api/oauth2/token/revoke' % HOSTNAME
     REVOKE_TOKEN_METHOD = 'GET'
     DEFAULT_SCOPE = ['identify']
     SCOPE_SEPARATOR = '+'
@@ -25,6 +26,6 @@ class DiscordOAuth2(BaseOAuth2):
                 'email': response.get('email') or ''}
 
     def user_data(self, access_token, *args, **kwargs):
-        url = 'https://discordapp.com/api/users/@me'
+        url = 'https://%s/api/users/@me' % self.HOSTNAME
         auth_header = {"Authorization": "Bearer %s" % access_token}
         return self.get_json(url, headers=auth_header)


### PR DESCRIPTION

## Proposed changes

Discord has announced that their API, including OAuth2 endpoints, have migrated to discord.com and that at some point support for the old discordapp.com will be discontinued.  This change updates social_core's Discord back end to point to the updated domain name.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [x] Other (please describe):

This is a configuration change, in anticipation of future breakage should Discord discontinue support for discordapp.com


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works


## Other information

I tested the update in a Django app that uses Discord OAuth2 for authentication: d20hex.herokuapp.com
