### PR TITLE
Update Azure AD B2C base URL to match updated endpoints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,8 @@ services:
       context: .
       dockerfile: ./files/tests/Dockerfile
       args:
-      - PYTHON_VERSIONS=3.6.12 3.7.9 3.8.7 3.9.1
+      - PYTHON_VERSIONS=3.6.12 3.7.16 3.8.16 3.9.16 3.10.10 3.11.2
     environment:
-    - PYTHON_VERSIONS=3.6.12 3.7.9 3.8.7 3.9.1
+    - PYTHON_VERSIONS=3.6.12 3.7.16 3.8.16 3.9.16 3.10.10 3.11.2
     volumes:
     - .:/code

--- a/social_core/backends/azuread_b2c.py
+++ b/social_core/backends/azuread_b2c.py
@@ -54,7 +54,7 @@ class AzureADB2COAuth2(AzureADOAuth2):
     name = "azuread-b2c-oauth2"
 
     BASE_URL = "https://{tenant_name}.{authority_host}/{tenant_name}.onmicrosoft.com"
-    AUTHORIZATION_URL = "{base_url}/oauth2/v2.0/authorize?p={policy}"
+    AUTHORIZATION_URL = "{base_url}/oauth2/v2.0/authorize"
     OPENID_CONFIGURATION_URL = (
         "{base_url}/v2.0/.well-known/openid-configuration?p={policy}"
     )
@@ -104,7 +104,8 @@ class AzureADB2COAuth2(AzureADOAuth2):
         )
 
     def authorization_url(self):
-        return self.AUTHORIZATION_URL.format(base_url=self.base_url, policy=self.policy)
+        # Policy is required, but added later by `auth_extra_arguments()`
+        return self.AUTHORIZATION_URL.format(base_url=self.base_url)
 
     def access_token_url(self):
         return self.ACCESS_TOKEN_URL.format(base_url=self.base_url, policy=self.policy)
@@ -124,15 +125,15 @@ class AzureADB2COAuth2(AzureADOAuth2):
             response["access_token"] = response["id_token"]
         return response
 
-    # def auth_extra_arguments(self):
-    #     """
-    #     Return extra arguments needed on auth process.
+    def auth_extra_arguments(self):
+        """
+        Return extra arguments needed on auth process.
 
-    #     The defaults can be overridden by GET parameters.
-    #     """
-    #     extra_arguments = super().auth_extra_arguments()
-    #     extra_arguments["p"] = self.policy or self.data.get("p")
-    #     return extra_arguments
+        The defaults can be overridden by GET parameters.
+        """
+        extra_arguments = super().auth_extra_arguments()
+        extra_arguments["p"] = self.policy or self.data.get("p")
+        return extra_arguments
 
     def jwt_key_to_pem(self, key_json_dict):
         """

--- a/social_core/backends/azuread_b2c.py
+++ b/social_core/backends/azuread_b2c.py
@@ -92,14 +92,19 @@ class AzureADB2COAuth2(AzureADOAuth2):
             )
         return policy
 
+    @property
+    def base_url(self):
+        return self.BASE_URL.format(
+            tenant_name=self.tenant_name, authority_host=self.authority_host
+        )
+
     def openid_configuration_url(self):
         return self.OPENID_CONFIGURATION_URL.format(
             base_url=self.base_url, policy=self.policy
         )
 
     def authorization_url(self):
-        # Policy is required, but added later by `auth_extra_arguments()`
-        return self.AUTHORIZATION_URL.format(base_url=self.base_url)
+        return self.AUTHORIZATION_URL.format(base_url=self.base_url, policy=self.policy)
 
     def access_token_url(self):
         return self.ACCESS_TOKEN_URL.format(base_url=self.base_url, policy=self.policy)

--- a/social_core/backends/azuread_b2c.py
+++ b/social_core/backends/azuread_b2c.py
@@ -53,7 +53,8 @@ from .azuread import AzureADOAuth2
 class AzureADB2COAuth2(AzureADOAuth2):
     name = "azuread-b2c-oauth2"
 
-    AUTHORIZATION_URL = "{base_url}/oauth2/v2.0/authorize"
+    BASE_URL = "https://{tenant_name}.{authority_host}/{tenant_name}.onmicrosoft.com"
+    AUTHORIZATION_URL = "{base_url}/oauth2/v2.0/authorize?p={policy}"
     OPENID_CONFIGURATION_URL = (
         "{base_url}/v2.0/.well-known/openid-configuration?p={policy}"
     )
@@ -74,8 +75,12 @@ class AzureADB2COAuth2(AzureADOAuth2):
     ]
 
     @property
-    def tenant_id(self):
-        return self.setting("TENANT_ID", "common")
+    def authority_host(self):
+        return self.setting("AUTHORITY_HOST", "b2clogin.com")
+
+    @property
+    def tenant_name(self):
+        return self.setting("TENANT_NAME")
 
     @property
     def policy(self):

