### PR TITLE
Fix https://github.com/python-social-auth/social-core/issues/918

### DIFF
--- a/social_core/backends/telegram.py
+++ b/social_core/backends/telegram.py
@@ -43,7 +43,7 @@ class TelegramAuth(BaseAuth):
         last_name = response.get("last_name", "")
         fullname = f"{first_name} {last_name}".strip()
         return {
-            "username": response.get("username") or response[self.ID_KEY],
+            "username": response.get("username") or str(response[self.ID_KEY]),
             "first_name": first_name,
             "last_name": last_name,
             "fullname": fullname,


### PR DESCRIPTION
Make username always a string to avoid errors in the user pipeline.

## Proposed changes

Bugfix https://github.com/python-social-auth/social-core/issues/918

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added documentation to https://github.com/python-social-auth/social-docs

## Other information

I was unable to build the make tests docker image
everything ended in error
failed to solve: process "/bin/sh -c /pyenv.sh" did not complete successfully: exit code: 1

I’m not sure what this is connected with (perhaps due to the blocking of the docker hub in Russia or something else, but because of this I could not run the tests)

upd: dont know how, but after rerun ```docker compose run social-tests``` tests works
```
  py38: OK (47.50=setup[10.21]+cmd[2.90,34.39] seconds)
  py39: OK (44.02=setup[6.38]+cmd[3.03,34.61] seconds)
  py310: OK (42.92=setup[6.09]+cmd[2.95,33.88] seconds)
  py311: OK (44.56=setup[5.40]+cmd[4.35,34.81] seconds)
  py312: OK (48.56=setup[7.95]+cmd[4.62,35.99] seconds)
  congratulations :) (227.62 seconds)
```