### PR TITLE
Amends to social_core.backends.orcid.py

### DIFF
--- a/social_core/backends/orcid.py
+++ b/social_core/backends/orcid.py
@@ -26,14 +26,15 @@ class ORCIDOAuth2(BaseOAuth2):
 
     def get_user_details(self, response):
         """Return user details from ORCID account"""
-        orcid_identifier = response.get('orcid-identifier', None)
+        orcid_identifier = response.get('orcid-identifier')
 
         fullname = response.get('name', '')
 
-        first_name = last_name = email = ''
+        first_name = last_name = email = username = ''
 
-        person = response.get('person', None)
+        person = response.get('person')
 
+        # Although we're checking here, the response will always have the orcid-identifier key:
         if orcid_identifier:
             username = orcid_identifier['path']
 

--- a/social_core/backends/orcid.py
+++ b/social_core/backends/orcid.py
@@ -26,11 +26,39 @@ class ORCIDOAuth2(BaseOAuth2):
 
     def get_user_details(self, response):
         """Return user details from ORCID account"""
+
+        # response data will be of the following format:
+        # {
+        #     'orcid-identifier': {
+        #         'uri': 'http://orcid.org/0000-0002-2601-8132',
+        #         'path': '0000-0002-2601-8132',
+        #         'host': 'orcid.org'
+        #     },
+        #     'person': {
+        #         'last-modified-date': None,
+        #         'name': {
+        #             'created-date': {
+        #                 'value': 1578249746904
+        #             },
+        #             'last-modified-date': {
+        #                 'value': 1578249746904
+        #             },
+        #             'given-names': {
+        #                 'value': 'Janani Kantharooban'
+        #             },
+        #             'family-name': {
+        #                 'value': 'Umachanger'
+        #             },
+        #             'credit-name': None,
+        #             'source': None,
+        #             'visibility': 'PUBLIC',
+        #             'path': '0000-0002-2601-8132'
+        #         },
+        #     }
+        # }
         orcid_identifier = response.get('orcid-identifier')
 
-        fullname = response.get('name', '')
-
-        first_name = last_name = email = username = ''
+        fullname = first_name = last_name = email = username = ''
 
         person = response.get('person')
 
@@ -40,6 +68,9 @@ class ORCIDOAuth2(BaseOAuth2):
 
         if person:
             name = person.get('name')
+
+            fullname = name
+
             if name:
                 first_name = name.get('given-names', {}).get('value', '')
                 last_name = name.get('family-name', {}).get('value', '')
@@ -94,6 +125,7 @@ class ORCIDOAuth2(BaseOAuth2):
         except Exception as ex:
             pass
 
