### PR TITLE
Make AppleID work with multiple identifiers

### DIFF
--- a/social_core/backends/apple.py
+++ b/social_core/backends/apple.py
@@ -75,7 +75,7 @@ class AppleIdAuth(BaseOAuth2):
 
     def generate_client_secret(self):
         now = int(time.time())
-        client_id = self.setting("CLIENT")
+        client_id = self.data.get("client_id", self.setting("CLIENT"))
         team_id = self.setting("TEAM")
         key_id = self.setting("KEY")
         private_key = self.get_private_key()
@@ -92,7 +92,7 @@ class AppleIdAuth(BaseOAuth2):
         return jwt.encode(payload, key=private_key, algorithm="ES256", headers=headers)
 
     def get_key_and_secret(self):
-        client_id = self.setting("CLIENT")
+        client_id = self.data.get("client_id", self.setting("CLIENT"))
         client_secret = self.generate_client_secret()
         return client_id, client_secret
 


### PR DESCRIPTION
## Proposed changes

When creating an application that uses 1 backend and multiple frontends (webapp and iOS), the backend needs to know to what App ID or Service ID you want the access token from Apple.

Now we can just sent the `client_id` together with the `provider` and `code`. That will make it possible support using AppleID for webapp and iOS app on the same backend.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added documentation to https://github.com/python-social-auth/social-docs
