### PR TITLE
944 fix params in auth url

### DIFF
--- a/social_core/backends/oauth.py
+++ b/social_core/backends/oauth.py
@@ -1,6 +1,6 @@
 import base64
 import hashlib
-from urllib.parse import unquote, urlencode
+from urllib.parse import urlencode
 
 from oauthlib.oauth1 import SIGNATURE_TYPE_AUTH_HEADER
 from requests_oauthlib import OAuth1

--- a/social_core/backends/oauth.py
+++ b/social_core/backends/oauth.py
@@ -277,7 +277,7 @@ class BaseOAuth1(OAuthAuth):
         )
         state = self.get_or_create_state()
         params[self.REDIRECT_URI_PARAMETER_NAME] = self.get_redirect_uri(state)
-        return f"{self.authorization_url()}?{urlencode(params)}"
+        return url_add_parameters(self.authorization_url(), params)
 
     def oauth_auth(
         self, token=None, oauth_verifier=None, signature_type=SIGNATURE_TYPE_AUTH_HEADER
@@ -352,12 +352,12 @@ class BaseOAuth2(OAuthAuth):
         params = self.auth_params(state)
         params.update(self.get_scope_argument())
         params.update(self.auth_extra_arguments())
-        params = urlencode(params)
-        if not self.REDIRECT_STATE:
-            # redirect_uri matching is strictly enforced, so match the
-            # providers value exactly.
-            params = unquote(params)
-        return f"{self.authorization_url()}?{params}"
+
+        # when self.REDIRECT_STATE is False, redirect_uri matching is strictly enforced,
+        # so match the providers value exactly.
+        return url_add_parameters(
+            self.authorization_url(), params, not self.REDIRECT_STATE
+        )
 
     def auth_complete_params(self, state=None):
         params = {

--- a/social_core/backends/soundcloud.py
+++ b/social_core/backends/soundcloud.py
@@ -3,8 +3,6 @@ Soundcloud OAuth2 backend, docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/soundcloud.html
 """
 
-from urllib.parse import urlencode
-
 from ..utils import url_add_parameters
 from .oauth import BaseOAuth2
 

--- a/social_core/backends/soundcloud.py
+++ b/social_core/backends/soundcloud.py
@@ -5,8 +5,8 @@ Soundcloud OAuth2 backend, docs at:
 
 from urllib.parse import urlencode
 
-from .oauth import BaseOAuth2
 from ..utils import url_add_parameters
+from .oauth import BaseOAuth2
 
 
 class SoundcloudOAuth2(BaseOAuth2):

--- a/social_core/backends/soundcloud.py
+++ b/social_core/backends/soundcloud.py
@@ -6,6 +6,7 @@ Soundcloud OAuth2 backend, docs at:
 from urllib.parse import urlencode
 
 from .oauth import BaseOAuth2
+from ..utils import url_add_parameters
 
 
 class SoundcloudOAuth2(BaseOAuth2):
@@ -56,4 +57,4 @@ class SoundcloudOAuth2(BaseOAuth2):
         params = self.auth_params(state)
         params.update(self.get_scope_argument())
         params.update(self.auth_extra_arguments())
-        return self.AUTHORIZATION_URL + "?" + urlencode(params)
+        return url_add_parameters(self.AUTHORIZATION_URL, params, True)

--- a/social_core/tests/backends/oauth.py
+++ b/social_core/tests/backends/oauth.py
@@ -1,5 +1,5 @@
-from urllib.parse import urlparse
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import requests
 from httpretty import HTTPretty, latest_requests
@@ -185,7 +185,7 @@ class BaseAuthUrlTestMixin:
         """
         Check the parameters in authorization url
 
-        When inserting parameters directly into AUTHORIZATION_URL, we expect the 
+        When inserting parameters directly into AUTHORIZATION_URL, we expect the
         other parameters to be added to the end of the url
         """
         original_url = (

--- a/social_core/tests/backends/oauth.py
+++ b/social_core/tests/backends/oauth.py
@@ -1,4 +1,5 @@
 from urllib.parse import urlparse
+from unittest.mock import patch
 
 import requests
 from httpretty import HTTPretty, latest_requests
@@ -176,3 +177,40 @@ class OAuth2PkceS256Test(OAuth2Test):
         )
 
         return user
+
+
+class BaseAuthUrlTestMixin:
+
+    def check_parameters_in_authorization_url(self, auth_url_key="AUTHORIZATION_URL"):
+        """
+        Check the parameters in authorization url
+
+        When inserting parameters directly into AUTHORIZATION_URL, we expect the 
+        other parameters to be added to the end of the url
+        """
+        original_url = (
+            self.backend.AUTHORIZATION_URL or self.backend.authorization_url()
+        )
+        with (
+            patch.object(
+                self.backend,
+                "authorization_url",
+                return_value=original_url + "?param1=value1&param2=value2",
+            ),
+            patch.object(
+                self.backend,
+                auth_url_key,
+                original_url + "?param1=value1&param2=value2",
+            ),
+        ):
+            # we expect an & symbol to join the different parameters
+            assert "?param1=value1&param2=value2&" in self.backend.auth_url()
+
+    def test_auth_url_parameters(self):
+        self.check_parameters_in_authorization_url()
+
+
+class OAuth1AuthUrlTestMixin(BaseAuthUrlTestMixin):
+    def test_auth_url_parameters(self):
+        self.request_token_handler()
+        self.check_parameters_in_authorization_url()

--- a/social_core/tests/backends/oauth.py
+++ b/social_core/tests/backends/oauth.py
@@ -191,20 +191,18 @@ class BaseAuthUrlTestMixin:
         original_url = (
             self.backend.AUTHORIZATION_URL or self.backend.authorization_url()
         )
-        with (
-            patch.object(
-                self.backend,
-                "authorization_url",
-                return_value=original_url + "?param1=value1&param2=value2",
-            ),
-            patch.object(
+        with patch.object(
+            self.backend,
+            "authorization_url",
+            return_value=original_url + "?param1=value1&param2=value2",
+        ):
+            with patch.object(
                 self.backend,
                 auth_url_key,
                 original_url + "?param1=value1&param2=value2",
-            ),
-        ):
-            # we expect an & symbol to join the different parameters
-            assert "?param1=value1&param2=value2&" in self.backend.auth_url()
+            ):
+                # we expect an & symbol to join the different parameters
+                assert "?param1=value1&param2=value2&" in self.backend.auth_url()
 
     def test_auth_url_parameters(self):
         self.check_parameters_in_authorization_url()

--- a/social_core/tests/backends/test_amazon.py
+++ b/social_core/tests/backends/test_amazon.py
@@ -2,7 +2,7 @@ import json
 
 from httpretty import HTTPretty
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class AmazonOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_amazon.py
+++ b/social_core/tests/backends/test_amazon.py
@@ -2,10 +2,10 @@ import json
 
 from httpretty import HTTPretty
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class AmazonOAuth2Test(OAuth2Test):
+class AmazonOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.amazon.AmazonOAuth2"
     user_data_url = "https://api.amazon.com/user/profile"
     expected_username = "FooBar"
@@ -25,7 +25,7 @@ class AmazonOAuth2Test(OAuth2Test):
         self.do_partial_pipeline()
 
 
-class AmazonOAuth2BrokenServerResponseTest(OAuth2Test):
+class AmazonOAuth2BrokenServerResponseTest(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.amazon.AmazonOAuth2"
     user_data_url = "https://www.amazon.com/ap/user/profile"
     expected_username = "FooBar"

--- a/social_core/tests/backends/test_angel.py
+++ b/social_core/tests/backends/test_angel.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class AngelOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_angel.py
+++ b/social_core/tests/backends/test_angel.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class AngelOAuth2Test(OAuth2Test):
+class AngelOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.angel.AngelOAuth2"
     user_data_url = "https://api.angel.co/1/me/"
     access_token_body = json.dumps({"access_token": "foobar", "token_type": "bearer"})

--- a/social_core/tests/backends/test_apple.py
+++ b/social_core/tests/backends/test_apple.py
@@ -1,7 +1,7 @@
 import json
 from unittest.mock import patch
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 TEST_KEY = """
 -----BEGIN EC PRIVATE KEY-----
@@ -20,7 +20,7 @@ token_data = {
 }
 
 
-class AppleIdTest(OAuth2Test):
+class AppleIdTest(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.apple.AppleIdAuth"
     user_data_url = "https://appleid.apple.com/auth/authorize/"
     id_token = "a-id-token"

--- a/social_core/tests/backends/test_apple.py
+++ b/social_core/tests/backends/test_apple.py
@@ -1,7 +1,7 @@
 import json
 from unittest.mock import patch
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 TEST_KEY = """
 -----BEGIN EC PRIVATE KEY-----

--- a/social_core/tests/backends/test_arcgis.py
+++ b/social_core/tests/backends/test_arcgis.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class ArcGISOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_arcgis.py
+++ b/social_core/tests/backends/test_arcgis.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class ArcGISOAuth2Test(OAuth2Test):
+class ArcGISOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     user_data_url = "https://www.arcgis.com/sharing/rest/community/self"
     backend_path = "social_core.backends.arcgis.ArcGISOAuth2"
     expected_username = "gis@rocks.com"

--- a/social_core/tests/backends/test_asana.py
+++ b/social_core/tests/backends/test_asana.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class AsanaOAuth2Test(OAuth2Test):
+class AsanaOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.asana.AsanaOAuth2"
     user_data_url = "https://app.asana.com/api/1.0/users/me"
     expected_username = "erlich@bachmanity.com"

--- a/social_core/tests/backends/test_asana.py
+++ b/social_core/tests/backends/test_asana.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class AsanaOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_atlassian.py
+++ b/social_core/tests/backends/test_atlassian.py
@@ -2,10 +2,10 @@ import json
 
 from httpretty import HTTPretty
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class AtlassianOAuth2Test(OAuth2Test):
+class AtlassianOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.atlassian.AtlassianOAuth2"
     tenant_url = "https://api.atlassian.com/oauth/token/accessible-resources"
     user_data_url = "https://api.atlassian.com/ex/jira/FAKED_CLOUD_ID/rest/api/2/myself"

--- a/social_core/tests/backends/test_atlassian.py
+++ b/social_core/tests/backends/test_atlassian.py
@@ -2,7 +2,7 @@ import json
 
 from httpretty import HTTPretty
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class AtlassianOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_auth0.py
+++ b/social_core/tests/backends/test_auth0.py
@@ -3,7 +3,7 @@ import json
 import jwt
 from httpretty import HTTPretty
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 JWK_KEY = {
     "kty": "RSA",
@@ -30,7 +30,7 @@ JWK_PUBLIC_KEY = {key: value for key, value in JWK_KEY.items() if key != "d"}
 DOMAIN = "foobar.auth0.com"
 
 
-class Auth0OAuth2Test(OAuth2Test):
+class Auth0OAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.auth0.Auth0OAuth2"
     access_token_body = json.dumps(
         {

--- a/social_core/tests/backends/test_auth0.py
+++ b/social_core/tests/backends/test_auth0.py
@@ -3,7 +3,7 @@ import json
 import jwt
 from httpretty import HTTPretty
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 JWK_KEY = {
     "kty": "RSA",

--- a/social_core/tests/backends/test_azuread.py
+++ b/social_core/tests/backends/test_azuread.py
@@ -26,7 +26,7 @@ SOFTWARE.
 
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class AzureADOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_azuread.py
+++ b/social_core/tests/backends/test_azuread.py
@@ -26,10 +26,10 @@ SOFTWARE.
 
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class AzureADOAuth2Test(OAuth2Test):
+class AzureADOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.azuread.AzureADOAuth2"
     user_data_url = "https://graph.windows.net/me"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_azuread_b2c.py
+++ b/social_core/tests/backends/test_azuread_b2c.py
@@ -31,7 +31,7 @@ import jwt
 from httpretty import HTTPretty
 from jwt.algorithms import RSAAlgorithm
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 # Dummy private and private keys:
 RSA_PUBLIC_JWT_KEY = {
@@ -84,7 +84,7 @@ RSA_PRIVATE_JWT_KEY = {
 }
 
 
-class AzureADB2COAuth2Test(OAuth2Test):
+class AzureADB2COAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     AUTH_KEY = "abcdef12-1234-9876-0000-abcdef098765"
     EXPIRES_IN = 3600
     AUTH_TIME = int(time())

--- a/social_core/tests/backends/test_azuread_b2c.py
+++ b/social_core/tests/backends/test_azuread_b2c.py
@@ -31,7 +31,7 @@ import jwt
 from httpretty import HTTPretty
 from jwt.algorithms import RSAAlgorithm
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 # Dummy private and private keys:
 RSA_PUBLIC_JWT_KEY = {

--- a/social_core/tests/backends/test_behance.py
+++ b/social_core/tests/backends/test_behance.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class BehanceOAuth2Test(OAuth2Test):
+class BehanceOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.behance.BehanceOAuth2"
     access_token_body = json.dumps(
         {

--- a/social_core/tests/backends/test_behance.py
+++ b/social_core/tests/backends/test_behance.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class BehanceOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_bitbucket.py
+++ b/social_core/tests/backends/test_bitbucket.py
@@ -4,7 +4,7 @@ from urllib.parse import urlencode
 from httpretty import HTTPretty
 
 from ...exceptions import AuthForbidden
-from .oauth import OAuth1Test, OAuth2Test
+from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin, OAuth2Test
 
 
 class BitbucketOAuthMixin:

--- a/social_core/tests/backends/test_bitbucket.py
+++ b/social_core/tests/backends/test_bitbucket.py
@@ -4,7 +4,7 @@ from urllib.parse import urlencode
 from httpretty import HTTPretty
 
 from ...exceptions import AuthForbidden
-from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test, OAuth2Test
+from .oauth import BaseAuthUrlTestMixin, OAuth1AuthUrlTestMixin, OAuth1Test, OAuth2Test
 
 
 class BitbucketOAuthMixin:
@@ -72,7 +72,7 @@ class BitbucketOAuthMixin:
     )
 
 
-class BitbucketOAuth1Test(BitbucketOAuthMixin, OAuth1Test):
+class BitbucketOAuth1Test(BitbucketOAuthMixin, OAuth1Test, OAuth1AuthUrlTestMixin):
     backend_path = "social_core.backends.bitbucket.BitbucketOAuth"
 
     request_token_body = urlencode(
@@ -131,7 +131,7 @@ class BitbucketOAuth1FailTest(BitbucketOAuth1Test):
             super().test_partial_pipeline()
 
 
-class BitbucketOAuth2Test(BitbucketOAuthMixin, OAuth2Test):
+class BitbucketOAuth2Test(BitbucketOAuthMixin, OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.bitbucket.BitbucketOAuth2"
 
     access_token_body = json.dumps(

--- a/social_core/tests/backends/test_bitbucket.py
+++ b/social_core/tests/backends/test_bitbucket.py
@@ -4,7 +4,7 @@ from urllib.parse import urlencode
 from httpretty import HTTPretty
 
 from ...exceptions import AuthForbidden
-from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin, OAuth2Test
+from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test, OAuth2Test
 
 
 class BitbucketOAuthMixin:

--- a/social_core/tests/backends/test_box.py
+++ b/social_core/tests/backends/test_box.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class BoxOAuth2Test(OAuth2Test):
+class BoxOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.box.BoxOAuth2"
     user_data_url = "https://api.box.com/2.0/users/me"
     expected_username = "sean+awesome@box.com"

--- a/social_core/tests/backends/test_box.py
+++ b/social_core/tests/backends/test_box.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class BoxOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_cas.py
+++ b/social_core/tests/backends/test_cas.py
@@ -2,7 +2,7 @@ import json
 
 from httpretty import HTTPretty
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 ROOT_URL = "https://cas.example.net/"

--- a/social_core/tests/backends/test_cas.py
+++ b/social_core/tests/backends/test_cas.py
@@ -8,7 +8,7 @@ from .test_open_id_connect import OpenIdConnectTestMixin
 ROOT_URL = "https://cas.example.net/"
 
 
-class CASOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test):
+class CASOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.cas.CASOpenIdConnectAuth"
     issuer = f"{ROOT_URL}oidc"
     openid_config_body = json.dumps(

--- a/social_core/tests/backends/test_cas.py
+++ b/social_core/tests/backends/test_cas.py
@@ -2,7 +2,7 @@ import json
 
 from httpretty import HTTPretty
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 ROOT_URL = "https://cas.example.net/"

--- a/social_core/tests/backends/test_chatwork.py
+++ b/social_core/tests/backends/test_chatwork.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class ChatworkOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_chatwork.py
+++ b/social_core/tests/backends/test_chatwork.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class ChatworkOAuth2Test(OAuth2Test):
+class ChatworkOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.chatwork.ChatworkOAuth2"
     user_data_url = "https://api.chatwork.com/v2/me"
     expected_username = "hogehoge"

--- a/social_core/tests/backends/test_cilogon.py
+++ b/social_core/tests/backends/test_cilogon.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class CILogonOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_cilogon.py
+++ b/social_core/tests/backends/test_cilogon.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class CILogonOAuth2Test(OAuth2Test):
+class CILogonOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.cilogon.CILogonOAuth2"
     user_data_url = "https://cilogon.org/oauth2/userinfo"
     user_data_url_post = True

--- a/social_core/tests/backends/test_clef.py
+++ b/social_core/tests/backends/test_clef.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class ClefOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_clef.py
+++ b/social_core/tests/backends/test_clef.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class ClefOAuth2Test(OAuth2Test):
+class ClefOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.clef.ClefOAuth2"
     user_data_url = "https://clef.io/api/v1/info"
     expected_username = "test"

--- a/social_core/tests/backends/test_cognito.py
+++ b/social_core/tests/backends/test_cognito.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class CognitoAuth2Test(OAuth2Test):
+class CognitoAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.cognito.CognitoOAuth2"
     pool_domain = "https://social_core.auth.eu-west-1.amazoncognito.com"
     expected_username = "cognito.account.ABCDE1234"

--- a/social_core/tests/backends/test_cognito.py
+++ b/social_core/tests/backends/test_cognito.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class CognitoAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_coinbase.py
+++ b/social_core/tests/backends/test_coinbase.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class CoinbaseOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_coinbase.py
+++ b/social_core/tests/backends/test_coinbase.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class CoinbaseOAuth2Test(OAuth2Test):
+class CoinbaseOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.coinbase.CoinbaseOAuth2"
     user_data_url = "https://api.coinbase.com/v2/user"
     expected_username = "satoshi_nakomoto"

--- a/social_core/tests/backends/test_coursera.py
+++ b/social_core/tests/backends/test_coursera.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class CourseraOAuth2Test(OAuth2Test):
+class CourseraOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.coursera.CourseraOAuth2"
     user_data_url = "https://api.coursera.org/api/externalBasicProfiles.v1?q=me"
     expected_username = "560e7ed2076e0d589e88bd74b6aad4b7"

--- a/social_core/tests/backends/test_coursera.py
+++ b/social_core/tests/backends/test_coursera.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class CourseraOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_dailymotion.py
+++ b/social_core/tests/backends/test_dailymotion.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class DailymotionOAuth2Test(OAuth2Test):
+class DailymotionOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.dailymotion.DailymotionOAuth2"
     user_data_url = "https://api.dailymotion.com/auth/"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_dailymotion.py
+++ b/social_core/tests/backends/test_dailymotion.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class DailymotionOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_deezer.py
+++ b/social_core/tests/backends/test_deezer.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class DeezerOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_deezer.py
+++ b/social_core/tests/backends/test_deezer.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class DeezerOAuth2Test(OAuth2Test):
+class DeezerOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.deezer.DeezerOAuth2"
     user_data_url = "http://api.deezer.com/user/me"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_digitalocean.py
+++ b/social_core/tests/backends/test_digitalocean.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class DigitalOceanOAuthTest(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_digitalocean.py
+++ b/social_core/tests/backends/test_digitalocean.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class DigitalOceanOAuthTest(OAuth2Test):
+class DigitalOceanOAuthTest(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.digitalocean.DigitalOceanOAuth"
     user_data_url = "https://api.digitalocean.com/v2/account"
     expected_username = "sammy@digitalocean.com"

--- a/social_core/tests/backends/test_discogs.py
+++ b/social_core/tests/backends/test_discogs.py
@@ -3,7 +3,7 @@ from urllib.parse import urlencode
 
 from httpretty import HTTPretty
 
-from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
+from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test
 
 
 class DiscsogsOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):

--- a/social_core/tests/backends/test_discogs.py
+++ b/social_core/tests/backends/test_discogs.py
@@ -3,10 +3,10 @@ from urllib.parse import urlencode
 
 from httpretty import HTTPretty
 
-from .oauth import OAuth1Test
+from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
 
 
-class DiscsogsOAuth1Test(OAuth1Test):
+class DiscsogsOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):
     _test_token = "lalala123boink"
     backend_path = "social_core.backends.discogs.DiscogsOAuth1"
     expected_username = "rodneyfool"

--- a/social_core/tests/backends/test_disqus.py
+++ b/social_core/tests/backends/test_disqus.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class DisqusOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_disqus.py
+++ b/social_core/tests/backends/test_disqus.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class DisqusOAuth2Test(OAuth2Test):
+class DisqusOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.disqus.DisqusOAuth2"
     user_data_url = "https://disqus.com/api/3.0/users/details.json"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_dribbble.py
+++ b/social_core/tests/backends/test_dribbble.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class DribbbleOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_dribbble.py
+++ b/social_core/tests/backends/test_dribbble.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class DribbbleOAuth2Test(OAuth2Test):
+class DribbbleOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.dribbble.DribbbleOAuth2"
     user_data_url = "https://api.dribbble.com/v1/user"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_drip.py
+++ b/social_core/tests/backends/test_drip.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class DripOAuthTest(OAuth2Test):
+class DripOAuthTest(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.drip.DripOAuth"
     user_data_url = "https://api.getdrip.com/v2/user"
     expected_username = "other@example.com"

--- a/social_core/tests/backends/test_drip.py
+++ b/social_core/tests/backends/test_drip.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class DripOAuthTest(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_dropbox.py
+++ b/social_core/tests/backends/test_dropbox.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class DropboxOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_dropbox.py
+++ b/social_core/tests/backends/test_dropbox.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class DropboxOAuth2Test(OAuth2Test):
+class DropboxOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.dropbox.DropboxOAuth2V2"
     user_data_url = "https://api.dropboxapi.com/2/users/get_current_account"
     user_data_url_post = True

--- a/social_core/tests/backends/test_dummy.py
+++ b/social_core/tests/backends/test_dummy.py
@@ -8,7 +8,7 @@ from ...actions import do_disconnect
 from ...backends.oauth import BaseOAuth2
 from ...exceptions import AuthForbidden
 from ..models import User
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
 class DummyOAuth2(BaseOAuth2):
@@ -40,7 +40,7 @@ class Dummy2OAuth2(DummyOAuth2):
     GET_ALL_EXTRA_DATA = True
 
 
-class DummyOAuth2Test(OAuth2Test):
+class DummyOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.tests.backends.test_dummy.DummyOAuth2"
     user_data_url = "http://dummy.com/user"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_dummy.py
+++ b/social_core/tests/backends/test_dummy.py
@@ -8,7 +8,7 @@ from ...actions import do_disconnect
 from ...backends.oauth import BaseOAuth2
 from ...exceptions import AuthForbidden
 from ..models import User
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class DummyOAuth2(BaseOAuth2):

--- a/social_core/tests/backends/test_edmodo.py
+++ b/social_core/tests/backends/test_edmodo.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class EdmodoOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_edmodo.py
+++ b/social_core/tests/backends/test_edmodo.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class EdmodoOAuth2Test(OAuth2Test):
+class EdmodoOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.edmodo.EdmodoOAuth2"
     user_data_url = "https://api.edmodo.com/users/me"
     expected_username = "foobar12345"

--- a/social_core/tests/backends/test_egi_checkin.py
+++ b/social_core/tests/backends/test_egi_checkin.py
@@ -2,7 +2,9 @@ from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 
-class EGICheckinOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test):
+class EGICheckinOpenIdConnectTest(
+    OpenIdConnectTestMixin, OAuth2Test, BaseAuthUrlTestMixin
+):
     backend_path = "social_core.backends.egi_checkin.EGICheckinOpenIdConnect"
     issuer = "https://aai.egi.eu/auth/realms/egi"
     openid_config_body = """

--- a/social_core/tests/backends/test_egi_checkin.py
+++ b/social_core/tests/backends/test_egi_checkin.py
@@ -1,4 +1,4 @@
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 

--- a/social_core/tests/backends/test_egi_checkin.py
+++ b/social_core/tests/backends/test_egi_checkin.py
@@ -1,4 +1,4 @@
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 

--- a/social_core/tests/backends/test_einfracz.py
+++ b/social_core/tests/backends/test_einfracz.py
@@ -1,4 +1,4 @@
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 

--- a/social_core/tests/backends/test_einfracz.py
+++ b/social_core/tests/backends/test_einfracz.py
@@ -1,4 +1,4 @@
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 

--- a/social_core/tests/backends/test_einfracz.py
+++ b/social_core/tests/backends/test_einfracz.py
@@ -2,7 +2,9 @@ from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 
-class EInfraCZOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test):
+class EInfraCZOpenIdConnectTest(
+    OpenIdConnectTestMixin, OAuth2Test, BaseAuthUrlTestMixin
+):
     backend_path = "social_core.backends.einfracz.EInfraCZOpenIdConnect"
     issuer = "https://login.e-infra.cz/oidc/"
     openid_config_body = """

--- a/social_core/tests/backends/test_elixir.py
+++ b/social_core/tests/backends/test_elixir.py
@@ -2,7 +2,7 @@ from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 
-class ElixirOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test):
+class ElixirOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.elixir.ElixirOpenIdConnect"
     issuer = "https://login.elixir-czech.org/oidc/"
     openid_config_body = """

--- a/social_core/tests/backends/test_elixir.py
+++ b/social_core/tests/backends/test_elixir.py
@@ -1,4 +1,4 @@
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 

--- a/social_core/tests/backends/test_elixir.py
+++ b/social_core/tests/backends/test_elixir.py
@@ -1,4 +1,4 @@
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 

--- a/social_core/tests/backends/test_eventbrite.py
+++ b/social_core/tests/backends/test_eventbrite.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class EventbriteAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_eventbrite.py
+++ b/social_core/tests/backends/test_eventbrite.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class EventbriteAuth2Test(OAuth2Test):
+class EventbriteAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.eventbrite.EventbriteOAuth2"
     user_data_url = "https://www.eventbriteapi.com/v3/users/me"
     expected_username = "sean+awesome@eventbrite.com"

--- a/social_core/tests/backends/test_evernote.py
+++ b/social_core/tests/backends/test_evernote.py
@@ -3,7 +3,7 @@ from urllib.parse import urlencode
 from requests import HTTPError
 
 from ...exceptions import AuthCanceled
-from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
+from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test
 
 
 class EvernoteOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):

--- a/social_core/tests/backends/test_evernote.py
+++ b/social_core/tests/backends/test_evernote.py
@@ -3,10 +3,10 @@ from urllib.parse import urlencode
 from requests import HTTPError
 
 from ...exceptions import AuthCanceled
-from .oauth import OAuth1Test
+from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
 
 
-class EvernoteOAuth1Test(OAuth1Test):
+class EvernoteOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):
     backend_path = "social_core.backends.evernote.EvernoteOAuth"
     expected_username = "101010"
     access_token_body = urlencode(

--- a/social_core/tests/backends/test_facebook.py
+++ b/social_core/tests/backends/test_facebook.py
@@ -2,11 +2,11 @@ import json
 
 from ...backends.facebook import API_VERSION
 from ...exceptions import AuthCanceled, AuthUnknownError
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 
-class FacebookOAuth2Test(OAuth2Test):
+class FacebookOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.facebook.FacebookOAuth2"
     user_data_url = "https://graph.facebook.com/v{version}/me".format(
         version=API_VERSION

--- a/social_core/tests/backends/test_facebook.py
+++ b/social_core/tests/backends/test_facebook.py
@@ -2,7 +2,7 @@ import json
 
 from ...backends.facebook import API_VERSION
 from ...exceptions import AuthCanceled, AuthUnknownError
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 

--- a/social_core/tests/backends/test_fence.py
+++ b/social_core/tests/backends/test_fence.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 

--- a/social_core/tests/backends/test_fence.py
+++ b/social_core/tests/backends/test_fence.py
@@ -4,7 +4,7 @@ from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 
-class FenceOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test):
+class FenceOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.fence.Fence"
     issuer = "https://nci-crdc.datacommons.io/"
     openid_config_body = json.dumps(

--- a/social_core/tests/backends/test_fence.py
+++ b/social_core/tests/backends/test_fence.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 

--- a/social_core/tests/backends/test_fitbit.py
+++ b/social_core/tests/backends/test_fitbit.py
@@ -1,10 +1,10 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test
+from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
 
 
-class FitbitOAuth1Test(OAuth1Test):
+class FitbitOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):
     backend_path = "social_core.backends.fitbit.FitbitOAuth1"
     expected_username = "foobar"
     access_token_body = urlencode(

--- a/social_core/tests/backends/test_fitbit.py
+++ b/social_core/tests/backends/test_fitbit.py
@@ -1,7 +1,7 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
+from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test
 
 
 class FitbitOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):

--- a/social_core/tests/backends/test_five_hundred_px.py
+++ b/social_core/tests/backends/test_five_hundred_px.py
@@ -1,10 +1,10 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test
+from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
 
 
-class FiveHundredPxOAuth1Test(OAuth1Test):
+class FiveHundredPxOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):
     backend_path = "social_core.backends.five_hundred_px.FiveHundredPxOAuth"
     user_data_url = "https://api.500px.com/v1/users"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_five_hundred_px.py
