### PR TITLE
[Okta] Properly join configuration URLs

### DIFF
--- a/social_core/backends/okta.py
+++ b/social_core/backends/okta.py
@@ -24,7 +24,7 @@ class OktaMixin(object):
     def oidc_config(self):
         return self.get_json(
             self._url(
-                '/.well-known/openid-configuration?client_id={}'.format(
+                './.well-known/openid-configuration?client_id={}'.format(
                     self.setting('KEY')
                 )
             )


### PR DESCRIPTION
Closes #524.

## Proposed changes

This change ensures that the configuration endpoint `/.well-known/openid-configuration` is appended to the configured Okta API_URL rather than replacing the whole slug.

The current approach used to generate the URL Okta applications truncates the provided `API_URL` then appends `/.well-known/openid-configuration` to it. So for custom applications, `mycompany.okta.com/oauth2/<app-identifier>/.well-known/openid-configuration` is instead truncated to `mycompany.okta.com/.well-known/openid-configuration` which won't 404 but may provide incorrect information.

## Types of changes

Please check the type of change your PR introduces:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

Tests pass, but I couldn't find any lint config.

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

