### PR TITLE
use urllib.parse instead of six

### DIFF
--- a/social_core/actions.py
+++ b/social_core/actions.py
@@ -1,4 +1,4 @@
-from six.moves.urllib_parse import quote
+from urllib.parse import quote
 
 from .utils import sanitize_redirect, user_is_authenticated, \
                    user_is_active, partial_pipeline_data, setting_url

--- a/social_core/backends/coding.py
+++ b/social_core/backends/coding.py
@@ -1,7 +1,7 @@
 """
 Coding OAuth2 backend, docs at:
 """
-from six.moves.urllib.parse import urljoin
+from urllib.parse import urljoin
 
 from .oauth import BaseOAuth2
 

--- a/social_core/backends/deezer.py
+++ b/social_core/backends/deezer.py
@@ -3,7 +3,7 @@ Deezer backend, docs at:
     https://developers.deezer.com/api/oauth
     https://developers.deezer.com/api/permissions
 """
-from six.moves.urllib.parse import parse_qsl
+from urllib.parse import parse_qsl
 
 from .oauth import BaseOAuth2
 

--- a/social_core/backends/fence.py
+++ b/social_core/backends/fence.py
@@ -1,4 +1,4 @@
-from six.moves.urllib.parse import urljoin
+from urllib.parse import urljoin
 
 from social_core.utils import cache
 

--- a/social_core/backends/github.py
+++ b/social_core/backends/github.py
@@ -2,9 +2,9 @@
 Github OAuth2 backend, docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/github.html
 """
-from requests import HTTPError
+from urllib.parse import urljoin
 
-from six.moves.urllib.parse import urljoin
+from requests import HTTPError
 
 from .oauth import BaseOAuth2
 from ..exceptions import AuthFailed

--- a/social_core/backends/github_enterprise.py
+++ b/social_core/backends/github_enterprise.py
@@ -2,7 +2,7 @@
 Github Enterprise OAuth2 backend, docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/github_enterprise.html
 """
-from six.moves.urllib.parse import urljoin
+from urllib.parse import urljoin
 
 from ..utils import append_slash
 from .github import GithubOAuth2, GithubOrganizationOAuth2, \

--- a/social_core/backends/khanacademy.py
+++ b/social_core/backends/khanacademy.py
@@ -2,9 +2,9 @@
 Khan Academy OAuth backend, docs at:
     https://github.com/Khan/khan-api/wiki/Khan-Academy-API-Authentication
 """
-import six
+from urllib.parse import urlencode
 
-from six.moves.urllib_parse import urlencode
+import six
 
 from oauthlib.oauth1 import SIGNATURE_HMAC, SIGNATURE_TYPE_QUERY
 from requests_oauthlib import OAuth1

--- a/social_core/backends/livejournal.py
+++ b/social_core/backends/livejournal.py
@@ -2,7 +2,7 @@
 LiveJournal OpenId backend, docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/livejournal.html
 """
-from six.moves.urllib_parse import urlsplit
+from urllib.parse import urlsplit
 
 from .open_id import OpenIdAuth
 from ..exceptions import AuthMissingParameter

--- a/social_core/backends/mailru.py
+++ b/social_core/backends/mailru.py
@@ -3,8 +3,7 @@ Mail.ru OAuth2 backend, docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/mailru.html
 """
 from hashlib import md5
-
-from six.moves.urllib_parse import unquote
+from urllib.parse import unquote
 
 from .oauth import BaseOAuth2
 

--- a/social_core/backends/mediawiki.py
+++ b/social_core/backends/mediawiki.py
@@ -5,12 +5,12 @@ MediaWiki OAuth1 backend, docs at:
 
 import re
 import time
+from urllib.parse import parse_qs, urlencode, urlparse
+
 import six
 import requests
 import jwt
-
 from six import b
-from six.moves.urllib.parse import parse_qs, urlencode, urlparse
 from requests_oauthlib import OAuth1
 
 from .oauth import BaseOAuth1

--- a/social_core/backends/oauth.py
+++ b/social_core/backends/oauth.py
@@ -1,9 +1,8 @@
-import six
+from urllib.parse import urlencode, unquote
 
