### PR TITLE
Add backend for Hashicorp Vault

### DIFF
--- a/social_core/backends/vault.py
+++ b/social_core/backends/vault.py
@@ -1,0 +1,108 @@
+"""
+Backend for Hashicorp Vault OIDC Identity Provider in Vault 1.9+
+https://www.vaultproject.io/docs/secrets/identity/oidc-provider
+"""
+import base64
+
+from social_core.backends.open_id_connect import OpenIdConnectAuth
+from social_core.utils import cache
+
+
+
+class VaultOpenIdConnect(OpenIdConnectAuth):
+    """Vault OIDC authentication backend
+
+    You will need to configure at minimum:
+
+    SOCIAL_AUTH_VAULT_OIDC_ENDPOINT = 'https://vault.example.net:8200/v1/identity/oidc/provider/default'
+    SOCIAL_AUTH_VAULT_KEY = '<client_id>'
+    SOCIAL_AUTH_VAULT_SECRET = '<client_secret>'
+
+    You might also want to override defaults inherited from open_id_connect.py, particularly
+
+    SOCIAL_AUTH_VAULT_USERNAME_KEY = 'preferred_username'
+    SOCIAL_AUTH_VAULT_SCOPE = ['groups']
+
+    You may need to set SOCIAL_AUTH_VAULT_VERIFY_SSL = False if your Vault server
+    does not have its certificate signed by a trusted CA (e.g. with LetsEncrypt)
+
+    On the Vault side, you will need to create a key and a provider:
+
+    vault write identity/oidc/key/oidc-key \
+        allowed_client_ids="*" \
+        verification_ttl="24h" \
+        rotation_period="24h" \
+        algorithm="RS256"
+
+    vault write identity/oidc/provider/default \
+        allowed_client_ids="*" \
+        scopes_supported="email,profile,groups"
+
+    Vault is very flexible with regard to configuring claims and scopes,
+    so it's up to you how you map entity and/or alias metadata to OIDC claims.
+    Here is a suggestion, which exposes the entity name as "preferred_username"
+    and takes the other claims from entity metadata:
+
+    vault write identity/oidc/scope/profile \
+      description="Provides user info" \
+      template='{
+        "preferred_username": {{identity.entity.name}},
+        "name": {{identity.entity.metadata.name}},
+        "given_name": {{identity.entity.metadata.given_name}},
+        "family_name": {{identity.entity.metadata.family_name}}
+    }'
+
+    vault write identity/oidc/scope/email \
+      description="Provides email address" \
+      template='{
+        "email": {{identity.entity.metadata.email}}
+    }'
+
+    vault write identity/oidc/scope/groups \
+      description="Provides a list of group names" \
+      template='{
+        "groups": {{identity.entity.groups.names}}
+    }'
+
+    Finally you will need to create an assignment and some clients
+
+    vault write identity/oidc/assignment/staff \
+        group_ids="<comma-separated-group-ids>"
+
+    vault write identity/oidc/client/my-app \
+        redirect_uris="https://www.example.com/callback" \
+        assignments="staff" \
+        key="oidc-key" \
+        id_token_ttl="30m" \
+        access_token_ttl="1h"
+    """
+    name = 'vault'
+
+    @property
+    def OIDC_ENDPOINT(self):
+        return self.setting('OIDC_ENDPOINT')
+
+    def auth_headers(self):
+        return {
+            'Authorization': b'Basic ' + base64.urlsafe_b64encode(
+                '{}:{}'.format(*self.get_key_and_secret()).encode()
+            )
+        }
+
+    def auth_complete_params(self, state=None):
+        return {
+            'grant_type': 'authorization_code',  # request auth code
+            'code': self.data.get('code', ''),  # server response code
+            'redirect_uri': self.get_redirect_uri(state)
+        }
+
+    def get_user_details(self, response):
+        username_key = self.setting('USERNAME_KEY', default=self.USERNAME_KEY)
+        return {
+            'username': response.get(username_key),
+            'email': response.get('email'),
+            'fullname': response.get('name'),
+            'first_name': response.get('given_name'),
+            'last_name': response.get('family_name'),
+            'groups': response.get('groups'),
+        }

