### PR TITLE
Set a JWT signature algorithm for the Globus backend to RS512

### DIFF
--- a/social_core/backends/globus.py
+++ b/social_core/backends/globus.py
@@ -10,6 +10,7 @@ from social_core.backends.open_id_connect import OpenIdConnectAuth
 class GlobusOpenIdConnect(OpenIdConnectAuth):
     name = 'globus'
     OIDC_ENDPOINT = 'https://auth.globus.org'
+    JWT_ALGORITHMS = ['RS256', 'RS512']
     EXTRA_DATA = [
         ('expires_in', 'expires_in', True),
         ('refresh_token', 'refresh_token', True),


### PR DESCRIPTION
When `JWT_ALGORITHMS = [RS256]` was hard coded in [backends/open_id_connect.py](https://github.com/python-social-auth/social-core/blob/master/social_core/backends/open_id_connect.py), web apps with the Globus backend started throwing `social_core.exceptions.AuthTokenError: Token error: Invalid signature`. This PR overwrites JWT_ALGORITHMS in the Globus backend.