### PR TITLE
Add passing tests for linkedin OAuth updates

### DIFF
--- a/social_core/backends/linkedin.py
+++ b/social_core/backends/linkedin.py
@@ -66,17 +66,7 @@ class LinkedinOAuth2(BaseOAuth2):
     ]
 
     def user_details_url(self):
-        # use set() since LinkedIn fails when values are duplicated
-        fields_selectors = list(
-            set(
-                ["sub", "given_name", "family_name", "email"]
-                + self.setting("FIELD_SELECTORS", [])
-            )
-        )
-        # user sort to ease the tests URL mocking
-        fields_selectors.sort()
-        fields_selectors = ",".join(fields_selectors)
-        return self.USER_DETAILS_URL.format(projection=fields_selectors)
+        return self.USER_DETAILS_URL
 
     def user_emails_url(self):
         return self.USER_EMAILS_URL

--- a/social_core/backends/linkedin.py
+++ b/social_core/backends/linkedin.py
@@ -48,14 +48,14 @@ class LinkedinOAuth2(BaseOAuth2):
     name = "linkedin-oauth2"
     AUTHORIZATION_URL = "https://www.linkedin.com/oauth/v2/authorization"
     ACCESS_TOKEN_URL = "https://www.linkedin.com/oauth/v2/accessToken"
-    USER_DETAILS_URL = "https://api.linkedin.com/v2/me?projection=({projection})"
+    USER_DETAILS_URL = "https://api.linkedin.com/v2/userinfo?projection=({projection})"
     USER_EMAILS_URL = (
         "https://api.linkedin.com/v2/emailAddress"
         "?q=members&projection=(elements*(handle~))"
     )
     ACCESS_TOKEN_METHOD = "POST"
     REDIRECT_STATE = False
-    DEFAULT_SCOPE = ["r_liteprofile"]
+    DEFAULT_SCOPE = ['email', 'profile', 'openid']
     EXTRA_DATA = [
         ("id", "id"),
         ("expires_in", "expires"),
@@ -68,7 +68,7 @@ class LinkedinOAuth2(BaseOAuth2):
     def user_details_url(self):
         # use set() since LinkedIn fails when values are duplicated
         fields_selectors = list(
-            set(["id", "firstName", "lastName"] + self.setting("FIELD_SELECTORS", []))
+            set(["sub", "given_name", "family_name", "email"] + self.setting("FIELD_SELECTORS", []))
         )
         # user sort to ease the tests URL mocking
         fields_selectors.sort()
@@ -83,10 +83,10 @@ class LinkedinOAuth2(BaseOAuth2):
             self.user_details_url(), headers=self.user_data_headers(access_token)
         )
 
-        if "emailAddress" in set(self.setting("FIELD_SELECTORS", [])):
+        if "email" in set(self.setting("FIELD_SELECTORS", [])):
             emails = self.email_data(access_token, *args, **kwargs)
             if emails:
-                response["emailAddress"] = emails[0]
+                response["email"] = emails[0]
 
         return response
 
@@ -96,38 +96,20 @@ class LinkedinOAuth2(BaseOAuth2):
         )
         email_addresses = []
         for element in response.get("elements", []):
-            email_address = element.get("handle~", {}).get("emailAddress")
+            email_address = element.get("handle~", {}).get("email")
             email_addresses.append(email_address)
         return list(filter(None, email_addresses))
 
     def get_user_details(self, response):
         """Return user details from Linkedin account"""
-
-        def get_localized_name(name):
-            """
-            FirstName & Last Name object
-            {
-                  'localized': {
-                     'en_US': 'Smith'
-                  },
-                  'preferredLocale': {
-                     'country': 'US',
-                     'language': 'en'
-                  }
-            }
-            :return the localizedName from the lastName object
-            """
-            locale = "{}_{}".format(
-                name["preferredLocale"]["language"], name["preferredLocale"]["country"]
-            )
-            return name["localized"].get(locale, "")
-
+        response = self.user_data(access_token=response['access_token'])
         fullname, first_name, last_name = self.get_user_names(
-            first_name=get_localized_name(response["firstName"]),
-            last_name=get_localized_name(response["lastName"]),
+            first_name=response["given_name"],
+            last_name=response["family_name"],
         )
