### PR TITLE
Modify the dummy tests to be timezone-safe

### DIFF
--- a/social_core/storage.py
+++ b/social_core/storage.py
@@ -71,9 +71,10 @@ class UserMixin:
             now = datetime.now(timezone.utc)
 
             # Detect if expires is a timestamp
-            if expires > time.mktime(now.timetuple()):
+            if expires > now.timestamp():
                 # expires is a datetime, return the remaining difference
-                return datetime.fromtimestamp(expires, tz=timezone.utc) - now
+                expiry_time = datetime.fromtimestamp(expires, tz=timezone.utc)
+                return expiry_time - now
             else:
                 # expires is the time to live seconds since creation,
                 # check against auth_time if present, otherwise return

--- a/social_core/storage.py
+++ b/social_core/storage.py
@@ -2,7 +2,6 @@
 
 import base64
 import re
-import time
 import uuid
 import warnings
 from datetime import datetime, timedelta, timezone

--- a/social_core/tests/backends/test_dummy.py
+++ b/social_core/tests/backends/test_dummy.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import time
 
 from httpretty import HTTPretty
 

--- a/social_core/tests/backends/test_dummy.py
+++ b/social_core/tests/backends/test_dummy.py
@@ -121,9 +121,7 @@ class ExpirationTimeTest(DummyOAuth2Test):
             "first_name": "Foo",
             "last_name": "Bar",
             "email": "foo@bar.com",
-            "expires": time.mktime(
-                (datetime.datetime.now(datetime.timezone.utc) + DELTA).timetuple()
-            ),
+            "expires": (datetime.datetime.now() + DELTA).timestamp(),
         }
     )
 


### PR DESCRIPTION

## Proposed changes
The dummy tests were failing on my non-UTC development machine, because the timestamps were generated with mktime(), which uses the locale settings from the host. Changing this to use the timezone-aware `now` sorted it.

Extracted from https://github.com/python-social-auth/social-core/pull/951 by @offbyone

## Types of changes

Please check the type of change your PR introduces:

- [ ] Release (new release request)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (PEP8, lint, formatting, renaming, etc)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build related changes (build process, tests runner, etc)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added documentation to https://github.com/python-social-auth/social-docs

## Other information

Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