+++ b/social_core/tests/backends/test_five_hundred_px.py
@@ -1,7 +1,7 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
+from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test
 
 
 class FiveHundredPxOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):

--- a/social_core/tests/backends/test_flat.py
+++ b/social_core/tests/backends/test_flat.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class FlatOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_flat.py
+++ b/social_core/tests/backends/test_flat.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class FlatOAuth2Test(OAuth2Test):
+class FlatOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.flat.FlatOAuth2"
     user_data_url = "https://api.flat.io/v2/me"
     expected_username = "vincent"

--- a/social_core/tests/backends/test_flickr.py
+++ b/social_core/tests/backends/test_flickr.py
@@ -1,9 +1,9 @@
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test
+from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
 
 
-class FlickrOAuth1Test(OAuth1Test):
+class FlickrOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):
     backend_path = "social_core.backends.flickr.FlickrOAuth"
     expected_username = "foobar"
     access_token_body = urlencode(

--- a/social_core/tests/backends/test_flickr.py
+++ b/social_core/tests/backends/test_flickr.py
@@ -1,6 +1,6 @@
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
+from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test
 
 
 class FlickrOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):

--- a/social_core/tests/backends/test_foursquare.py
+++ b/social_core/tests/backends/test_foursquare.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class FoursquareOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_foursquare.py
+++ b/social_core/tests/backends/test_foursquare.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class FoursquareOAuth2Test(OAuth2Test):
+class FoursquareOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.foursquare.FoursquareOAuth2"
     user_data_url = "https://api.foursquare.com/v2/users/self"
     expected_username = "FooBar"

