### PR TITLE
Replace jose with pyjwt

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,7 +1,7 @@
 requests>=2.9.1
 oauthlib>=1.0.3
 requests-oauthlib>=0.6.1
-PyJWT>=2.0.0
+PyJWT>=2.7.0
 cryptography>=1.4
 defusedxml>=0.5.0rc1
 python3-openid>=3.0.10

--- a/requirements-openidconnect.txt
+++ b/requirements-openidconnect.txt
@@ -1,1 +1,0 @@
-python-jose>=3.0.0

--- a/setup.py
+++ b/setup.py
@@ -40,13 +40,12 @@ def read_tests_requirements(filename):
 
 
 requirements = read_requirements("requirements-base.txt")
-requirements_openidconnect = read_requirements("requirements-openidconnect.txt")
 requirements_saml = read_requirements("requirements-saml.txt")
 requirements_azuread = read_requirements("requirements-azuread.txt")
 
 tests_requirements = read_tests_requirements("requirements.txt")
 
-requirements_all = requirements_openidconnect + requirements_saml + requirements_azuread
+requirements_all = requirements_saml + requirements_azuread
 
 tests_requirements = tests_requirements + requirements_all
 
@@ -73,7 +72,6 @@ setup(
     install_requires=requirements,
     python_requires=">=3.8",
     extras_require={
-        "openidconnect": [requirements_openidconnect],
         "saml": [requirements_saml],
         "azuread": [requirements_azuread],
         "all": [requirements_all],

--- a/social_core/backends/open_id_connect.py
+++ b/social_core/backends/open_id_connect.py
@@ -1,10 +1,11 @@
+import base64
 import datetime
 import json
 from calendar import timegm
 
-from jose import jwk, jwt
-from jose.jwt import ExpiredSignatureError, JWTClaimsError, JWTError
-from jose.utils import base64url_decode
+import jwt
+from jwt.utils import base64url_decode
+from jwt import ExpiredSignatureError, InvalidTokenError, PyJWTError, InvalidAudienceError
 
 from social_core.backends.oauth import BaseOAuth2
 from social_core.exceptions import AuthTokenError
@@ -186,10 +187,10 @@ class OpenIdConnectAuth(BaseOAuth2):
             if kid is None or kid == key.get("kid"):
                 if "alg" not in key:
                     key["alg"] = self.setting("JWT_ALGORITHMS", self.JWT_ALGORITHMS)[0]
-                rsakey = jwk.construct(key)
+                rsakey = jwt.PyJWK(key)
                 message, encoded_sig = id_token.rsplit(".", 1)
                 decoded_sig = base64url_decode(encoded_sig.encode("utf-8"))
-                if rsakey.verify(message.encode("utf-8"), decoded_sig):
+                if rsakey.Algorithm.verify(message.encode("utf-8"), rsakey.key, decoded_sig):
                     return key
         return None
 
@@ -205,24 +206,31 @@ class OpenIdConnectAuth(BaseOAuth2):
         if not key:
             raise AuthTokenError(self, "Signature verification failed")
 
-        rsakey = jwk.construct(key)
+        rsakey = jwt.PyJWK(key)
 
         try:
             claims = jwt.decode(
                 id_token,
-                rsakey.to_pem().decode("utf-8"),
+                rsakey.key,
                 algorithms=self.setting("JWT_ALGORITHMS", self.JWT_ALGORITHMS),
                 audience=client_id,
                 issuer=self.id_token_issuer(),
-                access_token=access_token,
                 options=self.setting("JWT_DECODE_OPTIONS", self.JWT_DECODE_OPTIONS),
             )
         except ExpiredSignatureError:
             raise AuthTokenError(self, "Signature has expired")
-        except JWTClaimsError as error:
+        except InvalidAudienceError:
+            # compatibility with jose error message
+            raise AuthTokenError(self, "Token error: Invalid audience")
+        except InvalidTokenError as error:
             raise AuthTokenError(self, str(error))
-        except JWTError:
+        except PyJWTError:
             raise AuthTokenError(self, "Invalid signature")
+
+        # pyjwt does not validate OIDC claims
+        # see https://github.com/jpadilla/pyjwt/pull/296
+        if claims.get("at_hash") != self.calc_at_hash(access_token, key['alg']):
+            raise AuthTokenError(self, "Invalid access token")
 
         self.validate_claims(claims)
 
@@ -253,3 +261,14 @@ class OpenIdConnectAuth(BaseOAuth2):
             "first_name": response.get("given_name"),
             "last_name": response.get("family_name"),
         }
+
+    @staticmethod
+    def calc_at_hash(access_token, algorithm):
+        """
+        Calculates "at_hash" claim which is not done by pyjwt.
+
+        See https://pyjwt.readthedocs.io/en/stable/usage.html#oidc-login-flow
+        """
+        alg_obj = jwt.get_algorithm_by_name(algorithm)
+        digest = alg_obj.compute_hash_digest(access_token.encode("utf-8"))
+        return base64.urlsafe_b64encode(digest[: (len(digest) // 2)]).decode("utf-8").rstrip("=")

--- a/social_core/tests/backends/test_auth0.py
+++ b/social_core/tests/backends/test_auth0.py
@@ -1,7 +1,7 @@
 import json
 
+import jwt
 from httpretty import HTTPretty
-from jose import jwt
 
 from .oauth import OAuth2Test
 
@@ -45,8 +45,9 @@ class Auth0OAuth2Test(OAuth2Test):
                     "picture": "http://example.com/image.png",
                     "sub": "123456",
                     "iss": f"https://{DOMAIN}/",
+                    "aud": "a-key"
                 },
-                JWK_KEY,
+                jwt.PyJWK(JWK_KEY).key,
                 algorithm="RS256",
             ),
         }

--- a/social_core/tests/backends/test_auth0.py
+++ b/social_core/tests/backends/test_auth0.py
@@ -45,7 +45,7 @@ class Auth0OAuth2Test(OAuth2Test):
                     "picture": "http://example.com/image.png",
                     "sub": "123456",
                     "iss": f"https://{DOMAIN}/",
-                    "aud": "a-key"
+                    "aud": "a-key",
                 },
                 jwt.PyJWK(JWK_KEY).key,
                 algorithm="RS256",

