### PR TITLE
Support PyJWT 2.0.0

### DIFF
--- a/social_core/backends/azuread.py
+++ b/social_core/backends/azuread.py
@@ -1,6 +1,6 @@
 import time
 
-from jwt import DecodeError, ExpiredSignature, decode as jwt_decode
+import jwt
 
 from ..exceptions import AuthTokenError
 from .oauth import BaseOAuth2
@@ -83,8 +83,8 @@ class AzureADOAuth2(BaseOAuth2):
             id_token = access_token
             
         try:
-            decoded_id_token = jwt_decode(id_token, verify=False)
-        except (DecodeError, ExpiredSignature) as de:
+            decoded_id_token = jwt_decode_no_verify(id_token)
+        except (jwt.DecodeError, jwt.ExpiredSignatureError) as de:
             raise AuthTokenError(self, de)
         return decoded_id_token
 
@@ -124,3 +124,14 @@ class AzureADOAuth2(BaseOAuth2):
             new_token_response = self.refresh_token(token=access_token)
             access_token = new_token_response['access_token']
         return access_token
+
+
+# PyJWT 2.0.0 changed the signature of jwt.decode
+# The semantics of argument `verify=False` are now specified by
+# setting 'verify_signature' to False in the `options` dictionary
+if jwt.__version__ < '2.0.0':
+    def jwt_decode_no_verify(token):
+        return jwt.decode(token, verify=False)
+else:
+    def jwt_decode_no_verify(token):
+        return jwt.decode(token, options={'verify_signature': False})

--- a/social_core/backends/azuread_b2c.py
+++ b/social_core/backends/azuread_b2c.py
@@ -31,7 +31,7 @@ import json
 import six
 
 from cryptography.hazmat.primitives import serialization
-from jwt import DecodeError, ExpiredSignature, decode as jwt_decode
+from jwt import DecodeError, ExpiredSignatureError, decode as jwt_decode
 from jwt.utils import base64url_decode
 
 
@@ -192,5 +192,5 @@ class AzureADB2COAuth2(AzureADOAuth2):
                 audience=self.setting('KEY'),
                 leeway=self.setting('JWT_LEEWAY', default=0),
             )
-        except (DecodeError, ExpiredSignature) as error:
+        except (DecodeError, ExpiredSignatureError) as error:
             raise AuthTokenError(self, error)

--- a/social_core/backends/azuread_tenant.py
+++ b/social_core/backends/azuread_tenant.py
@@ -3,7 +3,7 @@ import json
 
 from cryptography.x509 import load_pem_x509_certificate
 from cryptography.hazmat.backends import default_backend
-from jwt import DecodeError, ExpiredSignature, decode as jwt_decode
+from jwt import DecodeError, ExpiredSignatureError, decode as jwt_decode
 
 from ..exceptions import AuthTokenError
 from .azuread import AzureADOAuth2
@@ -114,5 +114,5 @@ class AzureADTenantOAuth2(AzureADOAuth2):
                 algorithms=algorithm,
                 audience=self.setting('KEY')
             )
-        except (DecodeError, ExpiredSignature) as error:
+        except (DecodeError, ExpiredSignatureError) as error:
             raise AuthTokenError(self, error)

--- a/social_core/tests/backends/test_azuread_b2c.py
+++ b/social_core/tests/backends/test_azuread_b2c.py
@@ -33,6 +33,15 @@ from jwt.algorithms import RSAAlgorithm
 from .oauth import OAuth2Test
 
 
+# PyJWT version 2.0.0 changed jwt.encode() from "-> bytes" to "-> str"
+def _encode(*args, **kw):
+    encoded = jwt.encode(*args, **kw)
+    if jwt.__version__ < '2.0.0':
+        return encoded.decode('utf-8')
+    else:
+        return encoded
+
+
 # Dummy private and private keys:
 RSA_PUBLIC_JWT_KEY = {
     # https://github.com/jpadilla/pyjwt/blob/06f461a/tests/keys/jwk_rsa_pub.json
@@ -78,7 +87,7 @@ class AzureADOAuth2Test(OAuth2Test):
     access_token_body = json.dumps({
         'access_token': 'foobar',
         'token_type': 'bearer',
-        'id_token': jwt.encode(
+        'id_token': _encode(
             key=RSAAlgorithm.from_jwk(json.dumps(RSA_PRIVATE_JWT_KEY)),
             headers={
                 'kid': RSA_PRIVATE_JWT_KEY['kid'],
@@ -103,7 +112,7 @@ class AzureADOAuth2Test(OAuth2Test):
                 'sub': '11223344-5566-7788-9999-aabbccddeeff',
                 'tfp': 'B2C_1_SignIn',
                 'ver': '1.0',
-        }).decode('ascii'),
+        }),
         'expires_in': EXPIRES_IN,
         'expires_on': EXPIRES_ON,
         'not_before': AUTH_TIME,

--- a/social_core/tests/backends/test_keycloak.py
+++ b/social_core/tests/backends/test_keycloak.py
@@ -89,7 +89,12 @@ def _encode(
     key=_PRIVATE_KEY,
     algorithm=_ALGORITHM
 ):
-    return jwt.encode(payload, key=key, algorithm=algorithm).decode('utf-8')
+    encoded = jwt.encode(payload, key=key, algorithm=algorithm)
+    if jwt.__version__ < '2.0.0':
+        return encoded.decode('utf-8')
+    else:
+        return encoded
+
 
 
 def _decode(


### PR DESCRIPTION
## Proposed changes

The release of PyJWT 2.0.0 last week included some backwards-incompatible changes.
This adapts some tests and the Azure backends to support the new release (while still supporting the older 1.7.1 version).

One suggestion to solve the problems was to pin PyJWT down to 1.7.1 (that is #532).
The issue was also discussed a little in #503.

## Types of changes

Please check the type of change your PR introduces:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

(The tests are failing before this PR. It fixes them)
(One test has been freezing for me locally; I thought it may have been an issue with my setup, but I've seen that it froze in CI as well. I skipped it locally, after verifying that it freezes the same way with either PyJWT 1.7.1 or 2.0.0. The skipping is done in 
3809cd1 which is part of the followup PR of tentative changes #537)

## Additional information

This PR is made on behalf of Matific -- https://www.matific.com -- https://github.com/SlateScience