### PR TITLE
Allow per-backend user pipeline settings

### DIFF
--- a/social_core/pipeline/user.py
+++ b/social_core/pipeline/user.py
@@ -11,17 +11,17 @@ def get_username(strategy, details, backend, user=None, *args, **kwargs):
     storage = strategy.storage
 
     if not user:
-        email_as_username = strategy.setting("USERNAME_IS_FULL_EMAIL", False)
-        uuid_length = strategy.setting("UUID_LENGTH", 16)
+        email_as_username = backend.setting("USERNAME_IS_FULL_EMAIL", False)
+        uuid_length = backend.setting("UUID_LENGTH", 16)
         max_length = storage.user.username_max_length()
-        do_slugify = strategy.setting("SLUGIFY_USERNAMES", False)
-        do_clean = strategy.setting("CLEAN_USERNAMES", True)
+        do_slugify = backend.setting("SLUGIFY_USERNAMES", False)
+        do_clean = backend.setting("CLEAN_USERNAMES", True)
 
         def identity_func(val):
             return val
 
         if do_clean:
-            override_clean = strategy.setting("CLEAN_USERNAME_FUNCTION")
+            override_clean = backend.setting("CLEAN_USERNAME_FUNCTION")
             if override_clean:
                 clean_func = module_member(override_clean)
             else:
@@ -30,7 +30,7 @@ def get_username(strategy, details, backend, user=None, *args, **kwargs):
             clean_func = identity_func
 
         if do_slugify:
-            override_slug = strategy.setting("SLUGIFY_FUNCTION")
+            override_slug = backend.setting("SLUGIFY_FUNCTION")
             slug_func = module_member(override_slug) if override_slug else slugify
         else:
             slug_func = identity_func
@@ -82,7 +82,7 @@ def user_details(strategy, details, backend, user=None, *args, **kwargs):
 
     # Default protected user fields (username, id, pk and email) can be ignored
     # by setting the SOCIAL_AUTH_NO_DEFAULT_PROTECTED_USER_FIELDS to True
-    if strategy.setting("NO_DEFAULT_PROTECTED_USER_FIELDS") is True:
+    if strategy.setting("NO_DEFAULT_PROTECTED_USER_FIELDS", backend=backend) is True:
         protected = ()
     else:
         protected = (
@@ -96,13 +96,13 @@ def user_details(strategy, details, backend, user=None, *args, **kwargs):
             "is_superuser",
         )
 
-    protected = protected + tuple(strategy.setting("PROTECTED_USER_FIELDS", []))
+    protected = protected + tuple(strategy.setting("PROTECTED_USER_FIELDS", [], backend=backend))
 
     # Update user model attributes with the new data sent by the current
     # provider. Update on some attributes is disabled by default, for
     # example username and id fields. It's also possible to disable update
     # on fields defined in SOCIAL_AUTH_PROTECTED_USER_FIELDS.
-    field_mapping = strategy.setting("USER_FIELD_MAPPING", {}, backend)
+    field_mapping = strategy.setting("USER_FIELD_MAPPING", {}, backend=backend)
     for name, value in details.items():
         # Convert to existing user field if mapping exists
         name = field_mapping.get(name, name)
@@ -113,7 +113,7 @@ def user_details(strategy, details, backend, user=None, *args, **kwargs):
         if current_value == value:
             continue
 
-        immutable_fields = tuple(strategy.setting("IMMUTABLE_USER_FIELDS", []))
+        immutable_fields = tuple(strategy.setting("IMMUTABLE_USER_FIELDS", [], backend=backend))
         if name in immutable_fields and current_value:
             continue
 

--- a/social_core/pipeline/user.py
+++ b/social_core/pipeline/user.py
@@ -96,7 +96,9 @@ def user_details(strategy, details, backend, user=None, *args, **kwargs):
             "is_superuser",
         )
 
-    protected = protected + tuple(strategy.setting("PROTECTED_USER_FIELDS", [], backend=backend))
+    protected = protected + tuple(
+        strategy.setting("PROTECTED_USER_FIELDS", [], backend=backend)
+    )
 
     # Update user model attributes with the new data sent by the current
     # provider. Update on some attributes is disabled by default, for
@@ -113,7 +115,9 @@ def user_details(strategy, details, backend, user=None, *args, **kwargs):
         if current_value == value:
             continue
 
-        immutable_fields = tuple(strategy.setting("IMMUTABLE_USER_FIELDS", [], backend=backend))
+        immutable_fields = tuple(
+            strategy.setting("IMMUTABLE_USER_FIELDS", [], backend=backend)
+        )
         if name in immutable_fields and current_value:
             continue
 


### PR DESCRIPTION
According to https://python-social-auth.readthedocs.io/en/latest/configuration/settings.html, "All settings can be defined per-backend by adding the backend name to the setting name, like SOCIAL_AUTH_TWITTER_LOGIN_URL". This changes user.py to actually use per-backend settings for options like USERNAME_IS_FULL_EMAIL.

Note that get_username is always called with a backend, but user_details isn't, so a different version of `setting' is needed for the two.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [X?] Lint and unit tests pass locally with my changes -- running tox reports an error in test_dummy both before and after my change
- [ ] I have added tests that prove my fix is effective or that my feature works

## Other information

Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.

<!--
    Pull request template based on the following templates:
    * https://raw.githubusercontent.com/ionic-team/ionic/master/.github/PULL_REQUEST_TEMPLATE.md
    * https://raw.githubusercontent.com/appium/appium/master/.github/PULL_REQUEST_TEMPLATE.md
-->
