### PR TITLE
Fix failing Elixir AAI token refresh

### DIFF
--- a/social_core/backends/elixir.py
+++ b/social_core/backends/elixir.py
@@ -32,3 +32,14 @@ class ElixirOpenIdConnect(OpenIdConnectAuth):
             "first_name": first_name,
             "last_name": last_name,
         }
+
+    def refresh_token(self, token, *args, **kwargs):
+        params = "&".join(
+            f"{param}={value}"
+            for param, value in self.refresh_token_params(token, *args, **kwargs).items()
+        )
+	    url = self.refresh_token_url()
+        method = self.REFRESH_TOKEN_METHOD
+        key = "params" if method == "GET" else "data"
+        request_args = {"headers": self.auth_headers(), "method": method, key: params}
+        return self.process_refresh_token_response(request, *args, **kwargs)


### PR DESCRIPTION
## Proposed changes

Refreshing Elixir AAI tokens fails with error `An error occurred when refreshing user token: 401 Client Error: 401 for url: https://login.elixir-czech.org/oidc/token`. The source of the HTTP 401 error is a malformed request. Closes #826, read the issue for details.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added documentation to https://github.com/python-social-auth/social-docs

## Other information

At the moment I just want to highlight the source of the problem and the solution, the patch is not properly integrated within the codebase, that's why the PR is a draft. For example, it is probably better to patch [`social_core.backends.oauth:BaseOAuth2.refresh_token`](https://github.com/python-social-auth/social-core/blob/fd7dd903eedd666027ffee65bf8f5f39647e9fbe/social_core/backends/oauth.py#L454-L461).