--- a/social_core/tests/backends/test_gitea.py
+++ b/social_core/tests/backends/test_gitea.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class GiteaOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_gitea.py
+++ b/social_core/tests/backends/test_gitea.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class GiteaOAuth2Test(OAuth2Test):
+class GiteaOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.gitea.GiteaOAuth2"
     user_data_url = "https://gitea.com/api/v1/user"
     expected_username = "foobar"
@@ -38,7 +38,7 @@ class GiteaOAuth2Test(OAuth2Test):
         self.do_partial_pipeline()
 
 
-class GiteaCustomDomainOAuth2Test(OAuth2Test):
+class GiteaCustomDomainOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.gitea.GiteaOAuth2"
     user_data_url = "https://example.com/api/v1/user"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_github.py
+++ b/social_core/tests/backends/test_github.py
@@ -3,10 +3,10 @@ import json
 from httpretty import HTTPretty
 
 from ...exceptions import AuthFailed
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class GithubOAuth2Test(OAuth2Test):
+class GithubOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.github.GithubOAuth2"
     user_data_url = "https://api.github.com/user"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_github.py
+++ b/social_core/tests/backends/test_github.py
@@ -3,7 +3,7 @@ import json
 from httpretty import HTTPretty
 
 from ...exceptions import AuthFailed
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class GithubOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_github_enterprise.py
+++ b/social_core/tests/backends/test_github_enterprise.py
@@ -3,7 +3,7 @@ import json
 from httpretty import HTTPretty
 
 from ...exceptions import AuthFailed
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class GithubEnterpriseOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_github_enterprise.py
+++ b/social_core/tests/backends/test_github_enterprise.py
@@ -3,10 +3,10 @@ import json
 from httpretty import HTTPretty
 
 from ...exceptions import AuthFailed
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class GithubEnterpriseOAuth2Test(OAuth2Test):
+class GithubEnterpriseOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.github_enterprise.GithubEnterpriseOAuth2"
     user_data_url = "https://www.example.com/api/v3/user"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_gitlab.py
