### PR TITLE
Add refresh_token to EXTRA_DATA

### DIFF
--- a/social_core/backends/arcgis.py
+++ b/social_core/backends/arcgis.py
@@ -11,7 +11,8 @@ class ArcGISOAuth2(BaseOAuth2):
     ACCESS_TOKEN_URL = 'https://www.arcgis.com/sharing/rest/oauth2/token'
     ACCESS_TOKEN_METHOD = 'POST'
     EXTRA_DATA = [
-        ('expires_in', 'expires_in')
+        ('expires_in', 'expires_in'),
+        ('refresh_token', 'refresh_token')
     ]
 
     def get_user_details(self, response):


### PR DESCRIPTION
The ArcGIS Rest API for OAuth supports using the refresh_token, so it should be included in EXTRA_DATA by default. See https://developers.arcgis.com/rest/users-groups-and-items/token.htm
