### PR TITLE
Update the Facebook API version from 12.0 to 18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- Updated Facebook API version to 18.0
+
+
 ## [4.5.1](https://github.com/python-social-auth/social-core/releases/tag/4.5.1) - 2023-11-29
 
 ### Changed

--- a/social_core/backends/facebook.py
+++ b/social_core/backends/facebook.py
@@ -17,7 +17,7 @@ from ..exceptions import (
 from ..utils import constant_time_compare, handle_http_errors, parse_qs
 from .oauth import BaseOAuth2
 
-API_VERSION = 12.0
+API_VERSION = 18.0
 
 
 class FacebookOAuth2(BaseOAuth2):


### PR DESCRIPTION
## Proposed changes

Version 12.0 of the API is only available until February 8th, 2024 after which requests will be force upgraded to version 13.0.

Version 18.0 is the latest available version and there are no changes to the endpoints requested by social-core so we can jump straight to the latest available version.

Changelog: https://developers.facebook.com/docs/graph-api/changelog.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [x] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added documentation to https://github.com/python-social-auth/social-docs

## Other information