+++ b/social_core/tests/backends/test_gitlab.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class GitLabOAuth2Test(OAuth2Test):
+class GitLabOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.gitlab.GitLabOAuth2"
     user_data_url = "https://gitlab.com/api/v4/user"
     expected_username = "foobar"
@@ -54,7 +54,7 @@ class GitLabOAuth2Test(OAuth2Test):
         self.do_partial_pipeline()
 
 
-class GitLabCustomDomainOAuth2Test(OAuth2Test):
+class GitLabCustomDomainOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.gitlab.GitLabOAuth2"
     user_data_url = "https://example.com/api/v4/user"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_gitlab.py
+++ b/social_core/tests/backends/test_gitlab.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class GitLabOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_globus.py
+++ b/social_core/tests/backends/test_globus.py
@@ -4,7 +4,7 @@ from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 
-class GlobusOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test):
+class GlobusOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.globus.GlobusOpenIdConnect"
     issuer = "https://auth.globus.org"
     openid_config_body = json.dumps(

--- a/social_core/tests/backends/test_globus.py
+++ b/social_core/tests/backends/test_globus.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 

--- a/social_core/tests/backends/test_globus.py
+++ b/social_core/tests/backends/test_globus.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 

--- a/social_core/tests/backends/test_google.py
+++ b/social_core/tests/backends/test_google.py
@@ -5,7 +5,7 @@ from httpretty import HTTPretty
 
 from ...actions import do_disconnect
 from ..models import User
-from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin, OAuth2Test
+from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 

--- a/social_core/tests/backends/test_google.py
+++ b/social_core/tests/backends/test_google.py
@@ -5,11 +5,11 @@ from httpretty import HTTPretty
 
 from ...actions import do_disconnect
 from ..models import User
-from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test, OAuth2Test
+from .oauth import BaseAuthUrlTestMixin, OAuth1AuthUrlTestMixin, OAuth1Test, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 
-class GoogleOAuth2Test(OAuth2Test, AuthUrlTestMixin):
+class GoogleOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.google.GoogleOAuth2"
     user_data_url = "https://www.googleapis.com/oauth2/v3/userinfo"
     expected_username = "foo"

--- a/social_core/tests/backends/test_google.py
+++ b/social_core/tests/backends/test_google.py
@@ -5,11 +5,11 @@ from httpretty import HTTPretty
 
 from ...actions import do_disconnect
 from ..models import User
-from .oauth import OAuth1Test, OAuth2Test
+from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 
-class GoogleOAuth2Test(OAuth2Test):
+class GoogleOAuth2Test(OAuth2Test, AuthUrlTestMixin):
     backend_path = "social_core.backends.google.GoogleOAuth2"
     user_data_url = "https://www.googleapis.com/oauth2/v3/userinfo"
     expected_username = "foo"
@@ -52,7 +52,7 @@ class GoogleOAuth2Test(OAuth2Test):
         self.do_login()
 
 
-class GoogleOAuth1Test(OAuth1Test):
+class GoogleOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):
     backend_path = "social_core.backends.google.GoogleOAuth"
     user_data_url = "https://www.googleapis.com/userinfo/email"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_grafana.py
