### PR TITLE
Unify exceptions

### DIFF
--- a/social_core/exceptions.py
+++ b/social_core/exceptions.py
@@ -20,7 +20,8 @@ class MissingBackend(WrongBackend):
 
 class NotAllowedToDisconnect(SocialAuthBaseException):
     """User is not allowed to disconnect it's social account."""
-    pass
+    def __str__(self):
+        return 'This account is not allowed to be disconnected.'
 
 
 class AuthException(SocialAuthBaseException):
@@ -90,7 +91,8 @@ class AuthStateForbidden(AuthException):
 
 class AuthAlreadyAssociated(AuthException):
     """A different user has already associated the target social account"""
-    pass
+    def __str__(self):
+        return 'This account is already in use.'
 
 
 class AuthTokenRevoked(AuthException):

--- a/social_core/pipeline/social_auth.py
+++ b/social_core/pipeline/social_auth.py
@@ -19,8 +19,7 @@ def social_user(backend, uid, user=None, *args, **kwargs):
     social = backend.strategy.storage.user.get_social_auth(provider, uid)
     if social:
         if user and social.user != user:
-            msg = 'This account is already in use.'
-            raise AuthAlreadyAssociated(backend, msg)
+            raise AuthAlreadyAssociated(backend)
         elif not user:
             user = social.user
     return {'social': social,

--- a/social_core/tests/actions/test_disconnect.py
+++ b/social_core/tests/actions/test_disconnect.py
@@ -14,7 +14,8 @@ class DisconnectActionTest(BaseActionTest):
     def test_not_allowed_to_disconnect(self):
         self.do_login()
         user = User.get(self.expected_username)
-        with self.assertRaises(NotAllowedToDisconnect):
+        with self.assertRaisesRegex(NotAllowedToDisconnect,
+                                    'This account is not allowed to be disconnected.'):
             do_disconnect(self.backend, user)
 
     def test_disconnect(self):

--- a/social_core/tests/test_exceptions.py
+++ b/social_core/tests/test_exceptions.py
@@ -52,7 +52,7 @@ class AuthStateMissingTest(BaseExceptionTestCase):
 
 class NotAllowedToDisconnectTest(BaseExceptionTestCase):
     exception = NotAllowedToDisconnect()
-    expected_message = ''
+    expected_message = 'This account is not allowed to be disconnected.'
 
 
 class AuthExceptionTest(BaseExceptionTestCase):
@@ -83,7 +83,7 @@ class AuthStateForbiddenTest(BaseExceptionTestCase):
 
 class AuthAlreadyAssociatedTest(BaseExceptionTestCase):
     exception = AuthAlreadyAssociated('foobar')
-    expected_message = ''
+    expected_message = 'This account is already in use.'
 
 
 class AuthTokenRevokedTest(BaseExceptionTestCase):


### PR DESCRIPTION
## Proposed changes

There are two exceptions, `NotAllowedToDisconnect` and `AuthAlreadyAssociated`, which do not define a `__str__` function. After looking through the code I did not find any valid reason why they should not look like the others. I changed them to work like any other exception which makes their handling easier.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [X] Lint and unit tests pass locally with my changes
- [X] I have adjusted tests that prove my fix is effective or that my feature works

## Other information

Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.

<!--
    Pull request template based on the following templates:
    * https://raw.githubusercontent.com/ionic-team/ionic/master/.github/PULL_REQUEST_TEMPLATE.md
    * https://raw.githubusercontent.com/appium/appium/master/.github/PULL_REQUEST_TEMPLATE.md
-->