--- a/social_core/backends/azuread_b2c.py
+++ b/social_core/backends/azuread_b2c.py
@@ -124,15 +124,15 @@ class AzureADB2COAuth2(AzureADOAuth2):
             response["access_token"] = response["id_token"]
         return response
 
-    def auth_extra_arguments(self):
-        """
-        Return extra arguments needed on auth process.
+    # def auth_extra_arguments(self):
+    #     """
+    #     Return extra arguments needed on auth process.
 
-        The defaults can be overridden by GET parameters.
-        """
-        extra_arguments = super().auth_extra_arguments()
-        extra_arguments["p"] = self.policy or self.data.get("p")
-        return extra_arguments
+    #     The defaults can be overridden by GET parameters.
+    #     """
+    #     extra_arguments = super().auth_extra_arguments()
+    #     extra_arguments["p"] = self.policy or self.data.get("p")
+    #     return extra_arguments
 
     def jwt_key_to_pem(self, key_json_dict):
         """

--- a/social_core/tests/backends/test_azuread_b2c.py
+++ b/social_core/tests/backends/test_azuread_b2c.py
@@ -120,7 +120,7 @@ class AzureADOAuth2Test(OAuth2Test):
                     "family_name": "Bar",
                     "given_name": "Foo",
                     "iat": AUTH_TIME,
-                    "iss": "https://login.microsoftonline.com/9a9a9a9a-1111-5555-0000-bc24adfdae00/v2.0/",
+                    "iss": "https://foobar.b2clogin.com/9a9a9a9a-1111-5555-0000-bc24adfdae00/v2.0/",
                     "name": "FooBar",
                     "nbf": AUTH_TIME,
                     "oid": "11223344-5566-7788-9999-aabbccddeeff",
@@ -142,7 +142,7 @@ class AzureADOAuth2Test(OAuth2Test):
             {
                 "SOCIAL_AUTH_" + self.name + "_POLICY": "b2c_1_signin",
                 "SOCIAL_AUTH_" + self.name + "_KEY": self.AUTH_KEY,
-                "SOCIAL_AUTH_" + self.name + "_TENANT_ID": "footenant.onmicrosoft.com",
+                "SOCIAL_AUTH_" + self.name + "_TENANT_NAME": "footenant",
             }
         )
         return settings
@@ -150,7 +150,7 @@ class AzureADOAuth2Test(OAuth2Test):
     def setUp(self):
         super().setUp()
 
-        keys_url = "https://login.microsoftonline.com/footenant.onmicrosoft.com/discovery/v2.0/keys?p=b2c_1_signin"
+        keys_url = "https://footenant.b2clogin.com/footenant.onmicrosoft.com/discovery/v2.0/keys?p=b2c_1_signin"
         keys_body = json.dumps(
             {
                 "keys": [

--- a/social_core/tests/backends/test_azuread_b2c.py
+++ b/social_core/tests/backends/test_azuread_b2c.py
@@ -83,7 +83,7 @@ RSA_PRIVATE_JWT_KEY = {
 }
 
 
-class AzureADOAuth2Test(OAuth2Test):
+class AzureADB2COAuth2Test(OAuth2Test):
     AUTH_KEY = "abcdef12-1234-9876-0000-abcdef098765"
     EXPIRES_IN = 3600
     AUTH_TIME = int(time())


### PR DESCRIPTION
## Proposed changes

This is similar to [PR 459](https://github.com/python-social-auth/social-core/pull/459). I kept the policy name as an extra argument. This appears to be the default endpoint suggested by Azure AD B2C which is probably less confusing. I also made the b2clogin.com endpoint using the `authority_host` property. I have updated the corresponding tests as well as the docker-compose.yml to test with these Python versions: 3.6.12 3.7.16 3.8.16 3.9.16 3.10.10 3.11.2. I have documentation updates drafted and I can propose those changes if this PR is accepted. 

Documentation for the endpoints can be found here: https://docs.microsoft.com/en-us/azure/active-directory-b2c/b2clogin

As proposed the `base_url` would be `https://{tenant_name}.{authority_host}/{tenant_name}.onmicrosoft.com` where `tenant_name` is required but `authority_host` will default to `b2clogin.com` if not set. The policy argument will still get added so an example URL for keys would look like this `https://footenant.b2clogin.com/footenant.onmicrosoft.com/discovery/v2.0/keys?p=b2c_1_signin`.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Other information

`SOCIAL_AUTH_AZUREAD_B2C_OAUTH2_TENANT_ID` is updated to `SOCIAL_AUTH_AZUREAD_B2C_OAUTH2_TENANT_NAME`

<!--
    Pull request template based on the following templates:
    * https://raw.githubusercontent.com/ionic-team/ionic/master/.github/PULL_REQUEST_TEMPLATE.md
    * https://raw.githubusercontent.com/appium/appium/master/.github/PULL_REQUEST_TEMPLATE.md
-->