--- a/social_core/tests/backends/test_open_id_connect.py
+++ b/social_core/tests/backends/test_open_id_connect.py
@@ -54,7 +54,10 @@ class OpenIdConnectTestMixin:
     issuer = None  # id_token issuer
     openid_config_body = None
     key = None
-    access_token_kwargs = {}
+    # Avoid sharing access_token_kwargs between different subclasses
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls.access_token_kwargs = getattr(cls, 'access_token_kwargs', {})
 
     def setUp(self):
         super().setUp()

--- a/social_core/tests/backends/test_vault.py
+++ b/social_core/tests/backends/test_vault.py
@@ -1,0 +1,41 @@
+import json
+
+from httpretty import HTTPretty
+
+from .oauth import OAuth2Test
+from .test_open_id_connect import OpenIdConnectTestMixin
+
+class VaultOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test):
+    backend_path = \
+        'social_core.backends.vault.VaultOpenIdConnect'
+    issuer = 'https://vault.example.net:8200/v1/identity/oidc/provider/default'
+    openid_config_body = json.dumps({
+      'issuer': 'https://vault.example.net:8200/v1/identity/oidc/provider/default',
+      'jwks_uri': 'https://vault.example.net:8200/v1/identity/oidc/provider/default/.well-known/keys',
+      'authorization_endpoint': 'https://vault.example.net:8200/ui/vault/identity/oidc/provider/default/authorize',
+      'token_endpoint': 'https://vault.example.net:8200/v1/identity/oidc/provider/default/token',
+      'userinfo_endpoint': 'https://vault.example.net:8200/v1/identity/oidc/provider/default/userinfo',
+      'request_uri_parameter_supported': False,
+      'grant_types_supported': [ 'authorization_code' ],
+      'token_endpoint_auth_methods_supported': [ 'client_secret_basic' ],
+    })
+
+    expected_username = 'cartman'
+
+    def extra_settings(self):
+        settings = super().extra_settings()
+        settings.update({
+            f'SOCIAL_AUTH_{self.name}_OIDC_ENDPOINT': 'https://vault.example.net:8200/v1/identity/oidc/provider/default',
+        })
+        return settings
+
+    def pre_complete_callback(self, start_url):
+        super().pre_complete_callback(start_url)
+        HTTPretty.register_uri('GET',
+                               uri=self.backend.userinfo_url(),
+                               status=200,
+                               body=json.dumps({'preferred_username': self.expected_username}),
+                               content_type='text/json')
+
+    def test_everything_works(self):
+        self.do_login()


### PR DESCRIPTION
## Proposed changes

This is a new backend for the [OIDC Provider](https://www.vaultproject.io/docs/secrets/identity/oidc-provider) in Hashicorp Vault 1.9+

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

(Not sure what linting you want, but flake8 passes)

## Other information

Tested with [Netbox](https://github.com/netbox-community/netbox/discussions/8579#discussioncomment-2200174)

NOTE 1: I had to override the base `OpenIdConnectAuth` class to do HTTP Basic Auth when talking to the token endpoint. Maybe it would be better if functionality were moved into the base class itself, since it can make use of the information exposed in the OIDC discovery response:

```
      'token_endpoint_auth_methods_supported': [ 'client_secret_basic' ],
```

NOTE 2: I turned OIDC_ENDPOINT into a property, since this is something the user has to configure to point to their own Vault server.  Maybe it would be better to turn this into a 'setting' on the `OpenIdConnectAuth` base class.

NOTE 3: With those two changes, I would have been able to instantiate the OpenIdConnectAuth class directly - except that it would still need to have a 'name' property.  If you set 'name' to 'oidc' here, then it would be usable as a generic OpenID Connect backend.  (I made one other change to pick up the 'groups' claim, which is non-standard but commonly implemented)