### PR TITLE
Add backend for Hashicorp Vault (alternative approach)

### DIFF
--- a/social_core/backends/open_id_connect.py
+++ b/social_core/backends/open_id_connect.py
@@ -26,7 +26,15 @@ class OpenIdConnectAuth(BaseOAuth2):
     """
     Base class for Open ID Connect backends.
     Currently only the code response type is supported.
+
+    It can also be directly instantiated as a generic OIDC backend.
+    To use it you will need to set at minimum:
+
+    SOCIAL_AUTH_OIDC_OIDC_ENDPOINT = 'https://.....'  # endpoint without /.well-known/openid-configuration
+    SOCIAL_AUTH_OIDC_KEY = '<client_id>'
+    SOCIAL_AUTH_OIDC_SECRET = '<client_secret>'
     """
+    name = 'oidc'
     # Override OIDC_ENDPOINT in your subclass to enable autoconfig of OIDC
     OIDC_ENDPOINT = None
     ID_TOKEN_MAX_AGE = 600
@@ -37,46 +45,58 @@ class OpenIdConnectAuth(BaseOAuth2):
     REVOKE_TOKEN_METHOD = 'GET'
     ID_KEY = 'sub'
     USERNAME_KEY = 'preferred_username'
+    JWT_ALGORITHMS = ['RS256']
+    JWT_DECODE_OPTIONS = dict()
+    # When these options are unspecified, server will choose via openid autoconfiguration
     ID_TOKEN_ISSUER = ''
     ACCESS_TOKEN_URL = ''
     AUTHORIZATION_URL = ''
     REVOKE_TOKEN_URL = ''
     USERINFO_URL = ''
     JWKS_URI = ''
-    JWT_ALGORITHMS = ['RS256']
-    JWT_DECODE_OPTIONS = dict()
+    TOKEN_ENDPOINT_AUTH_METHOD = ''
 
     def __init__(self, *args, **kwargs):
         self.id_token = None
         super().__init__(*args, **kwargs)
 
     def authorization_url(self):
-        return self.AUTHORIZATION_URL or \
+        return self.setting('AUTHORIZATION_URL', self.AUTHORIZATION_URL) or \
             self.oidc_config().get('authorization_endpoint')
 
     def access_token_url(self):
-        return self.ACCESS_TOKEN_URL or \
+        return self.setting('ACCESS_TOKEN_URL', self.ACCESS_TOKEN_URL) or \
             self.oidc_config().get('token_endpoint')
 
     def revoke_token_url(self, token, uid):
-        return self.REVOKE_TOKEN_URL or \
+        return self.setting('REVOKE_TOKEN_URL', self.REVOKE_TOKEN_URL) or \
             self.oidc_config().get('revocation_endpoint')
 
     def id_token_issuer(self):
-        return self.ID_TOKEN_ISSUER or \
+        return self.setting('ID_TOKEN_ISSUER', self.ID_TOKEN_ISSUER) or \
             self.oidc_config().get('issuer')
 
     def userinfo_url(self):
-        return self.USERINFO_URL or \
+        return self.setting('USERINFO_URL', self.USERINFO_URL) or \
             self.oidc_config().get('userinfo_endpoint')
 
     def jwks_uri(self):
-        return self.JWKS_URI or \
+        return self.setting('JWKS_URI', self.JWKS_URI) or \
             self.oidc_config().get('jwks_uri')
+
+    def use_basic_auth(self):
+        method = self.setting('TOKEN_ENDPOINT_AUTH_METHOD', self.TOKEN_ENDPOINT_AUTH_METHOD)
+        if method:
+            return method == 'client_secret_basic'
+        methods = self.oidc_config().get('token_endpoint_auth_methods_supported', [])
+        return not methods or 'client_secret_basic' in methods
+
+    def oidc_endpoint(self):
+        return self.setting('OIDC_ENDPOINT', self.OIDC_ENDPOINT)
 
     @cache(ttl=86400)
     def oidc_config(self):
