### PR TITLE
Make Keycloak's ID_KEY configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Fixed Azure AD Tenant authentication with custom signing keys
 - Added CAS OIDC backend
+- Made Keycloak `ID_KEY` configurable
 
 ## [4.4.1](https://github.com/python-social-auth/social-core/releases/tag/4.4.1) - 2023-03-30
 

--- a/social_core/backends/keycloak.py
+++ b/social_core/backends/keycloak.py
@@ -96,7 +96,6 @@ class KeycloakOAuth2(BaseOAuth2):  # pylint: disable=abstract-method
     """
 
     name = "keycloak"
-    ID_KEY = "username"
     ACCESS_TOKEN_METHOD = "POST"
     REDIRECT_STATE = False
 
@@ -120,6 +119,9 @@ class KeycloakOAuth2(BaseOAuth2):  # pylint: disable=abstract-method
                 "-----END PUBLIC KEY-----",
             ]
         )
+
+    def id_key(self):
+        return self.setting("ID_KEY", default="username")
 
     def user_data(
         self, access_token, *args, **kwargs
@@ -149,5 +151,11 @@ class KeycloakOAuth2(BaseOAuth2):  # pylint: disable=abstract-method
         }
 
     def get_user_id(self, details, response):
-        """Get and associate Django User by the field indicated by ID_KEY"""
-        return details.get(self.ID_KEY)
+        """Get and associate Django User by the field indicated by ID_KEY
+
+        The ID_KEY can be any field in the user details or the access token.
+        """
+        id_key = self.id_key()
+        if id_key in details:
+            return details[id_key]
+        return response.get(id_key)


### PR DESCRIPTION
## Proposed changes

As explained in:
- #813 

Currently, it is not possible to change the `ID_KEY` of the keycloak provider, even though this feature was meant to be present (according to the docstring). The `ID_KEY` is basically the claim used to map a user.

With this change, it is now possible to set the `ID_KEY` to any field present either in details or in the returned token:
```python
SOCIAL_AUTH_KEYCLOAK_ID_KEY = "email" # use the keycloak user email (from details)
SOCIAL_AUTH_KEYCLOAK_ID_KEY = "sub" # use the keycloak user id (from token)
```


## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Other information

I haven't added tests since such configurations don't seem to be tested on other backends. The default will stay exactly the same, thus not breaking the current behaviour.

Closes #813 
