### PR TITLE
Add OpenInfraOpenId backend (#753)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Backend for OpenInfra OpenID
 - Facebook Limited Login backend
 
 ### Changed

--- a/social_core/backends/openinfra.py
+++ b/social_core/backends/openinfra.py
@@ -1,0 +1,49 @@
+"""
+OpenInfra OpenId backend
+"""
+from urllib.parse import urlsplit
+
+from openid.extensions import ax
+
+from .open_id import OpenIdAuth
+
+
+class OpenInfraOpenId(OpenIdAuth):
+    name = "openinfra"
+    URL = "id.openinfra.dev"
+
+    def get_user_details(self, response):
+        """Generate username from identity url"""
+        values = super().get_user_details(response)
+        values["username"] = values.get("username") or urlsplit(
+            response.identity_url
+        ).path.strip("/")
+        values["nickname"] = values.get("nickname", "")
+        return values
+
+    def setup_request(self, params=None):
+        """Fetch email, firstname, lastname from openid"""
+        request = self.openid_request(params)
+
+        # TODO: use sreg instead ax request to fetch nickname as username
+        fetch_request = ax.FetchRequest()
+        fetch_request.add(
+            ax.AttrInfo(
+                "http://axschema.org/contact/email", alias="email", required=True
+            )
+        )
+
+        fetch_request.add(
+            ax.AttrInfo(
+                "http://axschema.org/namePerson/first", alias="firstname", required=True
+            )
+        )
+
+        fetch_request.add(
+            ax.AttrInfo(
+                "http://axschema.org/namePerson/last", alias="lastname", required=True
+            )
+        )
+
+        request.addExtension(fetch_request)
+        return request


### PR DESCRIPTION
Add a new backend that's functionally equivalent to the existing OpenStackOpenId backend, but uses the id.openinfra.dev provider.

## Proposed changes

Resolves feature request (issue #753)

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

- [ ] Lint and unit tests pass locally with my changes
     - social_core.tests.backends.test_dummy.ExpirationTimeTest fails for me locally at line 132; it also fails locally without my patch.  I tried to troubleshoot it, but I'm not sure what's going on there.
- [ ] I have added tests that prove my fix is effective or that my feature works
     - it's basically the same as an existing backend except for the URL; and the existing backend doesn't have any tests (looks like most of the subclasses of OpenIdAuth don't have unit tests).  I'll be happy to add tests if you can point me at an example.

## Other information

None.

<!--
    Pull request template based on the following templates:
    * https://raw.githubusercontent.com/ionic-team/ionic/master/.github/PULL_REQUEST_TEMPLATE.md
    * https://raw.githubusercontent.com/appium/appium/master/.github/PULL_REQUEST_TEMPLATE.md
-->