+++ b/social_core/tests/backends/test_grafana.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class GrafanaOAuth2Test(OAuth2Test):
+class GrafanaOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.grafana.GrafanaOAuth2"
     user_data_url = "https://grafana.com/api/oauth2/user"
     access_token_body = json.dumps(

--- a/social_core/tests/backends/test_grafana.py
+++ b/social_core/tests/backends/test_grafana.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class GrafanaOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_instagram.py
+++ b/social_core/tests/backends/test_instagram.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class InstagramOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_instagram.py
+++ b/social_core/tests/backends/test_instagram.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class InstagramOAuth2Test(OAuth2Test):
+class InstagramOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.instagram.InstagramOAuth2"
     user_data_url = "https://graph.instagram.com/me"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_itembase.py
+++ b/social_core/tests/backends/test_itembase.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class ItembaseOAuth2Test(OAuth2Test):
+class ItembaseOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.itembase.ItembaseOAuth2"
     user_data_url = "https://users.itembase.com/v1/me"
     expected_username = "foobar"
@@ -46,6 +46,6 @@ class ItembaseOAuth2Test(OAuth2Test):
         self.do_partial_pipeline()
 
 
-class ItembaseOAuth2SandboxTest(OAuth2Test):
+class ItembaseOAuth2SandboxTest(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.itembase.ItembaseOAuth2Sandbox"
     user_data_url = "http://sandbox.users.itembase.io/v1/me"

--- a/social_core/tests/backends/test_itembase.py
+++ b/social_core/tests/backends/test_itembase.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class ItembaseOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_kakao.py
+++ b/social_core/tests/backends/test_kakao.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class KakaoOAuth2Test(OAuth2Test):
+class KakaoOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.kakao.KakaoOAuth2"
     user_data_url = "https://kapi.kakao.com/v2/user/me"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_kakao.py
+++ b/social_core/tests/backends/test_kakao.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class KakaoOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_keycloak.py
+++ b/social_core/tests/backends/test_keycloak.py
@@ -3,7 +3,7 @@ import time
 
 import jwt
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 _PRIVATE_KEY_HEADERLESS = """
 MIIEowIBAAKCAQEAvyo2hx1L3ALHeUd/6xk/lIhTyZ/HJZ+Sss/ge6T6gPdES4Dw

--- a/social_core/tests/backends/test_keycloak.py
+++ b/social_core/tests/backends/test_keycloak.py
@@ -3,7 +3,7 @@ import time
 
 import jwt
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 _PRIVATE_KEY_HEADERLESS = """
 MIIEowIBAAKCAQEAvyo2hx1L3ALHeUd/6xk/lIhTyZ/HJZ+Sss/ge6T6gPdES4Dw
@@ -93,7 +93,7 @@ def _decode(token, key=_PUBLIC_KEY, algorithms=[_ALGORITHM], audience=_KEY):
     return jwt.decode(token, key=key, algorithms=algorithms, audience=audience)
 
 
-class KeycloakOAuth2Test(OAuth2Test):
+class KeycloakOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.keycloak.KeycloakOAuth2"
     expected_username = "john.doe"
     access_token_body = json.dumps(

--- a/social_core/tests/backends/test_linkedin.py
+++ b/social_core/tests/backends/test_linkedin.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 

--- a/social_core/tests/backends/test_linkedin.py
+++ b/social_core/tests/backends/test_linkedin.py
@@ -4,7 +4,9 @@ from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 
-class LinkedinOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test):
+class LinkedinOpenIdConnectTest(
+    OpenIdConnectTestMixin, OAuth2Test, BaseAuthUrlTestMixin
+):
     backend_path = "social_core.backends.linkedin.LinkedinOpenIdConnect"
     user_data_url = "https://api.linkedin.com/v2/userinfo"
     issuer = "https://www.linkedin.com"

--- a/social_core/tests/backends/test_linkedin.py
+++ b/social_core/tests/backends/test_linkedin.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 

--- a/social_core/tests/backends/test_live.py
+++ b/social_core/tests/backends/test_live.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class LiveOAuth2Test(OAuth2Test):
+class LiveOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.live.LiveOAuth2"
     user_data_url = "https://apis.live.net/v5.0/me"
     expected_username = "FooBar"

--- a/social_core/tests/backends/test_live.py
+++ b/social_core/tests/backends/test_live.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class LiveOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_lyft.py
+++ b/social_core/tests/backends/test_lyft.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class LyftOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_lyft.py
+++ b/social_core/tests/backends/test_lyft.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class LyftOAuth2Test(OAuth2Test):
+class LyftOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.lyft.LyftOAuth2"
     user_data_url = "https://api.lyft.com/v1/profile"
     access_token_body = json.dumps(

--- a/social_core/tests/backends/test_mailru.py
+++ b/social_core/tests/backends/test_mailru.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class MRGOAuth2Test(OAuth2Test):
+class MRGOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.mailru.MRGOAuth2"
     user_data_url = "https://oauth.mail.ru/userinfo"
     expected_username = "FooBar"

--- a/social_core/tests/backends/test_mailru.py
+++ b/social_core/tests/backends/test_mailru.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class MRGOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_mapmyfitness.py
+++ b/social_core/tests/backends/test_mapmyfitness.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class MapMyFitnessOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_mapmyfitness.py
+++ b/social_core/tests/backends/test_mapmyfitness.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class MapMyFitnessOAuth2Test(OAuth2Test):
+class MapMyFitnessOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.mapmyfitness.MapMyFitnessOAuth2"
     user_data_url = "https://oauth2-api.mapmyapi.com/v7.0/user/self/"
     expected_username = "FredFlinstone"

--- a/social_core/tests/backends/test_microsoft.py
+++ b/social_core/tests/backends/test_microsoft.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class MicrosoftOAuth2Test(OAuth2Test):
+class MicrosoftOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.microsoft.MicrosoftOAuth2"
     user_data_url = "https://graph.microsoft.com/v1.0/me"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_microsoft.py
+++ b/social_core/tests/backends/test_microsoft.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class MicrosoftOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_mineid.py
+++ b/social_core/tests/backends/test_mineid.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class MineIDOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_mineid.py
+++ b/social_core/tests/backends/test_mineid.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class MineIDOAuth2Test(OAuth2Test):
+class MineIDOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.mineid.MineIDOAuth2"
     user_data_url = "https://www.mineid.org/api/user"
     expected_username = "foo@bar.com"
@@ -20,3 +20,6 @@ class MineIDOAuth2Test(OAuth2Test):
 
     def test_partial_pipeline(self):
         self.do_partial_pipeline()
+
+    def test_auth_url_parameters(self):
+        self.check_parameters_in_authorization_url("_AUTHORIZATION_URL")

--- a/social_core/tests/backends/test_mixcloud.py
+++ b/social_core/tests/backends/test_mixcloud.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class MixcloudOAuth2Test(OAuth2Test):
+class MixcloudOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.mixcloud.MixcloudOAuth2"
     user_data_url = "https://api.mixcloud.com/me/"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_mixcloud.py
+++ b/social_core/tests/backends/test_mixcloud.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class MixcloudOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_musicbrainz.py
+++ b/social_core/tests/backends/test_musicbrainz.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class MusicBrainzAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_musicbrainz.py
+++ b/social_core/tests/backends/test_musicbrainz.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class MusicBrainzAuth2Test(OAuth2Test):
+class MusicBrainzAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.musicbrainz.MusicBrainzOAuth2"
     user_data_url = "https://musicbrainz.org/oauth2/userinfo"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_nationbuilder.py
+++ b/social_core/tests/backends/test_nationbuilder.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class NationBuilderOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_nationbuilder.py
+++ b/social_core/tests/backends/test_nationbuilder.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class NationBuilderOAuth2Test(OAuth2Test):
+class NationBuilderOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.nationbuilder.NationBuilderOAuth2"
     user_data_url = "https://foobar.nationbuilder.com/api/v1/people/me"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_naver.py
+++ b/social_core/tests/backends/test_naver.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class NaverOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_naver.py
+++ b/social_core/tests/backends/test_naver.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class NaverOAuth2Test(OAuth2Test):
+class NaverOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.naver.NaverOAuth2"
     user_data_url = "https://openapi.naver.com/v1/nid/me"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_okta.py
+++ b/social_core/tests/backends/test_okta.py
@@ -2,7 +2,7 @@ import json
 
 from httpretty import HTTPretty
 
-from social_core.tests.backends.oauth import OAuth2Test, BaseAuthUrlTestMixin
+from social_core.tests.backends.oauth import BaseAuthUrlTestMixin, OAuth2Test
 from social_core.tests.backends.test_open_id_connect import OpenIdConnectTestMixin
 
 JWK_KEY = {

--- a/social_core/tests/backends/test_okta.py
+++ b/social_core/tests/backends/test_okta.py
@@ -2,7 +2,7 @@ import json
 
 from httpretty import HTTPretty
 
-from social_core.tests.backends.oauth import OAuth2Test
+from social_core.tests.backends.oauth import OAuth2Test, BaseAuthUrlTestMixin
 from social_core.tests.backends.test_open_id_connect import OpenIdConnectTestMixin
 
 JWK_KEY = {
@@ -28,7 +28,7 @@ JWK_KEY = {
 JWK_PUBLIC_KEY = {key: value for key, value in JWK_KEY.items() if key != "d"}
 
 
-class OktaOAuth2Test(OAuth2Test):
+class OktaOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.okta.OktaOAuth2"
     user_data_url = "https://dev-000000.oktapreview.com/oauth2/v1/userinfo"
     expected_username = "foo"

--- a/social_core/tests/backends/test_open_id_connect.py
+++ b/social_core/tests/backends/test_open_id_connect.py
@@ -227,7 +227,7 @@ class OpenIdConnectTestMixin:
         )
 
 
-class BaseOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test):
+class BaseOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.open_id_connect.OpenIdConnectAuth"
     issuer = "https://example.com"
     openid_config_body = json.dumps(

--- a/social_core/tests/backends/test_open_id_connect.py
+++ b/social_core/tests/backends/test_open_id_connect.py
@@ -13,7 +13,7 @@ from social_core.backends.open_id_connect import OpenIdConnectAuth
 
 from ...exceptions import AuthTokenError
 from ...utils import parse_qs
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 sys.path.insert(0, "..")
 

--- a/social_core/tests/backends/test_open_id_connect.py
+++ b/social_core/tests/backends/test_open_id_connect.py
@@ -13,7 +13,7 @@ from social_core.backends.open_id_connect import OpenIdConnectAuth
 
 from ...exceptions import AuthTokenError
 from ...utils import parse_qs
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 sys.path.insert(0, "..")
 

--- a/social_core/tests/backends/test_openstreetmap_oauth2.py
+++ b/social_core/tests/backends/test_openstreetmap_oauth2.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class OpenStreetMapOAuth2Test(OAuth2Test):
+class OpenStreetMapOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.openstreetmap_oauth2.OpenStreetMapOAuth2"
     user_data_url = "https://api.openstreetmap.org/api/0.6/user/details.json"
     expected_username = "Steve"

--- a/social_core/tests/backends/test_openstreetmap_oauth2.py
+++ b/social_core/tests/backends/test_openstreetmap_oauth2.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class OpenStreetMapOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_orbi.py
+++ b/social_core/tests/backends/test_orbi.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class OrbiOAuth2Test(OAuth2Test):
+class OrbiOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.orbi.OrbiOAuth2"
     user_data_url = "https://login.orbi.kr/oauth/user/get"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_orbi.py
+++ b/social_core/tests/backends/test_orbi.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class OrbiOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_orcid.py
+++ b/social_core/tests/backends/test_orcid.py
@@ -2,7 +2,7 @@ import json
 
 from social_core.backends.orcid import ORCIDOAuth2
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class ORCIDOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_orcid.py
+++ b/social_core/tests/backends/test_orcid.py
@@ -2,10 +2,10 @@ import json
 
 from social_core.backends.orcid import ORCIDOAuth2
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class ORCIDOAuth2Test(OAuth2Test):
+class ORCIDOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.orcid.ORCIDOAuth2"
     user_data_url = ORCIDOAuth2.USER_ID_URL
     expected_username = "0000-0002-2601-8132"

--- a/social_core/tests/backends/test_osso.py
+++ b/social_core/tests/backends/test_osso.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class OssoOAuth2Test(OAuth2Test):
+class OssoOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.osso.OssoOAuth2"
     user_data_url = "https://demo.ossoapp.com/oauth/me"
     expected_username = "user@example.com"

--- a/social_core/tests/backends/test_osso.py
+++ b/social_core/tests/backends/test_osso.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class OssoOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_patreon.py
+++ b/social_core/tests/backends/test_patreon.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class PatreonOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_patreon.py
+++ b/social_core/tests/backends/test_patreon.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class PatreonOAuth2Test(OAuth2Test):
+class PatreonOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.patreon.PatreonOAuth2"
     user_data_url = (
         "https://www.patreon.com/api/oauth2/v2/identity?"

--- a/social_core/tests/backends/test_paypal.py
+++ b/social_core/tests/backends/test_paypal.py
@@ -2,7 +2,7 @@ import json
 
 from social_core.backends.paypal import PayPalOAuth2
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class PayPalOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_paypal.py
+++ b/social_core/tests/backends/test_paypal.py
@@ -2,10 +2,10 @@ import json
 
 from social_core.backends.paypal import PayPalOAuth2
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class PayPalOAuth2Test(OAuth2Test):
+class PayPalOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.paypal.PayPalOAuth2"
     user_data_url = (
         "https://api.paypal.com/v1/identity/oauth2/userinfo?schema=paypalv1.1"

--- a/social_core/tests/backends/test_phabricator.py
+++ b/social_core/tests/backends/test_phabricator.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class PhabricatorOAuth2Test(OAuth2Test):
+class PhabricatorOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.phabricator.PhabricatorOAuth2"
     user_data_url = "https://secure.phabricator.com/api/user.whoami"
     expected_username = "user"
@@ -37,7 +37,7 @@ class PhabricatorOAuth2Test(OAuth2Test):
         self.do_partial_pipeline()
 
 
-class PhabricatorCustomDomainOAuth2Test(OAuth2Test):
+class PhabricatorCustomDomainOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.phabricator.PhabricatorOAuth2"
     user_data_url = "https://example.com/api/user.whoami"
     expected_username = "user"

--- a/social_core/tests/backends/test_phabricator.py
+++ b/social_core/tests/backends/test_phabricator.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class PhabricatorOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_pinterest.py
+++ b/social_core/tests/backends/test_pinterest.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class PinterestOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_pinterest.py
+++ b/social_core/tests/backends/test_pinterest.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class PinterestOAuth2Test(OAuth2Test):
+class PinterestOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.pinterest.PinterestOAuth2"
     user_data_url = "https://api.pinterest.com/v1/me/"
     expected_username = "foobar"
@@ -24,7 +24,7 @@ class PinterestOAuth2Test(OAuth2Test):
         self.do_partial_pipeline()
 
 
-class PinterestOAuth2BrokenServerResponseTest(OAuth2Test):
+class PinterestOAuth2BrokenServerResponseTest(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.pinterest.PinterestOAuth2"
     user_data_url = "https://api.pinterest.com/v1/me/"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_podio.py
+++ b/social_core/tests/backends/test_podio.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class PodioOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_podio.py
+++ b/social_core/tests/backends/test_podio.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class PodioOAuth2Test(OAuth2Test):
+class PodioOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.podio.PodioOAuth2"
     user_data_url = "https://api.podio.com/user/status"
     expected_username = "user_1010101010"

--- a/social_core/tests/backends/test_qiita.py
+++ b/social_core/tests/backends/test_qiita.py
@@ -2,7 +2,7 @@ import json
 
 from social_core.exceptions import AuthException
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class QiitaOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_qiita.py
+++ b/social_core/tests/backends/test_qiita.py
@@ -2,10 +2,10 @@ import json
 
 from social_core.exceptions import AuthException
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class QiitaOAuth2Test(OAuth2Test):
+class QiitaOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.qiita.QiitaOAuth2"
     user_data_url = "https://qiita.com/api/v2/authenticated_user"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_quizlet.py
+++ b/social_core/tests/backends/test_quizlet.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class QuizletOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_quizlet.py
+++ b/social_core/tests/backends/test_quizlet.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class QuizletOAuth2Test(OAuth2Test):
+class QuizletOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.quizlet.QuizletOAuth2"
     expected_username = "foo_bar"
 

--- a/social_core/tests/backends/test_readability.py
+++ b/social_core/tests/backends/test_readability.py
@@ -1,10 +1,10 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test
+from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
 
 
-class ReadabilityOAuth1Test(OAuth1Test):
+class ReadabilityOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):
     backend_path = "social_core.backends.readability.ReadabilityOAuth"
     user_data_url = "https://www.readability.com/api/rest/v1/users/_current"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_readability.py
+++ b/social_core/tests/backends/test_readability.py
@@ -1,7 +1,7 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
+from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test
 
 
 class ReadabilityOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):

--- a/social_core/tests/backends/test_reddit.py
+++ b/social_core/tests/backends/test_reddit.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class RedditOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_reddit.py
+++ b/social_core/tests/backends/test_reddit.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class RedditOAuth2Test(OAuth2Test):
+class RedditOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.reddit.RedditOAuth2"
     user_data_url = "https://oauth.reddit.com/api/v1/me.json"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_scistarter.py
+++ b/social_core/tests/backends/test_scistarter.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class ScistarterOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_scistarter.py
+++ b/social_core/tests/backends/test_scistarter.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class ScistarterOAuth2Test(OAuth2Test):
+class ScistarterOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.scistarter.SciStarterOAuth2"
     user_data_url = "https://scistarter.com/api/user_info"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_seznam.py
+++ b/social_core/tests/backends/test_seznam.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class SeznamOAuth2Test(OAuth2Test):
+class SeznamOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.seznam.SeznamOAuth2"
     user_data_url = "https://login.szn.cz/api/v1/user"
     expected_username = "krasty"

--- a/social_core/tests/backends/test_seznam.py
+++ b/social_core/tests/backends/test_seznam.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class SeznamOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_simplelogin.py
+++ b/social_core/tests/backends/test_simplelogin.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class SimpleLoginOAuth2Test(OAuth2Test):
+class SimpleLoginOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.simplelogin.SimpleLoginOAuth2"
     user_data_url = "https://app.simplelogin.io/oauth2/userinfo"
     access_token_body = json.dumps({"access_token": "foobar", "token_type": "bearer"})

--- a/social_core/tests/backends/test_simplelogin.py
+++ b/social_core/tests/backends/test_simplelogin.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class SimpleLoginOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_sketchfab.py
+++ b/social_core/tests/backends/test_sketchfab.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class SketchfabOAuth2Test(OAuth2Test):
+class SketchfabOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.sketchfab.SketchfabOAuth2"
     user_data_url = "https://sketchfab.com/v2/users/me"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_sketchfab.py
+++ b/social_core/tests/backends/test_sketchfab.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class SketchfabOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_skyrock.py
+++ b/social_core/tests/backends/test_skyrock.py
@@ -1,10 +1,10 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test
+from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
 
 
-class SkyrockOAuth1Test(OAuth1Test):
+class SkyrockOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):
     backend_path = "social_core.backends.skyrock.SkyrockOAuth"
     user_data_url = "https://api.skyrock.com/v2/user/get.json"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_skyrock.py
+++ b/social_core/tests/backends/test_skyrock.py
@@ -1,7 +1,7 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
+from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test
 
 
 class SkyrockOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):

--- a/social_core/tests/backends/test_slack.py
+++ b/social_core/tests/backends/test_slack.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class SlackOAuth2Test(OAuth2Test):
+class SlackOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.slack.SlackOAuth2"
     user_data_url = "https://slack.com/api/users.identity"
     access_token_body = json.dumps({"access_token": "foobar", "token_type": "bearer"})

--- a/social_core/tests/backends/test_slack.py
+++ b/social_core/tests/backends/test_slack.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class SlackOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_soundcloud.py
+++ b/social_core/tests/backends/test_soundcloud.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class SoundcloudOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_soundcloud.py
+++ b/social_core/tests/backends/test_soundcloud.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class SoundcloudOAuth2Test(OAuth2Test):
+class SoundcloudOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.soundcloud.SoundcloudOAuth2"
     user_data_url = "https://api.soundcloud.com/me.json"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_spotify.py
+++ b/social_core/tests/backends/test_spotify.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class SpotifyOAuth2Test(OAuth2Test):
+class SpotifyOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.spotify.SpotifyOAuth2"
     user_data_url = "https://api.spotify.com/v1/me"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_spotify.py
+++ b/social_core/tests/backends/test_spotify.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class SpotifyOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_stackoverflow.py
+++ b/social_core/tests/backends/test_stackoverflow.py
@@ -1,7 +1,7 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class StackoverflowOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_stackoverflow.py
+++ b/social_core/tests/backends/test_stackoverflow.py
@@ -1,10 +1,10 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class StackoverflowOAuth2Test(OAuth2Test):
+class StackoverflowOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.stackoverflow.StackoverflowOAuth2"
     user_data_url = "https://api.stackexchange.com/2.1/me"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_stocktwits.py
+++ b/social_core/tests/backends/test_stocktwits.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class StocktwitsOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_stocktwits.py
+++ b/social_core/tests/backends/test_stocktwits.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class StocktwitsOAuth2Test(OAuth2Test):
+class StocktwitsOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.stocktwits.StocktwitsOAuth2"
     user_data_url = "https://api.stocktwits.com/api/2/account/verify.json"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_strava.py
+++ b/social_core/tests/backends/test_strava.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class StravaOAuthTest(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_strava.py
+++ b/social_core/tests/backends/test_strava.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class StravaOAuthTest(OAuth2Test):
+class StravaOAuthTest(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.strava.StravaOAuth"
     user_data_url = "https://www.strava.com/api/v3/athlete"
     expected_username = "marianne_v"

--- a/social_core/tests/backends/test_stripe.py
+++ b/social_core/tests/backends/test_stripe.py
@@ -3,7 +3,7 @@ import json
 import requests
 from httpretty import HTTPretty
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class StripeOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_stripe.py
+++ b/social_core/tests/backends/test_stripe.py
@@ -3,10 +3,10 @@ import json
 import requests
 from httpretty import HTTPretty
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class StripeOAuth2Test(OAuth2Test):
+class StripeOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.stripe.StripeOAuth2"
     account_data_url = "https://api.stripe.com/v1/account"
     access_token_body = json.dumps(

--- a/social_core/tests/backends/test_taobao.py
+++ b/social_core/tests/backends/test_taobao.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class TaobaoOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_taobao.py
+++ b/social_core/tests/backends/test_taobao.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class TaobaoOAuth2Test(OAuth2Test):
+class TaobaoOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.taobao.TAOBAOAuth"
     user_data_url = "https://eco.taobao.com/router/rest"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_thisismyjam.py
+++ b/social_core/tests/backends/test_thisismyjam.py
@@ -1,7 +1,7 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
+from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test
 
 
 class ThisIsMyJameOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):

--- a/social_core/tests/backends/test_thisismyjam.py
+++ b/social_core/tests/backends/test_thisismyjam.py
@@ -1,10 +1,10 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test
+from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
 
 
-class ThisIsMyJameOAuth1Test(OAuth1Test):
+class ThisIsMyJameOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):
     backend_path = "social_core.backends.thisismyjam.ThisIsMyJamOAuth1"
     user_data_url = "http://api.thisismyjam.com/1/verify.json"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_tripit.py
+++ b/social_core/tests/backends/test_tripit.py
@@ -1,10 +1,10 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test
+from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
 
 
-class TripitOAuth1Test(OAuth1Test):
+class TripitOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):
     backend_path = "social_core.backends.tripit.TripItOAuth"
     user_data_url = "https://api.tripit.com/v1/get/profile"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_tripit.py
+++ b/social_core/tests/backends/test_tripit.py
@@ -1,7 +1,7 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
+from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test
 
 
 class TripitOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):

--- a/social_core/tests/backends/test_tumblr.py
+++ b/social_core/tests/backends/test_tumblr.py
@@ -1,10 +1,10 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test
+from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
 
 
-class TumblrOAuth1Test(OAuth1Test):
+class TumblrOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):
     backend_path = "social_core.backends.tumblr.TumblrOAuth"
     user_data_url = "http://api.tumblr.com/v2/user/info"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_tumblr.py
+++ b/social_core/tests/backends/test_tumblr.py
@@ -1,7 +1,7 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
+from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test
 
 
 class TumblrOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):

--- a/social_core/tests/backends/test_twitch.py
+++ b/social_core/tests/backends/test_twitch.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 
@@ -53,7 +53,7 @@ class TwitchOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test):
     )
 
 