+import six
 from requests_oauthlib import OAuth1
 from oauthlib.oauth1 import SIGNATURE_TYPE_AUTH_HEADER
-
-from six.moves.urllib_parse import urlencode, unquote
 
 from ..utils import url_add_parameters, parse_qs, handle_http_errors, \
                     constant_time_compare

--- a/social_core/backends/odnoklassniki.py
+++ b/social_core/backends/odnoklassniki.py
@@ -3,8 +3,7 @@ Odnoklassniki OAuth2 and Iframe Application backends, docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/odnoklassnikiru.html
 """
 from hashlib import md5
-
-from six.moves.urllib_parse import unquote
+from urllib.parse import unquote
 
 from .base import BaseAuth
 from .oauth import BaseOAuth2

--- a/social_core/backends/okta.py
+++ b/social_core/backends/okta.py
@@ -2,7 +2,7 @@
 Okta OAuth2 and OpenIdConnect:
     https://python-social-auth.readthedocs.io/en/latest/backends/okta.html
 """
-from six.moves.urllib.parse import urljoin
+from urllib.parse import urljoin
 
 from ..utils import append_slash
 from .oauth import BaseOAuth2

--- a/social_core/backends/openshift.py
+++ b/social_core/backends/openshift.py
@@ -1,9 +1,9 @@
 """
 Openshift OAuth2 backend
 """
-import requests
+from urllib.parse import urljoin
 
-from six.moves.urllib.parse import urljoin
+import requests
 
 from ..utils import append_slash
 from .oauth import BaseOAuth2

--- a/social_core/backends/openstack.py
+++ b/social_core/backends/openstack.py
@@ -1,7 +1,7 @@
 """
 OpenStack OpenId backend
 """
-from six.moves.urllib_parse import urlsplit
+from urllib.parse import urlsplit
 from openid.extensions import ax
 
 from .open_id import OpenIdAuth

--- a/social_core/backends/openstackdev.py
+++ b/social_core/backends/openstackdev.py
@@ -1,7 +1,7 @@
 """
 OpenStack OpenId backend
 """
-from six.moves.urllib_parse import urlsplit
+from urllib.parse import urlsplit
 from openid.extensions import ax
 
 from .open_id import OpenIdAuth

--- a/social_core/backends/salesforce.py
+++ b/social_core/backends/salesforce.py
@@ -1,4 +1,4 @@
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 from .oauth import BaseOAuth2
 

--- a/social_core/backends/soundcloud.py
+++ b/social_core/backends/soundcloud.py
@@ -2,7 +2,7 @@
 Soundcloud OAuth2 backend, docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/soundcloud.html
 """
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 from .oauth import BaseOAuth2
 

--- a/social_core/backends/twilio.py
+++ b/social_core/backends/twilio.py
@@ -3,8 +3,7 @@ Twilio auth backend, docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/twilio.html
 """
 from re import sub
-
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 from .base import BaseAuth
 

--- a/social_core/backends/weixin.py
+++ b/social_core/backends/weixin.py
@@ -3,7 +3,7 @@
 """
 Weixin OAuth2 backend
 """
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 from requests import HTTPError
 
 from .oauth import BaseOAuth2

