### PR TITLE
Use timezone-aware datetime objects

### DIFF
--- a/social_core/backends/asana.py
+++ b/social_core/backends/asana.py
@@ -36,8 +36,8 @@ class AsanaOAuth2(BaseOAuth2):
     def extra_data(self, user, uid, response, details=None, *args, **kwargs):
         data = super().extra_data(user, uid, response, details)
         if self.setting("ESTIMATE_EXPIRES_ON"):
-            expires_on = datetime.datetime.utcnow() + datetime.timedelta(
-                seconds=data["expires"]
-            )
+            expires_on = datetime.datetime.now(
+                datetime.timezone.utc
+            ) + datetime.timedelta(seconds=data["expires"])
             data["expires_on"] = expires_on.isoformat()
         return data

--- a/social_core/backends/exacttarget.py
+++ b/social_core/backends/exacttarget.py
@@ -4,7 +4,7 @@ Support Authentication from IMH using JWT token and pre-shared key.
 Requires package pyjwt
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import jwt
 
@@ -91,7 +91,7 @@ class ExactTargetOAuth2(BaseOAuth2):
         # The expiresIn value determines how long the tokens are valid for.
         # Take a bit off, then convert to an int timestamp
         expiresSeconds = details.get("expiresIn", 0) - 30
-        expires = datetime.utcnow() + timedelta(seconds=expiresSeconds)
+        expires = datetime.now(timezone.utc) + timedelta(seconds=expiresSeconds)
         data["expires"] = (expires - datetime(1970, 1, 1)).total_seconds()
 
         if response.get("token"):

--- a/social_core/backends/linkedin.py
+++ b/social_core/backends/linkedin.py
@@ -30,7 +30,7 @@ class LinkedinOpenIdConnect(OpenIdConnectAuth):
     def validate_claims(self, id_token):
         """Copy of the regular validate_claims method without the nonce validation."""
 
-        utc_timestamp = timegm(datetime.datetime.utcnow().utctimetuple())
+        utc_timestamp = timegm(datetime.datetime.now(datetime.timezone.utc).timetuple())
 
         if "nbf" in id_token and utc_timestamp < id_token["nbf"]:
             raise AuthTokenError(self, "Incorrect id_token: nbf")

--- a/social_core/backends/open_id_connect.py
+++ b/social_core/backends/open_id_connect.py
@@ -152,7 +152,7 @@ class OpenIdConnectAuth(BaseOAuth2):
         self.strategy.storage.association.remove([nonce_id])
 
     def validate_claims(self, id_token):
-        utc_timestamp = timegm(datetime.datetime.utcnow().utctimetuple())
+        utc_timestamp = timegm(datetime.datetime.now(datetime.timezone.utc).timetuple())
 
         if "nbf" in id_token and utc_timestamp < id_token["nbf"]:
             raise AuthTokenError(self, "Incorrect id_token: nbf")

--- a/social_core/storage.py
+++ b/social_core/storage.py
@@ -5,7 +5,7 @@ import re
 import time
 import uuid
 import warnings
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from openid.association import Association as OpenIdAssociation
 
@@ -68,19 +68,19 @@ class UserMixin:
             except (ValueError, TypeError):
                 return None
 
-            now = datetime.utcnow()
+            now = datetime.now(timezone.utc)
 
             # Detect if expires is a timestamp
             if expires > time.mktime(now.timetuple()):
                 # expires is a datetime, return the remaining difference
-                return datetime.utcfromtimestamp(expires) - now
+                return datetime.fromtimestamp(expires, tz=timezone.utc) - now
             else:
                 # expires is the time to live seconds since creation,
                 # check against auth_time if present, otherwise return
                 # the value
                 auth_time = self.extra_data.get("auth_time")
                 if auth_time:
-                    reference = datetime.utcfromtimestamp(auth_time)
+                    reference = datetime.fromtimestamp(auth_time, tz=timezone.utc)
                     return (reference + timedelta(seconds=expires)) - now
                 else:
                     return timedelta(seconds=expires)

--- a/social_core/tests/backends/test_dummy.py
+++ b/social_core/tests/backends/test_dummy.py
@@ -121,7 +121,9 @@ class ExpirationTimeTest(DummyOAuth2Test):
             "first_name": "Foo",
             "last_name": "Bar",
             "email": "foo@bar.com",