-class TwitchOAuth2Test(OAuth2Test):
+class TwitchOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.twitch.TwitchOAuth2"
     user_data_url = "https://api.twitch.tv/helix/users"
     expected_username = "test_user1"

--- a/social_core/tests/backends/test_twitch.py
+++ b/social_core/tests/backends/test_twitch.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 

--- a/social_core/tests/backends/test_twitter.py
+++ b/social_core/tests/backends/test_twitter.py
@@ -1,10 +1,10 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test
+from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
 
 
-class TwitterOAuth1Test(OAuth1Test):
+class TwitterOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):
     backend_path = "social_core.backends.twitter.TwitterOAuth"
     user_data_url = "https://api.twitter.com/1.1/account/" "verify_credentials.json"
     expected_username = "foobar"
@@ -125,7 +125,7 @@ class TwitterOAuth1Test(OAuth1Test):
         self.do_partial_pipeline()
 
 
-class TwitterOAuth1IncludeEmailTest(OAuth1Test):
+class TwitterOAuth1IncludeEmailTest(OAuth1Test, OAuth1AuthUrlTestMixin):
     backend_path = "social_core.backends.twitter.TwitterOAuth"
     user_data_url = (
         "https://api.twitter.com/1.1/account/"

--- a/social_core/tests/backends/test_twitter.py
+++ b/social_core/tests/backends/test_twitter.py
@@ -1,7 +1,7 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
+from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test
 
 
 class TwitterOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):

