### PR TITLE
Preventing installing v2.0.0 of PyJWT

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -2,5 +2,5 @@ requests>=2.9.1
 oauthlib>=1.0.3
 requests-oauthlib>=0.6.1
 six>=1.10.0
-PyJWT>=1.4.0
+PyJWT>=1.4.0,<2
 cryptography>=1.4


### PR DESCRIPTION
## Proposed changes

PyJWT 2.0.0 has a breaking change for the current release, pin to a version less than 2.0

```
File "/usr/local/lib/python3.6/site-packages/social_core/backends/azuread_tenant.py", line 6, in <module>
    from jwt import DecodeError, ExpiredSignature, decode as jwt_decode
ImportError: cannot import name 'ExpiredSignature'
```


## Types of changes

Please check the type of change your PR introduces:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

