### PR TITLE
Assume RSA256 if key "alg" not set in open_id_connect.py

### DIFF
--- a/social_core/backends/open_id_connect.py
+++ b/social_core/backends/open_id_connect.py
@@ -160,7 +160,7 @@ class OpenIdConnectAuth(BaseOAuth2):
         for key in keys:
             if kid is None or kid == key.get('kid'):
                 if 'alg' not in key:
-                    key['alg'] = 'RSA256'
+                    key['alg'] = self.JWT_ALGORITHMS[0]
                 rsakey = jwk.construct(key)
                 message, encoded_sig = id_token.rsplit('.', 1)
                 decoded_sig = base64url_decode(encoded_sig.encode('utf-8'))

--- a/social_core/backends/open_id_connect.py
+++ b/social_core/backends/open_id_connect.py
@@ -159,6 +159,8 @@ class OpenIdConnectAuth(BaseOAuth2):
 
         for key in keys:
             if kid is None or kid == key.get('kid'):
+                if 'alg' not in key:
+                    key['alg'] = 'RSA256'
                 rsakey = jwk.construct(key)
                 message, encoded_sig = id_token.rsplit('.', 1)
                 decoded_sig = base64url_decode(encoded_sig.encode('utf-8'))


### PR DESCRIPTION
This change, proposed [here](https://github.com/mpdavis/python-jose/pull/171#issuecomment-574311477), fixed Signature verification errors we had with ping identity.
