### PR TITLE
Fix ORCID login when no family name was given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- Handle case where user has not registered a `family-name`  with ORCID
+
 ## [4.5.4](https://github.com/python-social-auth/social-core/releases/tag/4.5.4) - 2024-04-25
 
 ### Added

--- a/social_core/backends/orcid.py
+++ b/social_core/backends/orcid.py
@@ -76,7 +76,8 @@ class ORCIDOAuth2(BaseOAuth2):
 
             if name:
                 first_name = name.get("given-names", {}).get("value", "")
-                last_name = name.get("family-name", {}).get("value", "")
+                if name.get("family-name", None) is not None:
+                    last_name = name.get("family-name").get("value", "")
 
             emails = person.get("emails")
             if emails:

--- a/social_core/backends/orcid.py
+++ b/social_core/backends/orcid.py
@@ -76,8 +76,8 @@ class ORCIDOAuth2(BaseOAuth2):
 
             if name:
                 first_name = name.get("given-names", {}).get("value", "")
-                if name.get("family-name", None) is not None:
-                    last_name = name.get("family-name").get("value", "")
+                if (family_name := name.get("family-name", None)) is not None:
+                    last_name = family_name.get("value", "")
 
             emails = person.get("emails")
             if emails:


### PR DESCRIPTION
Handle the case where the user has not registered a `family-name` and ORCID returns `None`.

## Proposed changes

This addresses [https://github.com/python-social-auth/social-app-django/issues/355](https://github.com/python-social-auth/social-app-django/issues/355) and #602 (which it appears to duplicate). Full credit to [paloha](https://github.com/paloha), who very clearly [explained](https://github.com/python-social-auth/social-app-django/issues/355#issuecomment-1568685404) the issue and proposed the simple fix included here.

As a brief summary: ORCID does not require users to enter a family name and returns a `family-name` key with value `None` in this case. The code expects that key to either be absent, or contain a dictionary. This leads to an `AttributeError` after successful login by a user who has not provided a family name to ORCID.

I considered adding a test case to cover this scenario, but it looks like the testing infrastructure is only set up for a single possible `user_data_body`? Please let me know if I have missed an easy and obvious way to add a test for an additional case of returned data. The change does resolve the issue in my manual testing.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] Lint and unit tests pass locally with my changes - caveat: 6 of 587 discovered tests fail independently of these changes in my environment but they do not appear to be covering the changed code (they are related to SAML)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added documentation to https://github.com/python-social-auth/social-docs

## Other information

_Any other information that is important to this PR such as screenshots of how
the component looks before and after the change._
