### PR TITLE
Fix deprecated Atlassian field `name`

### DIFF
--- a/social_core/backends/atlassian.py
+++ b/social_core/backends/atlassian.py
@@ -22,7 +22,7 @@ class AtlassianOAuth2(BaseOAuth2):
     def get_user_details(self, response):
         fullname, first_name, last_name = self.get_user_names(response["displayName"])
         return {
-            "username": response["name"],
+            "username": response["accountId"],
             "email": response["emailAddress"],
             "fullname": fullname,
             "first_name": first_name,

--- a/social_core/tests/backends/test_atlassian.py
+++ b/social_core/tests/backends/test_atlassian.py
@@ -9,7 +9,7 @@ class AtlassianOAuth2Test(OAuth2Test):
     backend_path = "social_core.backends.atlassian.AtlassianOAuth2"
     tenant_url = "https://api.atlassian.com/oauth/token/accessible-resources"
     user_data_url = "https://api.atlassian.com/ex/jira/FAKED_CLOUD_ID/rest/api/2/myself"
-    expected_username = "erlich"
+    expected_username = "9927935d01-92a7-4687-8272-a9b8d3b2ae2e"
     access_token_body = json.dumps({"access_token": "aviato", "token_type": "bearer"})
     tenant_data_body = json.dumps(
         [
@@ -26,7 +26,6 @@ class AtlassianOAuth2Test(OAuth2Test):
             "self": "http://bachmanity.atlassian.net/rest/api/3/user?username=erlich",
             "key": "erlich",
             "accountId": "99:27935d01-92a7-4687-8272-a9b8d3b2ae2e",
-            "name": "erlich",
             "emailAddress": "erlich@bachmanity.com",
             "avatarUrls": {
                 "48x48": "http://bachmanity.atlassian.net/secure/useravatar?size=large&ownerId=erlich",


### PR DESCRIPTION
## Proposed changes

Remove usage `name` in favor for `accountId` for Atlassian backend. Fixes [Issue 517](https://github.com/python-social-auth/social-core/issues/517) - essentially a `KeyError` when trying to access `name`.
![SCR-20241024-tvtj](https://github.com/user-attachments/assets/6a5e72b4-243a-4a98-b123-b49e001bcc1f)


Atlassian deprecation notice 1 October 2018:

> By 29 April 2019, we will remove personal data from the API that is used to identify users, such as `username` and `userKey`, and instead use the Atlassian account ID (`accountId`). Additionally, will be restricting the visibility of other personal data, such as email, in conjunction with a user's profile privacy settings.

Further down in the same deprecation notice:


Field | Change | Nullable | Notes
-- | -- | -- | --
name | REMOVED | N/A | Use accountId instead.

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added documentation to https://github.com/python-social-auth/social-docs

## Other information

Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
