### PR TITLE
Google Plus: Convert id_token using tokeninfo endpoint

### DIFF
--- a/social_core/backends/google.py
+++ b/social_core/backends/google.py
@@ -132,8 +132,6 @@ class GooglePlusAuth(BaseGoogleOAuth2API, BaseOAuth2):
             raise AuthMissingParameter(self, 'access_token, id_token, or code')
 
     def user_data(self, access_token, *args, **kwargs):
-        if 'id_token' not in self.data:
-            return super().user_data(access_token, *args, **kwargs)
         response = self.get_json(
             'https://www.googleapis.com/oauth2/v3/tokeninfo',
             params={'id_token': access_token}


### PR DESCRIPTION
## Proposed changes

Do not validate `id_token` in `self.data` when converting `id_token` to `access_token` using `/tokeninfo` endpoint.

It might be unclear to me, why this statement is here as the function (or super) doesn't seem to be working with such variable or how should I populate these data with `id_token`.
This change fixed [Google Identity Service](https://developers.google.com/identity/gsi/web) for me which needs to convert "id Token" to "Access token" as described in [GIS Documentation](https://developers.google.com/identity/sign-in/web/backend-auth#calling-the-tokeninfo-endpoint)

## Types of changes

- [ ] Release (new release request)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

I'll run unit-tests right after fixing some local apt-related issues.

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Other information

