### PR TITLE
Removes version constraint for lxml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Updated `user_data` method in `StripeOAuth2` to return `email` in `get_user_details`
+- Removes fixed version of `lxml`
 
 
 ## [4.3.0](https://github.com/python-social-auth/social-core/releases/tag/4.3.0) - 2022-06-13

--- a/requirements-saml.txt
+++ b/requirements-saml.txt
@@ -1,2 +1,1 @@
-python3-saml>=1.2.1
-lxml<4.7
+python3-saml>=1.5.0


### PR DESCRIPTION
Should fix #659

## Proposed changes

Eases constraint on lxml as python3-saml 1.5.0 should no longer require anything before 4.7.0 and it'd allow users of python-social-auth to mitigate [CVE-2021-43818](https://www.cvedetails.com/cve/CVE-2021-43818/) by upgrading to a more recent version

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [X] Other (please describe): Dependency update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

No relevant changes to python files at this time

