### PR TITLE
Log `HTTPError` response text

### DIFF
--- a/social_core/utils.py
+++ b/social_core/utils.py
@@ -225,7 +225,7 @@ def handle_http_errors(func):
         try:
             return func(*args, **kwargs)
         except requests.HTTPError as err:
-            social_logger.exception(err.response.text)
+            social_logger.exception("Request failed with %d: %s", err.response.status_code, err.response.text)
 
             if err.response.status_code == 400:
                 raise AuthCanceled(args[0], response=err.response)

--- a/social_core/utils.py
+++ b/social_core/utils.py
@@ -225,6 +225,8 @@ def handle_http_errors(func):
         try:
             return func(*args, **kwargs)
         except requests.HTTPError as err:
+            social_logger.exception(err.response.text)
+
             if err.response.status_code == 400:
                 raise AuthCanceled(args[0], response=err.response)
             if err.response.status_code == 401:

--- a/social_core/utils.py
+++ b/social_core/utils.py
@@ -225,7 +225,11 @@ def handle_http_errors(func):
         try:
             return func(*args, **kwargs)
         except requests.HTTPError as err:
-            social_logger.exception("Request failed with %d: %s", err.response.status_code, err.response.text)
+            social_logger.exception(
+                "Request failed with %d: %s",
+                err.response.status_code,
+                err.response.text,
+            )
 
             if err.response.status_code == 400:
                 raise AuthCanceled(args[0], response=err.response)


### PR DESCRIPTION
## Proposed changes

Logging the response text for an `HTTPError` greatly improves the developer's ability to figure out what might going wrong with an integration. 

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added documentation to https://github.com/python-social-auth/social-docs

