### PR TITLE
IMMUTABLE_USER_FIELDS: Add a setting for immutable user fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased](https://github.com/python-social-auth/social-core/)
 
 ### Added
-
+- Add fields that populate on create but not update `SOCIAL_AUTH_IMMUTABLE_USER_FIELDS`
 
 ### Changed
 - Fixed Slack user identity API call with Bearer headers
@@ -73,7 +73,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Directly use `access_token` in Azure Tenant backend
-- Support Apple JWT audience 
+- Support Apple JWT audience
 - Update partial session cleanup to remove old token from session too
 - Fetch user email in Okta integration
 - Improve Python 3.9 compatibility

--- a/social_core/pipeline/user.py
+++ b/social_core/pipeline/user.py
@@ -112,6 +112,10 @@ def user_details(strategy, details, backend, user=None, *args, **kwargs):
         if current_value == value:
             continue
 
+        immutable_fields = tuple(strategy.setting('IMMUTABLE_USER_FIELDS', []))
+        if name in immutable_fields and current_value:
+            continue
+
         changed = True
         setattr(user, name, value)
 

--- a/social_core/tests/models.py
+++ b/social_core/tests/models.py
@@ -28,6 +28,7 @@ class User(BaseModel):
         self.id = User.next_id()
         self.username = username
         self.email = email
+        self.first_name = None
         self.password = None
         self.slug = None
         self.social = []

--- a/social_core/tests/test_pipeline.py
+++ b/social_core/tests/test_pipeline.py
@@ -1,5 +1,6 @@
 import json
 
+from ..pipeline.user import user_details
 from ..utils import PARTIAL_TOKEN_SESSION_NAME
 from ..exceptions import AuthException
 
@@ -230,3 +231,35 @@ class UserPersistsInPartialPipeline(BaseActionTest):
         token = self.strategy.session_pop(PARTIAL_TOKEN_SESSION_NAME)
         partial = self.strategy.partial_load(token)
         self.backend.continue_pipeline(partial)
+
+
+
+class TestUserDetails(BaseActionTest):
+
+    def test_user_details(self):
+        self.strategy.set_settings({})
+        details = {'first_name': 'Test'}
+        user = User(username='foobar')
+        backend = None
+        user_details(self.strategy, details, backend, user)
+        self.assertEqual(user.first_name, 'Test')
+
+        # Also test mutation
+        details = {'first_name': 'Test2'}
+        user_details(self.strategy, details, backend, user)
+        self.assertEqual(user.first_name, 'Test2')
+
+    def test_user_details_(self):
+        self.strategy.set_settings({
+            'SOCIAL_AUTH_IMMUTABLE_USER_FIELDS': ('first_name',)
+        })
+        details = {'first_name': 'Test'}
+        user = User(username='foobar')
+        backend = None
+        user_details(self.strategy, details, backend, user)
+        self.assertEqual(user.first_name, 'Test')
+
+        # Also test mutation does not change field
+        details = {'first_name': 'Test2'}
+        user_details(self.strategy, details, backend, user)
+        self.assertEqual(user.first_name, 'Test')


### PR DESCRIPTION
## Proposed changes

The behavior and documentation for `PROTECTED_USER_FIELDS` used to imply that the fields would be set on user create but then be immutable afterwards. Both the behavior and later the documentation has since changed https://github.com/python-social-auth/social-core/commit/8aab8099a2345ccf7deaa358da3d45e1af9ef8f7 to always protect userfields. However that change has created some confusion (see related Stackoverflow and GIthub issues)

In many cases, you want the initial field for a user but then not to overwite it later on. An example might be a user who logs in as Jonathan from their Gmail but then later updates their nick to Jon for our service.

This change introduces a setting called `IMMUTABLE_USER_FIELDS` which is a peer of `PROTECTED_USER_FIELDS` but allows initial setting of the field.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

