### PR TITLE
add gitea as an oauth2 backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Add fields that populate on create but not update `SOCIAL_AUTH_IMMUTABLE_USER_FIELDS`
+- Add Gitea oauth2 backend
 
 ### Changed
 - Fixed Slack user identity API call with Bearer headers

--- a/social_core/backends/gitea.py
+++ b/social_core/backends/gitea.py
@@ -1,0 +1,51 @@
+"""
+Gitea OAuth2 backend, docs at:
+    https://python-social-auth.readthedocs.io/en/latest/backends/gitea.html
+"""
+from .oauth import BaseOAuth2
+
+
+class GiteaOAuth2   (BaseOAuth2):
+    """Github OAuth authentication backend"""
+
+    name = 'gitea'
+    API_URL = 'https://gitea.com'
+    AUTHORIZATION_URL = 'https://gitea.com/login/oauth/authorize'
+    ACCESS_TOKEN_URL = 'https://gitea.com/login/oauth/access_token'
+    ACCESS_TOKEN_METHOD = 'POST'
+    SCOPE_SEPARATOR = ','
+    REDIRECT_STATE = False
+    STATE_PARAMETER = True
+    EXTRA_DATA = [
+        ('id', 'id'),
+        ('expires_in', 'expires'),
+        ('refresh_token', 'refresh_token')
+    ]
+
+    def api_url(self, path):
+        api_url = self.setting('API_URL') or self.API_URL
+        return '{0}{1}'.format(api_url.rstrip('/'), path)
+
+    def authorization_url(self):
+        return self.api_url('/login/oauth/authorize')
+
+    def access_token_url(self):
+        return self.api_url('/login/oauth/access_token')
+
+    def get_user_details(self, response):
+        """Return user details from Gitea account"""
+        fullname, first_name, last_name = self.get_user_names(
+            response.get('fullname')
+        )
+        return {'username': response.get('login'),
+                'email': response.get('email') or '',
+                'fullname': fullname,
+                'first_name': first_name,
+                'last_name': last_name}
+
+    def user_data(self, access_token, *args, **kwargs):
+        """Loads user data from service"""
+        return self.get_json(self.api_url('/api/v1/user'), params={
+            'access_token': access_token
+        })
+

--- a/social_core/backends/gitea.py
+++ b/social_core/backends/gitea.py
@@ -6,7 +6,7 @@ from .oauth import BaseOAuth2
 
 
 class GiteaOAuth2   (BaseOAuth2):
-    """Github OAuth authentication backend"""
+    """Gitea OAuth authentication backend"""
 
     name = 'gitea'
     API_URL = 'https://gitea.com'

--- a/social_core/tests/backends/test_gitea.py
+++ b/social_core/tests/backends/test_gitea.py
@@ -1,0 +1,71 @@
+import json
+
+from .oauth import OAuth2Test
+
+
+class GiteaOAuth2Test(OAuth2Test):
+    backend_path = 'social_core.backends.gitea.GiteaOAuth2'
+    user_data_url = 'https://gitea.com/api/v1/user'
+    expected_username = 'foobar'
+    access_token_body = json.dumps({
+        'access_token': 'foobar',
+        'token_type': 'bearer',
+        'expires_in': 7200,
+        'refresh_token': 'barfoo'
+    })
+    user_data_body = json.dumps({
+        "id": 123456,
+        "login": "foobar",
+        "full_name": "Foo Bar",
+        "email": "foobar@example.com",
+        "avatar_url": "https://gitea.com/user/avatar/foobar/-1",
+        "language": "en-US",
+        "is_admin": False,
+        "last_login": "2016-12-28T12:26:19+01:00",
+        "created": "2016-12-28T12:26:19+01:00",
+        "restricted": False,
+        "username": "foobar"
+    })
+
+    def test_login(self):
+        self.do_login()
+
+    def test_partial_pipeline(self):
+        self.do_partial_pipeline()
+
+
+class GiteaCustomDomainOAuth2Test(OAuth2Test):
+    backend_path = 'social_core.backends.gitea.GiteaOAuth2'
+    user_data_url = 'https://example.com/api/v1/user'
+    expected_username = 'foobar'
+    access_token_body = json.dumps({
+        'access_token': 'foobar',
+        'token_type': 'bearer',
+        'expires_in': 7200,
+        'refresh_token': 'barfoo'
+    })
+    user_data_body = json.dumps({
+        "id": 123456,
+        "login": "foobar",
+        "full_name": "Foo Bar",
+        "email": "foobar@example.com",
+        "avatar_url": "https://example.com/user/avatar/foobar/-1",
+        "language": "en-US",
+        "is_admin": False,
+        "last_login": "2016-12-28T12:26:19+01:00",
+        "created": "2016-12-28T12:26:19+01:00",
+        "restricted": False,
+        "username": "foobar"
+    })
+
+    def test_login(self):
+        self.strategy.set_settings({
+            'SOCIAL_AUTH_GITEA_API_URL': 'https://example.com'
+        })
+        self.do_login()
+
+    def test_partial_pipeline(self):
+        self.strategy.set_settings({
+            'SOCIAL_AUTH_GITEA_API_URL': 'https://example.com'
+        })
+        self.do_partial_pipeline()