--- a/social_core/tests/backends/test_twitter_oauth2.py
+++ b/social_core/tests/backends/test_twitter_oauth2.py
@@ -125,7 +125,7 @@ class TwitterOAuth2Mixin:
         self.assertEqual(social.extra_data["public_metrics"]["listed_count"], 7)
 
 
-class TwitterOAuth2TestMissingOptionalValue(OAuth2Test):
+class TwitterOAuth2TestMissingOptionalValue(OAuth2Test, AuthUrlTestMixin):
     backend_path = "social_core.backends.twitter_oauth2.TwitterOAuth2"
     user_data_url = "https://api.twitter.com/2/users/me"
     access_token_body = json.dumps(

--- a/social_core/tests/backends/test_twitter_oauth2.py
+++ b/social_core/tests/backends/test_twitter_oauth2.py
@@ -2,7 +2,12 @@ import json
 
 from social_core.exceptions import AuthException
 
-from .oauth import OAuth2PkcePlainTest, OAuth2PkceS256Test, OAuth2Test
+from .oauth import (
+    BaseAuthUrlTestMixin,
+    OAuth2PkcePlainTest,
+    OAuth2PkceS256Test,
+    OAuth2Test,
+)
 
 
 class TwitterOAuth2Mixin:
@@ -125,7 +130,7 @@ class TwitterOAuth2Mixin:
         self.assertEqual(social.extra_data["public_metrics"]["listed_count"], 7)
 
 
-class TwitterOAuth2TestMissingOptionalValue(OAuth2Test, AuthUrlTestMixin):
+class TwitterOAuth2TestMissingOptionalValue(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.twitter_oauth2.TwitterOAuth2"
     user_data_url = "https://api.twitter.com/2/users/me"
     access_token_body = json.dumps(

--- a/social_core/tests/backends/test_uber.py
+++ b/social_core/tests/backends/test_uber.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class UberOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_uber.py
+++ b/social_core/tests/backends/test_uber.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class UberOAuth2Test(OAuth2Test):
+class UberOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     user_data_url = "https://api.uber.com/v1/me"
     backend_path = "social_core.backends.uber.UberOAuth2"
     expected_username = "foo@bar.com"

--- a/social_core/tests/backends/test_udata.py
+++ b/social_core/tests/backends/test_udata.py
@@ -1,10 +1,10 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class DatagouvfrOAuth2Test(OAuth2Test):
+class DatagouvfrOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.udata.DatagouvfrOAuth2"
     user_data_url = "https://www.data.gouv.fr/api/1/me/"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_udata.py
+++ b/social_core/tests/backends/test_udata.py
@@ -1,7 +1,7 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class DatagouvfrOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_universe.py
+++ b/social_core/tests/backends/test_universe.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class UniverseAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_universe.py
+++ b/social_core/tests/backends/test_universe.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class UniverseAuth2Test(OAuth2Test):
+class UniverseAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.universe.UniverseOAuth2"
     user_data_url = "https://www.universe.com/api/v2/current_user"
     expected_username = "scott+awesome@universe.com"

--- a/social_core/tests/backends/test_upwork.py
+++ b/social_core/tests/backends/test_upwork.py
@@ -1,10 +1,10 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test
+from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
 
 
-class UpworkOAuth1Test(OAuth1Test):
+class UpworkOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):
     backend_path = "social_core.backends.upwork.UpworkOAuth"
     user_data_url = "https://www.upwork.com/api/auth/v1/info.json"
     expected_username = "10101010"

--- a/social_core/tests/backends/test_upwork.py
+++ b/social_core/tests/backends/test_upwork.py
@@ -1,7 +1,7 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
+from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test
 
 
 class UpworkOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):

--- a/social_core/tests/backends/test_vault.py
+++ b/social_core/tests/backends/test_vault.py
@@ -2,7 +2,7 @@ import json
 
 from httpretty import HTTPretty
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 ROOT_URL = "https://vault.example.net:8200/"

--- a/social_core/tests/backends/test_vault.py
+++ b/social_core/tests/backends/test_vault.py
@@ -8,7 +8,7 @@ from .test_open_id_connect import OpenIdConnectTestMixin
 ROOT_URL = "https://vault.example.net:8200/"
 
 
-class VaultOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test):
+class VaultOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.vault.VaultOpenIdConnect"
     issuer = f"{ROOT_URL}v1/identity/oidc/provider/default"
     openid_config_body = json.dumps(

--- a/social_core/tests/backends/test_vault.py
+++ b/social_core/tests/backends/test_vault.py
@@ -2,7 +2,7 @@ import json
 
 from httpretty import HTTPretty
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
 ROOT_URL = "https://vault.example.net:8200/"

--- a/social_core/tests/backends/test_vk.py
+++ b/social_core/tests/backends/test_vk.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class VKOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_vk.py
+++ b/social_core/tests/backends/test_vk.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class VKOAuth2Test(OAuth2Test):
+class VKOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.vk.VKOAuth2"
     user_data_url = "https://api.vk.com/method/users.get"
     expected_username = "durov"

--- a/social_core/tests/backends/test_wlcg.py
+++ b/social_core/tests/backends/test_wlcg.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class WLCGOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_wlcg.py
+++ b/social_core/tests/backends/test_wlcg.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class WLCGOAuth2Test(OAuth2Test):
+class WLCGOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.wlcg.WLCGOAuth2"
     user_data_url = "https://wlcg.cloud.cnaf.infn.it/userinfo"
     expected_username = "foo@bar.com"

--- a/social_core/tests/backends/test_wunderlist.py
+++ b/social_core/tests/backends/test_wunderlist.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class WunderlistOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_wunderlist.py
+++ b/social_core/tests/backends/test_wunderlist.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class WunderlistOAuth2Test(OAuth2Test):
+class WunderlistOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.wunderlist.WunderlistOAuth2"
     user_data_url = "https://a.wunderlist.com/api/v1/user"
     expected_username = "12345"

--- a/social_core/tests/backends/test_xing.py
+++ b/social_core/tests/backends/test_xing.py
@@ -1,10 +1,10 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test
+from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
 
 
-class XingOAuth1Test(OAuth1Test):
+class XingOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):
     backend_path = "social_core.backends.xing.XingOAuth"
     user_data_url = "https://api.xing.com/v1/users/me.json"
     expected_username = "FooBar"

