### PR TITLE
[feat] Add OAuth2 support for OpenStreetMap

### DIFF
--- a/social_core/backends/openstreetmap_oauth2.py
+++ b/social_core/backends/openstreetmap_oauth2.py
@@ -11,6 +11,7 @@ More info: https://wiki.openstreetmap.org/wiki/OAuth
 
 from .oauth import BaseOAuth2PKCE
 
+
 class OpenStreetMapOAuth2(BaseOAuth2PKCE):
     """OpenStreetMap OAuth2 authentication backend"""
 
@@ -45,12 +46,12 @@ class OpenStreetMapOAuth2(BaseOAuth2PKCE):
         headers = {"Authorization": f"Bearer {access_token}"}
         response = self.get_json(
             url="https://api.openstreetmap.org/api/0.6/user/details.json",
-            headers=headers
+            headers=headers,
         )
 
         return {
             "id": response["user"]["id"],
             "username": response["user"]["display_name"],
             "account_created": response["user"]["account_created"],
-            "avatar": response["user"].get("img", {}).get("href")
+            "avatar": response["user"].get("img", {}).get("href"),
         }

--- a/social_core/backends/openstreetmap_oauth2.py
+++ b/social_core/backends/openstreetmap_oauth2.py
@@ -1,0 +1,56 @@
+"""
+OpenStreetMap OAuth 2.0 support.
+
+This adds support for OpenStreetMap OAuth service. An application must be
+registered first on OpenStreetMap and the settings
+SOCIAL_AUTH_OPENSTREETMAP_OAUTH2_KEY and SOCIAL_AUTH_OPENSTREETMAP_OAUTH2_SECRET
+must be defined with the corresponding values.
+
+More info: https://wiki.openstreetmap.org/wiki/OAuth
+"""
+
+from .oauth import BaseOAuth2PKCE
+
+class OpenStreetMapOAuth2(BaseOAuth2PKCE):
+    """OpenStreetMap OAuth2 authentication backend"""
+
+    name = "openstreetmap-oauth2"
+    AUTHORIZATION_URL = "https://www.openstreetmap.org/oauth2/authorize"
+    ACCESS_TOKEN_URL = "https://www.openstreetmap.org/oauth2/token"
+    ACCESS_TOKEN_METHOD = "POST"
+    SCOPE_SEPARATOR = " "
+    STATE_PARAMETER = True
+    DEFAULT_SCOPE = ["read_prefs"]
+    EXTRA_DATA = [
+        ("id", "id"),
+        ("avatar", "avatar"),
+        ("account_created", "account_created"),
+    ]
+    PKCE_DEFAULT_CODE_CHALLENGE_METHOD = "S256"
+    DEFAULT_USE_PKCE = True
+
+    def get_user_details(self, response):
+        """Return user details from OpenStreetMap account"""
+        return {
+            "username": response["username"],
+            "email": "",
+            "fullname": "",
+            "first_name": "",
+            "last_name": "",
+        }
+
+    def user_data(self, access_token, *args, **kwargs):
+        """Return user data provided"""
+
+        headers = {"Authorization": f"Bearer {access_token}"}
+        response = self.get_json(
+            url="https://api.openstreetmap.org/api/0.6/user/details.json",
+            headers=headers
+        )
+
+        return {
+            "id": response["user"]["id"],
+            "username": response["user"]["display_name"],
+            "account_created": response["user"]["account_created"],
+            "avatar": response["user"].get("img", {}).get("href")
+        }

--- a/social_core/tests/backends/test_openstreetmap_oauth2.py
+++ b/social_core/tests/backends/test_openstreetmap_oauth2.py
@@ -18,8 +18,8 @@ class OpenStreetMapOAuth2Test(OAuth2Test):
             "user": {
                 "id": 1,
                 "display_name": "Steve",
-                "account_created": "2005-09-13T15:32:57Z"
-            }
+                "account_created": "2005-09-13T15:32:57Z",
+            },
         }
     )
 

--- a/social_core/tests/backends/test_openstreetmap_oauth2.py
+++ b/social_core/tests/backends/test_openstreetmap_oauth2.py
@@ -1,0 +1,30 @@
+import json
+
+from .oauth import OAuth2Test
+
+
+class OpenStreetMapOAuth2Test(OAuth2Test):
+    backend_path = "social_core.backends.openstreetmap_oauth2.OpenStreetMapOAuth2"
+    user_data_url = "https://api.openstreetmap.org/api/0.6/user/details.json"
+    expected_username = "Steve"
+    access_token_body = json.dumps({"access_token": "foobar", "token_type": "bearer"})
+    user_data_body = json.dumps(
+        {
+            "version": "0.6",
+            "generator": "OpenStreetMap server",
+            "copyright": "OpenStreetMap and contributors",
+            "attribution": "http://www.openstreetmap.org/copyright",
+            "license": "http://opendatacommons.org/licenses/odbl/1-0/",
+            "user": {
+                "id": 1,
+                "display_name": "Steve",
+                "account_created": "2005-09-13T15:32:57Z"
+            }
+        }
+    )
+
+    def test_login(self):
+        self.do_login()
+
+    def test_partial_pipeline(self):
+        self.do_partial_pipeline()


### PR DESCRIPTION
Fixes #758

## Proposed changes

Adding OAuth 2.0 support for OpenStreetMap, since the existing OAuth 1.0a support will be [sunset in June 2024](https://community.openstreetmap.org/t/oauth-1-0a-and-http-basic-auth-shutdown/108490).
Multiple applications using python-social-auth won't be able to authenticate anymore at that point.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added documentation to https://github.com/python-social-auth/social-docs

## Other information

I've added more details, including a screen recording,  in this comment: https://github.com/python-social-auth/social-core/issues/758#issuecomment-1913232732

Edits:
* I forced-pushed the branch to include the DEFAULT_SCOPE parameter.
* Another rebase due to "[pre-commit.ci] auto fixes from pre-commit.com hooks " being merged into master.