+        # We can now attempt to access the ORCID public API with the Orcid:
         try:
             return self.get_json(
                     self.USER_DATA_URL.format(orcid),

--- a/social_core/backends/orcid.py
+++ b/social_core/backends/orcid.py
@@ -80,16 +80,19 @@ class ORCIDOAuth2(BaseOAuth2):
         #     "family_name":"Jones",
         #     "given_name":"Tom"
         # }
-        response = self.get_json(
-            self.USER_ID_URL,
-            headers={
-                'Content-Type': 'application/json',
-                'Authorization': 'Bearer {}'.format(str(access_token))
-            },
-        )
+        try:
+            response = self.get_json(
+                self.USER_ID_URL,
+                headers={
+                    'Content-Type': 'application/json',
+                    'Authorization': 'Bearer {}'.format(str(access_token))
+                },
+            )
 
-        # Update Jan 28 2021: Now we definitely have an ORCID id of format "0000-0000-0000-0000"
-        orcid = response['sub']
+            # Update Jan 28 2021: Now we definitely have an ORCID id of format "0000-0000-0000-0000"
+            orcid = response['sub']
+        except Exception as ex:
+            pass
 
         try:
             return self.get_json(

--- a/social_core/tests/backends/test_orcid.py
+++ b/social_core/tests/backends/test_orcid.py
@@ -6,16 +6,17 @@ from social_core.backends.orcid import ORCIDOAuth2
 
 class ORCIDOAuth2Test(OAuth2Test):
     backend_path = 'social_core.backends.orcid.ORCIDOAuth2'
-    user_data_url = 'https://login.orbi.kr/oauth/user/get'
-    expected_username = 'foobar'
+    user_data_url = 'https://orcid.org/oauth/userinfo'
+    expected_username = '0000-0002-2601-8132'
     access_token_body = json.dumps({
         'access_token': 'foobar',
+        'token_type': 'bearer'
     })
     user_data_body = json.dumps({
-        'sub': '0000-0002-2601-8132',
-        'name': 'Credit Name',
-        'family_name': 'Jones',
-        'given_name': 'Tom'
+        "sub":"0000-0002-2601-8132",
+        "name":"Credit Name",
+        "family_name":"Jones",
+        "given_name":"Tom"
     })
 
     def test_login(self):

--- a/social_core/tests/backends/test_orcid.py
+++ b/social_core/tests/backends/test_orcid.py
@@ -1,0 +1,25 @@
+import json
+
+from .oauth import OAuth2Test
+
+from social_core.backends.orcid import ORCIDOAuth2
+
+class ORCIDOAuth2Test(OAuth2Test):
+    backend_path = 'social_core.backends.orcid.ORCIDOAuth2'
+    user_data_url = 'https://login.orbi.kr/oauth/user/get'
+    expected_username = 'foobar'
+    access_token_body = json.dumps({
+        'access_token': 'foobar',
+    })
+    user_data_body = json.dumps({
+        "sub":"0000-0002-2601-8132",
+        "name":"Credit Name",
+        "family_name":"Jones",
+        "given_name":"Tom"
+    })
+
+    def test_login(self):
+        self.do_login()
+
+    def test_partial_pipeline(self):
+        self.do_partial_pipeline()

--- a/social_core/tests/backends/test_orcid.py
+++ b/social_core/tests/backends/test_orcid.py
@@ -6,17 +6,74 @@ from social_core.backends.orcid import ORCIDOAuth2
 
 class ORCIDOAuth2Test(OAuth2Test):
     backend_path = 'social_core.backends.orcid.ORCIDOAuth2'
-    user_data_url = 'https://orcid.org/oauth/userinfo'
+    user_data_url = ORCIDOAuth2.USER_ID_URL
     expected_username = '0000-0002-2601-8132'
     access_token_body = json.dumps({
         'access_token': 'foobar',
-        'token_type': 'bearer'
+        'token_type': 'bearer',
+        'orcid-identifier': {
+            'path': '0000-0002-2601-8132'
+        },
     })
     user_data_body = json.dumps({
-        "sub":"0000-0002-2601-8132",
-        "name":"Credit Name",
-        "family_name":"Jones",
-        "given_name":"Tom"
+        'orcid-identifier': {
+            'uri': 'http://orcid.org/0000-0002-2601-8132',
+            'path': '0000-0002-2601-8132',
+            'host': 'orcid.org'
+        },
+        'person': {
+            'last-modified-date': None,
+            'name': {
+                'created-date': {
+                    'value': 1578249746904
+                },
+                'last-modified-date': {
+                    'value': 1578249746904
+                },
+                'given-names': {
+                    'value': 'Janani Kantharooban'
+                },
+                'family-name': {
+                    'value': 'Umachanger'
+                },
+                'credit-name': None,
+                'source': None,
+                'visibility': 'PUBLIC',
+                'path': '0000-0002-2601-8132'
+            },
+            'other-names': {
+                'last-modified-date': None,
+                'other-name': [],
+                'path': '/0000-0002-2601-8132/other-names'
+            },
+            'biography': None,
+            'researcher-urls': {
+                'last-modified-date': None,
+                'researcher-url': [],
+                'path': '/0000-0002-2601-8132/researcher-urls'
+            },
+            'emails': {
+                'last-modified-date': None,
+                'email': [],
+                'path': '/0000-0002-2601-8132/email'
+            },
+            'addresses': {
+                'last-modified-date': None,
+                'address': [],
+                'path': '/0000-0002-2601-8132/address'
+            },
+            'keywords': {
+                'last-modified-date': None,
+                'keyword': [],
+                'path': '/0000-0002-2601-8132/keywords'
+            },
+            'external-identifiers': {
+                'last-modified-date': None,
+                'external-identifier': [],
+                'path': '/0000-0002-2601-8132/external-identifiers'
+            },
+            'path': '/0000-0002-2601-8132/person'
+        }
     })
 
     def test_login(self):

--- a/social_core/tests/backends/test_orcid.py
+++ b/social_core/tests/backends/test_orcid.py
@@ -12,10 +12,10 @@ class ORCIDOAuth2Test(OAuth2Test):
         'access_token': 'foobar',
     })
     user_data_body = json.dumps({
-        "sub":"0000-0002-2601-8132",
-        "name":"Credit Name",
-        "family_name":"Jones",
-        "given_name":"Tom"
+        'sub': '0000-0002-2601-8132',
+        'name': 'Credit Name',
+        'family_name': 'Jones',
+        'given_name': 'Tom'
     })
 
     def test_login(self):


### PR DESCRIPTION
## Proposed changes

Added a new USER_DATA_ID attribute for the ORCIDOAuth2 and ORCIDMemberOAuth2 classes (and their associated sandbox modes).

Alterations made to self.user_data() call to pass the access_token as a Bearer token to that endpoint. Reference: [https://github.com/ORCID/ORCID-Source/blob/master/orcid-web/ORCID_AUTH_WITH_OPENID_CONNECT.md#other-endpoints] for more details.

Alterations made to the get_user_details() as the orcid parameter is now longer accessible at response['orcid'] instead it is at response['orcid-identifier']['path'].

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