--- a/social_core/tests/backends/test_xing.py
+++ b/social_core/tests/backends/test_xing.py
@@ -1,7 +1,7 @@
 import json
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
+from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test
 
 
 class XingOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):

--- a/social_core/tests/backends/test_yahoo.py
+++ b/social_core/tests/backends/test_yahoo.py
@@ -4,10 +4,10 @@ from urllib.parse import urlencode
 import requests
 from httpretty import HTTPretty
 
-from .oauth import OAuth1Test
+from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
 
 
-class YahooOAuth1Test(OAuth1Test):
+class YahooOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):
     backend_path = "social_core.backends.yahoo.YahooOAuth"
     user_data_url = "https://social.yahooapis.com/v1/user/a-guid/profile?" "format=json"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_yahoo.py
+++ b/social_core/tests/backends/test_yahoo.py
@@ -4,7 +4,7 @@ from urllib.parse import urlencode
 import requests
 from httpretty import HTTPretty
 
-from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
+from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test
 
 
 class YahooOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):

--- a/social_core/tests/backends/test_yammer.py
+++ b/social_core/tests/backends/test_yammer.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class YammerOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_yammer.py
+++ b/social_core/tests/backends/test_yammer.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class YammerOAuth2Test(OAuth2Test):
+class YammerOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.yammer.YammerOAuth2"
     expected_username = "foobar"
     access_token_body = json.dumps(

--- a/social_core/tests/backends/test_yandex.py
+++ b/social_core/tests/backends/test_yandex.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class YandexOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_yandex.py
+++ b/social_core/tests/backends/test_yandex.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class YandexOAuth2Test(OAuth2Test):
+class YandexOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.yandex.YandexOAuth2"
     user_data_url = "https://login.yandex.ru/info"
     expected_username = "foobar"
@@ -26,7 +26,7 @@ class YandexOAuth2Test(OAuth2Test):
         self.do_partial_pipeline()
 
 
-class YandexOAuth2TestEmptyEmail(OAuth2Test):
+class YandexOAuth2TestEmptyEmail(OAuth2Test, BaseAuthUrlTestMixin):
     """
     When user log in to yandex service with social network account (e.g.
     vk.com), they `default_email` could be empty.

--- a/social_core/tests/backends/test_zoom.py
+++ b/social_core/tests/backends/test_zoom.py
@@ -1,6 +1,6 @@
 import json
 
-from .oauth import OAuth2Test, BaseAuthUrlTestMixin
+from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 class ZoomOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_zoom.py
+++ b/social_core/tests/backends/test_zoom.py
@@ -1,9 +1,9 @@
 import json
 
-from .oauth import OAuth2Test
+from .oauth import OAuth2Test, BaseAuthUrlTestMixin
 
 
-class ZoomOAuth2Test(OAuth2Test):
+class ZoomOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.zoom.ZoomOAuth2"
     user_data_url = "https://api.zoom.us/v2/users/me"
     expected_username = "foobar"

--- a/social_core/tests/backends/test_zotero.py
+++ b/social_core/tests/backends/test_zotero.py
@@ -1,9 +1,9 @@
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test
+from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
 
 
-class ZoteroOAuth1Test(OAuth1Test):
+class ZoteroOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):
     backend_path = "social_core.backends.zotero.ZoteroOAuth"
     expected_username = "FooBar"
     access_token_body = urlencode(

--- a/social_core/tests/backends/test_zotero.py
+++ b/social_core/tests/backends/test_zotero.py
@@ -1,6 +1,6 @@
 from urllib.parse import urlencode
 
-from .oauth import OAuth1Test, OAuth1AuthUrlTestMixin
+from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test
 
 
 class ZoteroOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):

--- a/social_core/utils.py
+++ b/social_core/utils.py
@@ -6,7 +6,7 @@ import sys
 import time
 import unicodedata
 from urllib.parse import parse_qs as battery_parse_qs
-from urllib.parse import urlencode, urlparse, urlunparse, unquote
+from urllib.parse import unquote, urlencode, urlparse, urlunparse
 
 import requests
 from requests.adapters import HTTPAdapter

--- a/social_core/utils.py
+++ b/social_core/utils.py
@@ -6,7 +6,7 @@ import sys
 import time
 import unicodedata
 from urllib.parse import parse_qs as battery_parse_qs
-from urllib.parse import urlencode, urlparse, urlunparse
+from urllib.parse import urlencode, urlparse, urlunparse, unquote
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -65,13 +65,15 @@ def user_agent():
     return "social-auth-" + social_core.__version__
 
 
-def url_add_parameters(url, params):
+def url_add_parameters(url, params, _unquote_query=False):
     """Adds parameters to URL, parameter will be repeated if already present"""
     if params:
         fragments = list(urlparse(url))
         value = parse_qs(fragments[4])
         value.update(params)
         fragments[4] = urlencode(value)
+        if _unquote_query:
+            fragments[4] = unquote(fragments[4])
         url = urlunparse(fragments)
     return url
 


### PR DESCRIPTION
## Proposed changes
Query parameters are correctly handled when building `auth_url` if parameters are in the base `AUTHORIZATION_URL`

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added documentation to https://github.com/python-social-auth/social-docs

## Other information
- fixes #944 
- main changes are in [this commit](https://github.com/python-social-auth/social-core/commit/ec0647134f97b99131b97eeb941c173d20bd28c7), the rest is test files
