### PR TITLE
add possibility to configure tenant id

### DIFF
--- a/social_core/backends/azuread.py
+++ b/social_core/backends/azuread.py
@@ -64,7 +64,7 @@ class AzureADOAuth2(BaseOAuth2):
 
     @property
     def tenant_id(self):
-        return "common"
+        return self.setting("TENANT_ID", "common")
 
     @property
     def base_url(self):


### PR DESCRIPTION
Bug: https://github.com/python-social-auth/social-core/issues/748

Tested locally and was able to change the Tenant ID to `organizations` with

```
SOCIAL_AUTH_AZUREAD_OAUTH2_TENANT_ID = "organizations"
```