### PR TITLE
BUGFIX: Slack backend user_data should provide access_token in bearer…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Several improvements to the ORCIDOAuth2 backend
 - Make WHITELIST_\* settings properly case insensitive
 - Fixed token validation in the AzureADV2TenantOAuth2 backend
+- Fixed Slack user identity API call with Bearer headers
 
 ## [4.0.3](https://github.com/python-social-auth/social-core/releases/tag/4.0.3) - 2021-01-12
 

--- a/social_core/backends/slack.py
+++ b/social_core/backends/slack.py
@@ -55,7 +55,7 @@ class SlackOAuth2(BaseOAuth2):
     def user_data(self, access_token, *args, **kwargs):
         """Loads user data from service"""
         response = self.get_json('https://slack.com/api/users.identity',
-                                 params={'token': access_token})
+                                 headers={'Authorization': 'Bearer %s' % access_token})
         if not response.get('id', None):
             response['id'] = response['user']['id']
         return response


### PR DESCRIPTION
Slack user identity API requires access token to be provided in Bearer headers.
https://api.slack.com/methods/users.identity#arg_token

bug as described here: https://github.com/python-social-auth/social-core/issues/570