### PR TITLE
Don't try to import cPickle module

### DIFF
--- a/social_core/store.py
+++ b/social_core/store.py
@@ -1,9 +1,5 @@
+import pickle
 import time
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
 
 from openid.store.interface import OpenIDStore as BaseOpenIDStore
 from openid.store.nonce import SKEW


### PR DESCRIPTION
Instead just import `pickle` module.
Python3+ automatically uses cPickle if it is available.

From the Python 3 release notes:
> A common pattern in Python 2.x is to have one version of a module implemented in pure Python, with an optional accelerated version implemented as a C extension; for example, pickle and cPickle. This places the burden of importing the accelerated version and falling back on the pure Python version on each user of these modules. In Python 3.0, the accelerated versions are considered implementation details of the pure Python versions. Users should always import the standard version, which attempts to import the accelerated version and falls back to the pure Python version.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
