### PR TITLE
Fix for Keycloak backend: remove redirect_state

### DIFF
--- a/social_core/backends/keycloak.py
+++ b/social_core/backends/keycloak.py
@@ -88,6 +88,7 @@ class KeycloakOAuth2(BaseOAuth2):  # pylint: disable=abstract-method
     name = 'keycloak'
     ID_KEY = 'username'
     ACCESS_TOKEN_METHOD = 'POST'
+    REDIRECT_STATE = False
 
     def authorization_url(self):
         return self.setting('AUTHORIZATION_URL')


### PR DESCRIPTION
## Proposed changes

Set `REDIRECT_STATE = False` in keycloak backend.

Without this fix, PSA appends ?redirect_state=XXXX to the redirect_uri parameter value passed to the auth endpoint, and Keycloak rejects this with "Invalid parameter: redirect_uri"

Tested with:
- keycloak 17.0.0
- social-auth-core==4.2.0 plus this patch

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [?] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

It is possibly a "Breaking change", if this backend ever worked before.  But it definitely doesn't with current Keycloak.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Other information

User setting `SOCIAL_AUTH_KEYCLOAK_REDIRECT_STATE = False` doesn't fix this, hence as far as I can tell it's necessary to do a code change.

If there are concerns about backwards compatibility / breaking change, this could be turned into a `setting()` that could be overridden by the user.