### PR TITLE
add appid query parameter for azuread

### DIFF
--- a/social_core/backends/azuread_tenant.py
+++ b/social_core/backends/azuread_tenant.py
@@ -46,18 +46,25 @@ for verifying JWT tokens.
 
 class AzureADTenantOAuth2(AzureADOAuth2):
     name = "azuread-tenant-oauth2"
-    OPENID_CONFIGURATION_URL = "{base_url}/.well-known/openid-configuration"
-    JWKS_URL = "{base_url}/discovery/keys"
+    OPENID_CONFIGURATION_URL = "{base_url}/.well-known/openid-configuration{appid}"
+    JWKS_URL = "{base_url}/discovery/keys{appid}}"
 
     @property
     def tenant_id(self):
         return self.setting("TENANT_ID", "common")
 
     def openid_configuration_url(self):
-        return self.OPENID_CONFIGURATION_URL.format(base_url=self.base_url)
+        return self.OPENID_CONFIGURATION_URL.format(
+            base_url=self.base_url, appid=self._appid()
+        )
 
     def jwks_url(self):
-        return self.JWKS_URL.format(base_url=self.base_url)
+        return self.JWKS_URL.format(base_url=self.base_url, appid=self._appid())
+
+    def _appid(self):
+        return (
+            f"?appid={self.setting('KEY')}" if self.setting('KEY') is not None else ""
+        )
 
     def get_certificate(self, kid):
         # retrieve keys from jwks_url
@@ -101,10 +108,10 @@ class AzureADTenantOAuth2(AzureADOAuth2):
 
 class AzureADV2TenantOAuth2(AzureADTenantOAuth2):
     name = "azuread-v2-tenant-oauth2"
-    OPENID_CONFIGURATION_URL = "{base_url}/v2.0/.well-known/openid-configuration"
+    OPENID_CONFIGURATION_URL = "{base_url}/v2.0/.well-known/openid-configuration{appid}"
     AUTHORIZATION_URL = "{base_url}/oauth2/v2.0/authorize"
     ACCESS_TOKEN_URL = "{base_url}/oauth2/v2.0/token"
-    JWKS_URL = "{base_url}/discovery/v2.0/keys"
+    JWKS_URL = "{base_url}/discovery/v2.0/keys{appid}"
     DEFAULT_SCOPE = ["openid", "profile", "offline_access"]
 
     def get_user_id(self, details, response):

--- a/social_core/backends/azuread_tenant.py
+++ b/social_core/backends/azuread_tenant.py
@@ -63,7 +63,7 @@ class AzureADTenantOAuth2(AzureADOAuth2):
 
     def _appid(self):
         return (
-            f"?appid={self.setting('KEY')}" if self.setting('KEY') is not None else ""
+            f"?appid={self.setting('KEY')}" if self.setting("KEY") is not None else ""
         )
 
     def get_certificate(self, kid):


### PR DESCRIPTION
## Proposed changes

Issue: https://github.com/python-social-auth/social-core/issues/695

Documentation
If your app has custom signing keys as a result of using the claims-mapping ( https://learn.microsoft.com/en-us/azure/active-directory/develop/active-directory-claims-mapping ) feature, you must append an appid query parameter containing the app ID to get a jwks_uri pointing to your app's signing key information, which should be used for validation.
Source: https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens#validating-tokens

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Other information

Like @wurstbrot already described in the issue #695, there might be a better fix for this issue, but this seems to work.