-            "expires": time.mktime((datetime.datetime.utcnow() + DELTA).timetuple()),
+            "expires": time.mktime(
+                (datetime.datetime.now(datetime.timezone.utc) + DELTA).timetuple()
+            ),
         }
     )
 

--- a/social_core/tests/backends/test_livejournal.py
+++ b/social_core/tests/backends/test_livejournal.py
@@ -6,7 +6,9 @@ from httpretty import HTTPretty
 from ...exceptions import AuthMissingParameter
 from .open_id import OpenIdTest
 
-JANRAIN_NONCE = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+JANRAIN_NONCE = datetime.datetime.now(datetime.timezone.utc).strftime(
+    "%Y-%m-%dT%H:%M:%SZ"
+)
 
 
 class LiveJournalOpenIdTest(OpenIdTest):

--- a/social_core/tests/backends/test_ngpvan.py
+++ b/social_core/tests/backends/test_ngpvan.py
@@ -7,7 +7,9 @@ from httpretty import HTTPretty
 
 from .open_id import OpenIdTest
 
-JANRAIN_NONCE = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+JANRAIN_NONCE = datetime.datetime.now(datetime.timezone.utc).strftime(
+    "%Y-%m-%dT%H:%M:%SZ"
+)
 
 
 class NGPVANActionIDOpenIDTest(OpenIdTest):

--- a/social_core/tests/backends/test_open_id_connect.py
+++ b/social_core/tests/backends/test_open_id_connect.py
@@ -136,7 +136,7 @@ class OpenIdConnectTestMixin:
 
         body = {"access_token": "foobar", "token_type": "bearer"}
         client_key = client_key or self.client_key
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         expiration_datetime = expiration_datetime or (
             now + datetime.timedelta(seconds=30)
         )
@@ -145,8 +145,8 @@ class OpenIdConnectTestMixin:
         issuer = issuer or self.issuer
         id_token = self.get_id_token(
             client_key,
-            timegm(expiration_datetime.utctimetuple()),
-            timegm(issue_datetime.utctimetuple()),
+            timegm(expiration_datetime.timetuple()),
+            timegm(issue_datetime.timetuple()),
             nonce,
             issuer,
         )
@@ -156,7 +156,7 @@ class OpenIdConnectTestMixin:
         body["id_token"] = jwt.encode(
             id_token,
             key=jwt.PyJWK(
-                dict(self.key, iat=timegm(issue_datetime.utctimetuple()), nonce=nonce)
+                dict(self.key, iat=timegm(issue_datetime.timetuple()), nonce=nonce)
             ).key,
             algorithm="RS256",
             headers=dict(kid=kid) if kid else None,
@@ -190,9 +190,9 @@ class OpenIdConnectTestMixin:
         )
 
     def test_expired_signature(self):
-        expiration_datetime = datetime.datetime.utcnow() - datetime.timedelta(
-            seconds=30
-        )
+        expiration_datetime = datetime.datetime.now(
+            datetime.timezone.utc
+        ) - datetime.timedelta(seconds=30)
         self.authtoken_raised(
             "Token error: Signature has expired",
             expiration_datetime=expiration_datetime,
@@ -207,9 +207,9 @@ class OpenIdConnectTestMixin:
         )
 
     def test_invalid_issue_time(self):
-        expiration_datetime = datetime.datetime.utcnow() - datetime.timedelta(
-            seconds=self.backend.ID_TOKEN_MAX_AGE * 2
-        )
+        expiration_datetime = datetime.datetime.now(
+            datetime.timezone.utc
+        ) - datetime.timedelta(seconds=self.backend.ID_TOKEN_MAX_AGE * 2)
         self.authtoken_raised(
             "Token error: Incorrect id_token: iat", issue_datetime=expiration_datetime
         )


### PR DESCRIPTION
Rather than using the `datetime.utcnow()` and `datetime.utcfromtimestamp()` methods which produce timezone-naive datetime objects, we should instead use `datetime.now()` and `datetime.fromtimestamp()` with UTC provided as the timezone, in order to create timezone-aware datetime objects.

This removes the DeprecationWarning that otherwise is raised since Python 3.12 for these methods.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added documentation to https://github.com/python-social-auth/social-docs