### PR TITLE
Fix setting fullname for ORCID

### DIFF
--- a/social_core/backends/orcid.py
+++ b/social_core/backends/orcid.py
@@ -70,11 +70,11 @@ class ORCIDOAuth2(BaseOAuth2):
         if person:
             name = person.get('name')
 
-            fullname = name
-
             if name:
                 first_name = name.get('given-names', {}).get('value', '')
                 last_name = name.get('family-name', {}).get('value', '')
+                fullname = first_name + ' ' + last_name
+                fullname = fullname.strip()
 
             emails = person.get('emails')
             if emails:


### PR DESCRIPTION
Originally, fullname was set to `response['person']['name']`, which in
ORCID is a large json object. Everywhere else, fullname is assumed to be
a string. It cannot be used directly as a fullname but needs converting.

## Proposed changes

The patch ensures that fullname is a string, in a similar way to how other backends do it.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

(I had to install libxmlsec1-dev manually on debian in order to get tox to run.)