-        return self.get_json(self.OIDC_ENDPOINT +
+        return self.get_json(self.oidc_endpoint() +
                              '/.well-known/openid-configuration')
 
     @cache(ttl=86400)
@@ -160,7 +180,7 @@ class OpenIdConnectAuth(BaseOAuth2):
         for key in keys:
             if kid is None or kid == key.get('kid'):
                 if 'alg' not in key:
-                    key['alg'] = self.JWT_ALGORITHMS[0]
+                    key['alg'] = self.setting('JWT_ALGORITHMS', self.JWT_ALGORITHMS)[0]
                 rsakey = jwk.construct(key)
                 message, encoded_sig = id_token.rsplit('.', 1)
                 decoded_sig = base64url_decode(encoded_sig.encode('utf-8'))
@@ -186,11 +206,11 @@ class OpenIdConnectAuth(BaseOAuth2):
             claims = jwt.decode(
                 id_token,
                 rsakey.to_pem().decode('utf-8'),
-                algorithms=self.JWT_ALGORITHMS,
+                algorithms=self.setting('JWT_ALGORITHMS', self.JWT_ALGORITHMS),
                 audience=client_id,
                 issuer=self.id_token_issuer(),
                 access_token=access_token,
-                options=self.JWT_DECODE_OPTIONS,
+                options=self.setting('JWT_DECODE_OPTIONS', self.JWT_DECODE_OPTIONS),
             )
         except ExpiredSignatureError:
             raise AuthTokenError(self, 'Signature has expired')
@@ -221,11 +241,12 @@ class OpenIdConnectAuth(BaseOAuth2):
         })
 
     def get_user_details(self, response):
-        username_key = self.setting('USERNAME_KEY', default=self.USERNAME_KEY)
+        username_key = self.setting('USERNAME_KEY', self.USERNAME_KEY)
         return {
             'username': response.get(username_key),
             'email': response.get('email'),
             'fullname': response.get('name'),
             'first_name': response.get('given_name'),
             'last_name': response.get('family_name'),
+            'groups': response.get('groups'),    # not standardized but widely implemented
         }

--- a/social_core/backends/vault.py
+++ b/social_core/backends/vault.py
@@ -1,0 +1,18 @@
+"""
+Backend for Hashicorp Vault OIDC Identity Provider in Vault 1.9+
+https://www.vaultproject.io/docs/secrets/identity/oidc-provider
+"""
+import base64
+
+from social_core.backends.open_id_connect import OpenIdConnectAuth
+from social_core.utils import cache
+
+
+
+class VaultOpenIdConnect(OpenIdConnectAuth):
+    """
+    Vault OIDC authentication backend
+
+    This is an alias for the generic OIDC backend
+    """
+    name = 'vault'

--- a/social_core/tests/backends/test_vault.py
+++ b/social_core/tests/backends/test_vault.py
@@ -1,0 +1,41 @@
+import json
+
+from httpretty import HTTPretty
+
+from .oauth import OAuth2Test
+from .test_open_id_connect import OpenIdConnectTestMixin
+
+class VaultOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test):
+    backend_path = \
+        'social_core.backends.vault.VaultOpenIdConnect'
+    issuer = 'https://vault.example.net:8200/v1/identity/oidc/provider/default'
+    openid_config_body = json.dumps({
+      'issuer': 'https://vault.example.net:8200/v1/identity/oidc/provider/default',
+      'jwks_uri': 'https://vault.example.net:8200/v1/identity/oidc/provider/default/.well-known/keys',
+      'authorization_endpoint': 'https://vault.example.net:8200/ui/vault/identity/oidc/provider/default/authorize',
+      'token_endpoint': 'https://vault.example.net:8200/v1/identity/oidc/provider/default/token',
+      'userinfo_endpoint': 'https://vault.example.net:8200/v1/identity/oidc/provider/default/userinfo',
+      'request_uri_parameter_supported': False,
+      'grant_types_supported': [ 'authorization_code' ],
+      'token_endpoint_auth_methods_supported': [ 'client_secret_basic' ],
+    })
+
+    expected_username = 'cartman'
+
+    def extra_settings(self):
+        settings = super().extra_settings()
+        settings.update({
+            f'SOCIAL_AUTH_{self.name}_OIDC_ENDPOINT': 'https://vault.example.net:8200/v1/identity/oidc/provider/default',
+        })
+        return settings
+
+    def pre_complete_callback(self, start_url):
+        super().pre_complete_callback(start_url)
+        HTTPretty.register_uri('GET',
+                               uri=self.backend.userinfo_url(),
+                               status=200,
+                               body=json.dumps({'preferred_username': self.expected_username}),
+                               content_type='text/json')
+
+    def test_everything_works(self):
+        self.do_login()


### PR DESCRIPTION
## Proposed changes

This is a more generic solution to PR #668 - for consideration.

In this PR, the OpenIdConnectAuth class is enhanced so that it can be instantiated directly, as a "generic" OIDC connector.

To enable this, it also makes the OAuth2 authentication mechanism configurable (i.e. form post or HTTP Basic), and uses OIDC discovery to select this automatically.

Vault then becomes an empty subclass of OpenIdConnectAuth, since it's an out-of-the-box OIDC provider.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

I believe this *shouldn't* break existing code, and all tests pass, but it would be wise to check the other OpenIdConnectAuth subclasses just in case.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## Other information

This PR also includes a fix for okta test which surfaced as part of this change. I believe this should only fix the test, not the actual behavior of the okta backend.