### PR TITLE
Fix typo in PartialDecoratorTestCase mock name

### DIFF
--- a/social_core/tests/test_partial.py
+++ b/social_core/tests/test_partial.py
@@ -17,8 +17,8 @@ class PartialDecoratorTestCase(unittest.TestCase):
         self.mock_partial_store = Mock()
         self.mock_strategy.storage.partial.store = self.mock_partial_store
 
-        self.mock_sesstion_set = Mock()
-        self.mock_strategy.session_set = self.mock_sesstion_set
+        self.mock_session_set = Mock()
+        self.mock_strategy.session_set = self.mock_session_set
 
     def test_save_to_session(self):
         # GIVEN
@@ -42,10 +42,10 @@ class PartialDecoratorTestCase(unittest.TestCase):
             self.assertEqual((self.mock_current_partial,),
                              self.mock_partial_store.call_args[0])
 
-            self.assertEqual(1, self.mock_sesstion_set.call_count)
+            self.assertEqual(1, self.mock_session_set.call_count)
             self.assertEqual((PARTIAL_TOKEN_SESSION_NAME,
                               self.mock_current_partial_token),
-                             self.mock_sesstion_set.call_args[0])
+                             self.mock_session_set.call_args[0])
 
     def test_not_to_save_to_session(self):
         # GIVEN
@@ -69,7 +69,7 @@ class PartialDecoratorTestCase(unittest.TestCase):
             self.assertEqual((self.mock_current_partial,),
                              self.mock_partial_store.call_args[0])
 
-            self.assertEqual(0, self.mock_sesstion_set.call_count)
+            self.assertEqual(0, self.mock_session_set.call_count)
 
     def test_save_to_session_by_backward_compatible_decorator(self):
         # GIVEN
@@ -93,10 +93,10 @@ class PartialDecoratorTestCase(unittest.TestCase):
             self.assertEqual((self.mock_current_partial,),
                              self.mock_partial_store.call_args[0])
 
-            self.assertEqual(1, self.mock_sesstion_set.call_count)
+            self.assertEqual(1, self.mock_session_set.call_count)
             self.assertEqual((PARTIAL_TOKEN_SESSION_NAME,
                               self.mock_current_partial_token),
-                             self.mock_sesstion_set.call_args[0])
+                             self.mock_session_set.call_args[0])
 
     def test_not_to_save_to_session_when_the_response_is_a_dict(self):
         # GIVEN
@@ -114,4 +114,4 @@ class PartialDecoratorTestCase(unittest.TestCase):
         # THEN
         self.assertEqual(expected_response, response)
         self.assertEqual(0, self.mock_partial_store.call_count)
-        self.assertEqual(0, self.mock_sesstion_set.call_count)
+        self.assertEqual(0, self.mock_session_set.call_count)


### PR DESCRIPTION
## Proposed changes

Simple fix in the name of the variable used in this TestCase to correct a typo in the word "session".
Changes all usage of `mock_sesstion_set` to `mock_session_set`

## Types of changes

- [ ] Release (new release request)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works