### PR TITLE
Map is_staff, is_active and is_superuser into the user details

### DIFF
--- a/social_core/backends/keycloak.py
+++ b/social_core/backends/keycloak.py
@@ -131,6 +131,9 @@ class KeycloakOAuth2(BaseOAuth2):  # pylint: disable=abstract-method
             'fullname': response.get('name'),
             'first_name': response.get('given_name'),
             'last_name': response.get('family_name'),
+            'is_staff': response.get('is_staff'),
+            'is_active': response.get('is_active'),
+            'is_superuser': response.get('is_superuser')
         }
 
     def get_user_id(self, details, response):


### PR DESCRIPTION
## Proposed changes

I want to allow attributes on the identity - to map to user attributes.
Specifically the default protected keys `is_staff`, `is_active` and `is_superuser`.

Reasoning is that sometimes you want to be default give a user staff permissions.
It is blocked by default anywhere with the protected attributes - so mapping those values in will be superfluous in many cases.

```
protected = ('username', 'id', 'pk', 'email', 'password',
                     'is_active', 'is_staff', 'is_superuser',)
```

I understand that this could be a custom pipeline - however these are specifically user attributes. 

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Other information

I am happy to add the unit tests but could @omab @aleksihakli please give some guidance...if you would rather this be solved with a custom pipeline by developers instead of adding it to the backend.