### PR TITLE
Version up of VK on invoking auth method

### DIFF
--- a/social_core/backends/vk.py
+++ b/social_core/backends/vk.py
@@ -178,7 +178,7 @@ def vk_api(backend, method, data):
         http://goo.gl/yLcaa
     """
     # We need to perform server-side call if no access_token
-    data['v'] = backend.setting('API_VERSION', '5.131')
+    data['v'] = backend.setting('API_VERSION', '5.81')
     if 'access_token' not in data:
         key, secret = backend.get_key_and_secret()
         if 'api_id' not in data:


### PR DESCRIPTION
## Proposed changes

Up version to 5.81 because AuthException at `.../complete/vk-oauth2/` is raised: "Invalid request: versions below 5.81 are deprecated. Version param should be passed as "v". "version" param is invalid and not supported. For more information go to https://vk.com/dev/constant_version_updates"

## Types of changes

* Bugfix (non-breaking change which fixes an issue)