-        email = response.get("emailAddress", "")
+        email = response.get("email", "")
         return {
+            "id": response.get("sub", ""),
             "username": first_name + last_name,
             "fullname": fullname,
             "first_name": first_name,

--- a/social_core/backends/linkedin.py
+++ b/social_core/backends/linkedin.py
@@ -55,7 +55,7 @@ class LinkedinOAuth2(BaseOAuth2):
     )
     ACCESS_TOKEN_METHOD = "POST"
     REDIRECT_STATE = False
-    DEFAULT_SCOPE = ['email', 'profile', 'openid']
+    DEFAULT_SCOPE = ["email", "profile", "openid"]
     EXTRA_DATA = [
         ("id", "id"),
         ("expires_in", "expires"),
@@ -68,7 +68,10 @@ class LinkedinOAuth2(BaseOAuth2):
     def user_details_url(self):
         # use set() since LinkedIn fails when values are duplicated
         fields_selectors = list(
-            set(["sub", "given_name", "family_name", "email"] + self.setting("FIELD_SELECTORS", []))
+            set(
+                ["sub", "given_name", "family_name", "email"]
+                + self.setting("FIELD_SELECTORS", [])
+            )
         )
         # user sort to ease the tests URL mocking
         fields_selectors.sort()
@@ -102,7 +105,7 @@ class LinkedinOAuth2(BaseOAuth2):
 
     def get_user_details(self, response):
         """Return user details from Linkedin account"""
-        response = self.user_data(access_token=response['access_token'])
+        response = self.user_data(access_token=response["access_token"])
         fullname, first_name, last_name = self.get_user_names(
             first_name=response["given_name"],
             last_name=response["family_name"],

--- a/social_core/tests/backends/test_linkedin.py
+++ b/social_core/tests/backends/test_linkedin.py
@@ -42,26 +42,23 @@ class LinkedinOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test):
 
 
 class BaseLinkedinTest:
-    user_data_url = (
-        "https://api.linkedin.com/v2/me" "?projection=(firstName,id,lastName)"
-    )
+    user_data_url = "https://api.linkedin.com/v2/userinfo"
     expected_username = "FooBar"
     access_token_body = json.dumps({"access_token": "foobar", "token_type": "bearer"})
 
     # Reference:
-    # https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self
-    # -serve/sign-in-with-linkedin?context=linkedin/consumer/context#api-request
+    # https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self
+    # -serve/sign-in-with-linkedin-v2#response-body-schema
     user_data_body = json.dumps(
         {
-            "id": "1010101010",
-            "firstName": {
-                "localized": {"en_US": "Foo"},
-                "preferredLocale": {"country": "US", "language": "en"},
-            },
-            "lastName": {
-                "localized": {"en_US": "Bar"},
-                "preferredLocale": {"country": "US", "language": "en"},
-            },
+            "sub": "782bbtaQ",
+            "name": "FooBar",
+            "given_name": "Foo",
+            "family_name": "Bar",
+            "picture": "https://media.licdn-ei.com/dms/image/C5F03AQHqK8v7tB1HCQ/profile-displayphoto-shrink_100_100/0/",  # noqa: E501
+            "locale": "en-US",
+            "email": "doe@email.com",
+            "email_verified": True,
         }
     )
 


### PR DESCRIPTION
This is a follow-up to and addition onto https://github.com/python-social-auth/social-core/pull/915

All that the preceding PR includes is part of it, plus tests passing. Props to @MohamedAhmed412000 for the initial work

It'll supersede #915 and #934