--- a/social_core/tests/backends/test_gitea.py
+++ b/social_core/tests/backends/test_gitea.py
@@ -14,17 +14,17 @@ class GiteaOAuth2Test(OAuth2Test):
         'refresh_token': 'barfoo'
     })
     user_data_body = json.dumps({
-        "id": 123456,
-        "login": "foobar",
-        "full_name": "Foo Bar",
-        "email": "foobar@example.com",
-        "avatar_url": "https://gitea.com/user/avatar/foobar/-1",
-        "language": "en-US",
-        "is_admin": False,
-        "last_login": "2016-12-28T12:26:19+01:00",
-        "created": "2016-12-28T12:26:19+01:00",
-        "restricted": False,
-        "username": "foobar"
+        'id': 123456,
+        'login': 'foobar',
+        'full_name': 'Foo Bar',
+        'email': 'foobar@example.com',
+        'avatar_url': 'https://gitea.com/user/avatar/foobar/-1',
+        'language': 'en-US',
+        'is_admin': False,
+        'last_login': '2016-12-28T12:26:19+01:00',
+        'created': '2016-12-28T12:26:19+01:00',
+        'restricted': False,
+        'username': 'foobar'
     })
 
     def test_login(self):
@@ -45,17 +45,17 @@ class GiteaCustomDomainOAuth2Test(OAuth2Test):
         'refresh_token': 'barfoo'
     })
     user_data_body = json.dumps({
-        "id": 123456,
-        "login": "foobar",
-        "full_name": "Foo Bar",
-        "email": "foobar@example.com",
-        "avatar_url": "https://example.com/user/avatar/foobar/-1",
-        "language": "en-US",
-        "is_admin": False,
-        "last_login": "2016-12-28T12:26:19+01:00",
-        "created": "2016-12-28T12:26:19+01:00",
-        "restricted": False,
-        "username": "foobar"
+        'id': 123456,
+        'login': 'foobar',
+        'full_name': 'Foo Bar',
+        'email': 'foobar@example.com',
+        'avatar_url': 'https://example.com/user/avatar/foobar/-1',
+        'language': 'en-US',
+        'is_admin': False,
+        'last_login': '2016-12-28T12:26:19+01:00',
+        'created': '2016-12-28T12:26:19+01:00',
+        'restricted': False,
+        'username': 'foobar'
     })
 
     def test_login(self):


### PR DESCRIPTION
This is modeled after gitlab/github.

Gitea oauth docs: https://docs.gitea.io/en-us/oauth2-provider/

User api: https://try.gitea.io/api/swagger#/user/userGetCurrent

Tested with weblate authenticating against gitea, can be tried in the wild at https://weblate.bubu1.eu which allows singing in with codeberg.org accounts.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Other information

Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.

<!--
    Pull request template based on the following templates:
    * https://raw.githubusercontent.com/ionic-team/ionic/master/.github/PULL_REQUEST_TEMPLATE.md
    * https://raw.githubusercontent.com/appium/appium/master/.github/PULL_REQUEST_TEMPLATE.md
-->
