### PR TITLE
Removes server_port from request_info

### DIFF
--- a/social_core/backends/saml.py
+++ b/social_core/backends/saml.py
@@ -269,7 +269,6 @@ class SAMLAuth(BaseAuth):
             'https': 'on' if self.strategy.request_is_secure() else 'off',
             'http_host': self.strategy.request_host(),
             'script_name': self.strategy.request_path(),
-            'server_port': self.strategy.request_port(),
             'get_data': self.strategy.request_get(),
             'post_data': self.strategy.request_post(),
         }


### PR DESCRIPTION
## Proposed changes

Remove server_port from request_info.

Resolve issue #609 - Stop passing server_port to python3-saml

server_port has been deprecated by python3-saml, see: https://github.com/onelogin/python3-saml/pull/276

If the server application is running behind a load balancer or a reverse proxy the request port might not match the SAML configuration.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ x] Other (please describe): Changes in reaction to a deprecation in dependency

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Other information

Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.

<!--
    Pull request template based on the following templates:
    * https://raw.githubusercontent.com/ionic-team/ionic/master/.github/PULL_REQUEST_TEMPLATE.md
    * https://raw.githubusercontent.com/appium/appium/master/.github/PULL_REQUEST_TEMPLATE.md
-->