--- a/social_core/backends/yandex.py
+++ b/social_core/backends/yandex.py
@@ -6,7 +6,7 @@ openid.yandex.ru/user. Username is retrieved from the identity url.
 
 If username is not specified, OpenID 2.0 url used for authentication.
 """
-from six.moves.urllib_parse import urlsplit
+from urllib.parse import urlsplit
 
 from .open_id import OpenIdAuth
 from .oauth import BaseOAuth2

--- a/social_core/tests/actions/actions.py
+++ b/social_core/tests/actions/actions.py
@@ -1,10 +1,9 @@
 import json
 import requests
 import unittest2 as unittest
+from urllib.parse import urlparse
 
 from httpretty import HTTPretty
-
-from six.moves.urllib_parse import urlparse
 
 from ...utils import parse_qs, module_member
 from ...actions import do_auth, do_complete

--- a/social_core/tests/backends/oauth.py
+++ b/social_core/tests/backends/oauth.py
@@ -1,11 +1,9 @@
-import requests
+from urllib.parse import urlparse
 
+import requests
 from httpretty import HTTPretty
 
-from six.moves.urllib_parse import urlparse
-
 from ...utils import parse_qs, url_add_parameters
-
 from ..models import User
 from .base import BaseBackendTest
 

--- a/social_core/tests/backends/open_id.py
+++ b/social_core/tests/backends/open_id.py
@@ -1,17 +1,18 @@
 # -*- coding: utf-8 -*-
+import sys
+from html.parser import HTMLParser
+
+import requests
+from httpretty import HTTPretty
+from openid import oidutil
+
 from ...backends.utils import load_backends
 from ...utils import parse_qs, module_member
 from ..models import TestStorage, User, TestUserSocialAuth, \
     TestNonce, TestAssociation
 from ..strategy import TestStrategy
 from .base import BaseBackendTest
-import sys
 
-import requests
-
-from six.moves.html_parser import HTMLParser
-from openid import oidutil
-from httpretty import HTTPretty
 
 sys.path.insert(0, '..')
 

--- a/social_core/tests/backends/test_bitbucket.py
+++ b/social_core/tests/backends/test_bitbucket.py
@@ -1,8 +1,7 @@
 import json
+from urllib.parse import urlencode
 
 from httpretty import HTTPretty
-
-from six.moves.urllib_parse import urlencode
 
 from ...exceptions import AuthForbidden
 from .oauth import OAuth1Test, OAuth2Test

--- a/social_core/tests/backends/test_dropbox.py
+++ b/social_core/tests/backends/test_dropbox.py
@@ -1,6 +1,5 @@
 import json
-
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 from .oauth import OAuth1Test
 

--- a/social_core/tests/backends/test_evernote.py
+++ b/social_core/tests/backends/test_evernote.py
@@ -1,6 +1,6 @@
-from requests import HTTPError
+from urllib.parse import urlencode
 
-from six.moves.urllib_parse import urlencode
+from requests import HTTPError
 
 from ...exceptions import AuthCanceled
 from .oauth import OAuth1Test

--- a/social_core/tests/backends/test_fitbit.py
+++ b/social_core/tests/backends/test_fitbit.py
@@ -1,6 +1,5 @@
 import json
-
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 from .oauth import OAuth1Test
 

--- a/social_core/tests/backends/test_five_hundred_px.py
+++ b/social_core/tests/backends/test_five_hundred_px.py
@@ -1,6 +1,5 @@
 import json
-
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 from .oauth import OAuth1Test
 

--- a/social_core/tests/backends/test_flickr.py
+++ b/social_core/tests/backends/test_flickr.py
@@ -1,4 +1,4 @@
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 from .oauth import OAuth1Test
 

--- a/social_core/tests/backends/test_google.py
+++ b/social_core/tests/backends/test_google.py
@@ -1,8 +1,7 @@
 import json
+from urllib.parse import urlencode
 
 from httpretty import HTTPretty
-
-from six.moves.urllib_parse import urlencode
 
 from ...actions import do_disconnect
 

--- a/social_core/tests/backends/test_khanacademy.py
+++ b/social_core/tests/backends/test_khanacademy.py
@@ -1,6 +1,5 @@
 import json
-
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 
 from .oauth import OAuth1Test

--- a/social_core/tests/backends/test_livejournal.py
+++ b/social_core/tests/backends/test_livejournal.py
@@ -1,8 +1,7 @@
 import datetime
+from urllib.parse import urlencode
 
 from httpretty import HTTPretty
-
-from six.moves.urllib_parse import urlencode
 
 from ...exceptions import AuthMissingParameter
 

--- a/social_core/tests/backends/test_ngpvan.py
+++ b/social_core/tests/backends/test_ngpvan.py
@@ -1,9 +1,8 @@
 """Tests for NGP VAN ActionID Backend"""
 import datetime
+from urllib.parse import urlencode
 
 from httpretty import HTTPretty
-
-from six.moves.urllib_parse import urlencode
 
 from .open_id import OpenIdTest
 

--- a/social_core/tests/backends/test_readability.py
+++ b/social_core/tests/backends/test_readability.py
@@ -1,6 +1,5 @@
 import json
-
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 from .oauth import OAuth1Test
 

--- a/social_core/tests/backends/test_saml.py
+++ b/social_core/tests/backends/test_saml.py
@@ -1,19 +1,19 @@
-import re
+
 import json
+import os
+import re
 import sys
 import unittest2
-import requests
-import os
 from os import path
+from urllib.parse import urlparse, urlunparse, urlencode, parse_qs
 
+import requests
 
 try:
     from unittest.mock import patch
 except ImportError:
     from mock import patch
 from httpretty import HTTPretty
-
-from six.moves.urllib_parse import urlparse, urlunparse, urlencode, parse_qs
 
 try:
     from onelogin.saml2.utils import OneLogin_Saml2_Utils

--- a/social_core/tests/backends/test_skyrock.py
+++ b/social_core/tests/backends/test_skyrock.py
@@ -1,6 +1,5 @@
 import json
-
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 from .oauth import OAuth1Test
 

--- a/social_core/tests/backends/test_stackoverflow.py
+++ b/social_core/tests/backends/test_stackoverflow.py
@@ -1,6 +1,5 @@
 import json
-
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 from .oauth import OAuth2Test
 

--- a/social_core/tests/backends/test_steam.py
+++ b/social_core/tests/backends/test_steam.py
@@ -1,9 +1,8 @@
-import json
 import datetime
+import json
+from urllib.parse import urlencode
 
 from httpretty import HTTPretty
-
-from six.moves.urllib_parse import urlencode
 
 from ...exceptions import AuthFailed
 

--- a/social_core/tests/backends/test_thisismyjam.py
+++ b/social_core/tests/backends/test_thisismyjam.py
@@ -1,6 +1,5 @@
 import json
-
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 from .oauth import OAuth1Test
 

--- a/social_core/tests/backends/test_tripit.py
+++ b/social_core/tests/backends/test_tripit.py
@@ -1,6 +1,5 @@
 import json
-
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 from .oauth import OAuth1Test
 

--- a/social_core/tests/backends/test_tumblr.py
+++ b/social_core/tests/backends/test_tumblr.py
@@ -1,6 +1,5 @@
 import json
-
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 from .oauth import OAuth1Test
 

--- a/social_core/tests/backends/test_twitter.py
+++ b/social_core/tests/backends/test_twitter.py
@@ -1,6 +1,5 @@
 import json
-
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 from .oauth import OAuth1Test
 

--- a/social_core/tests/backends/test_udata.py
+++ b/social_core/tests/backends/test_udata.py
@@ -1,6 +1,5 @@
 import json
-
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 from .oauth import OAuth2Test
 

--- a/social_core/tests/backends/test_upwork.py
+++ b/social_core/tests/backends/test_upwork.py
@@ -1,6 +1,5 @@
 import json
-
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 from .oauth import OAuth1Test
 

--- a/social_core/tests/backends/test_xing.py
+++ b/social_core/tests/backends/test_xing.py
@@ -1,6 +1,5 @@
 import json
-
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 from .oauth import OAuth1Test
 

--- a/social_core/tests/backends/test_yahoo.py
+++ b/social_core/tests/backends/test_yahoo.py
@@ -1,8 +1,8 @@
 import json
+from urllib.parse import urlencode
+
 import requests
 from httpretty import HTTPretty
-
-from six.moves.urllib_parse import urlencode
 
 from .oauth import OAuth1Test
 

--- a/social_core/tests/backends/test_zotero.py
+++ b/social_core/tests/backends/test_zotero.py
@@ -1,4 +1,4 @@
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 from .oauth import OAuth1Test
 

--- a/social_core/utils.py
+++ b/social_core/utils.py
@@ -5,13 +5,12 @@ import unicodedata
 import functools
 import hmac
 import logging
+from urllib.parse import urlparse, urlunparse, urlencode, \
+                                   parse_qs as battery_parse_qs
 
 import six
 import requests
 import social_core
-
-from six.moves.urllib_parse import urlparse, urlunparse, urlencode, \
-                                   parse_qs as battery_parse_qs
 
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.poolmanager import PoolManager


### PR DESCRIPTION
## Proposed changes

As Python 2 is not maintained anymore, social-core needs to drop Python 2 support. This PR will change social-core to use urllib instead of six, then eventually make it possible to drop six as dependency.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Other information

Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
