### PR TITLE
Stop using deprecated ssl.PROTOCOL_TLSv1 in the Amazon backend.

### DIFF
--- a/social_core/backends/amazon.py
+++ b/social_core/backends/amazon.py
@@ -15,7 +15,7 @@ class AmazonOAuth2(BaseOAuth2):
     DEFAULT_SCOPE = ['profile']
     REDIRECT_STATE = False
     ACCESS_TOKEN_METHOD = 'POST'
-    SSL_PROTOCOL = ssl.PROTOCOL_TLSv1
+    SSL_PROTOCOL = ssl.PROTOCOL_TLS
     EXTRA_DATA = [
         ('refresh_token', 'refresh_token', True),
         ('user_id', 'user_id'),


### PR DESCRIPTION
## Proposed changes

ssl.PROTOCOL_TLSv1 used in Amazon backend is deprecated since python3.6; use just ssl.PROTOCOL_TLS instead (use highest TLS version supported by both client & server) as suggested in the manual

This fixes an error signing in using the Amazon backend (Authentication failed: HTTPSConnectionPool(host='api.amazon.com', port=443): Max retries exceeded with url: /auth/o2/token (Caused by SSLError(SSLError(1, '[SSL] internal error (_ssl.c:1131)'))))

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Other information

Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.

<!--
    Pull request template based on the following templates:
    * https://raw.githubusercontent.com/ionic-team/ionic/master/.github/PULL_REQUEST_TEMPLATE.md
    * https://raw.githubusercontent.com/appium/appium/master/.github/PULL_REQUEST_TEMPLATE.md
-->