--- a/social_core/tests/backends/test_open_id_connect.py
+++ b/social_core/tests/backends/test_open_id_connect.py
@@ -7,7 +7,7 @@ from calendar import timegm
 from urllib.parse import urlparse
 
 from httpretty import HTTPretty
-from jose import jwt
+import jwt
 
 from social_core.backends.open_id_connect import OpenIdConnectAuth
 
@@ -150,13 +150,14 @@ class OpenIdConnectTestMixin:
             nonce,
             issuer,
         )
+        # calc at_hash
+        id_token["at_hash"] = OpenIdConnectAuth.calc_at_hash("foobar", "RS256")
 
         body["id_token"] = jwt.encode(
-            claims=id_token,
-            key=dict(self.key, iat=timegm(issue_datetime.utctimetuple()), nonce=nonce),
+            id_token,
+            key=jwt.PyJWK(dict(self.key, iat=timegm(issue_datetime.utctimetuple()), nonce=nonce)).key,
             algorithm="RS256",
-            access_token="foobar",
-            headers=dict(kid=kid),
+            headers=dict(kid=kid) if kid else None,
         )
 
         if tamper_message:

--- a/social_core/tests/backends/test_open_id_connect.py
+++ b/social_core/tests/backends/test_open_id_connect.py
@@ -6,8 +6,8 @@ import sys
 from calendar import timegm
 from urllib.parse import urlparse
 
-from httpretty import HTTPretty
 import jwt
+from httpretty import HTTPretty
 
 from social_core.backends.open_id_connect import OpenIdConnectAuth
 
@@ -155,7 +155,9 @@ class OpenIdConnectTestMixin:
 
         body["id_token"] = jwt.encode(
             id_token,
-            key=jwt.PyJWK(dict(self.key, iat=timegm(issue_datetime.utctimetuple()), nonce=nonce)).key,
+            key=jwt.PyJWK(
+                dict(self.key, iat=timegm(issue_datetime.utctimetuple()), nonce=nonce)
+            ).key,
             algorithm="RS256",
             headers=dict(kid=kid) if kid else None,
         )


### PR DESCRIPTION
## Proposed changes

Replace `python-jose` with `pyjwt` (see #503).

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Other information

As discussed in #503 some changes was done to perform the migration:

- add `calc_at_hash` static method to `OpenIdConnectAuth` since PyJWT does not support validating claims which are not part of JWT RFCs (see https://github.com/jpadilla/pyjwt/pull/296)
- manual add `"at_hash"` claim in `OpenIdConnectTestMixin.prepare_access_token_body` (see above)
- add `"aud"` claim in `Auth0OAuth2Test.access_token_body` because PyJWT behaves different from jose: it does not allow this claim to not be present if is should be validated
- implement in `Auth0OAuth2` the logic which tries every found key since PyJWT does not implement it while jose does.
- update PyJWT minimum requirement to `2.7.0` which is the minimum version which provides the full API to handle OIDC
