### PR TITLE
Google One Tap implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ dev = [
 ]
 google-onetap = [
   "google-auth~=2.38.0",
-  "packaging"
 ]
 saml = [
   "python3-saml>=1.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ version = "4.5.4"
 all = [
   "social-auth-core[saml]",
   "social-auth-core[azuread]",
-  "social-auth-core[shopify]"
+  "social-auth-core[shopify]",
+  "social-auth-core[google-onetap]"
 ]
 allpy3 = [
   "social-auth-core[all]"
@@ -81,6 +82,10 @@ saml = [
 ]
 shopify = [
   "ShopifyAPI"
+]
+google-onetap = [
+   "google-auth~=2.38.0",
+   "packaging"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dev = [
   "pyright>=1.1.391"
 ]
 google-onetap = [
-  "google-auth~=2.38.0",
+  "google-auth~=2.38.0"
 ]
 saml = [
   "python3-saml>=1.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,10 @@ dev = [
   "urllib3~=2.2.0",
   "pyright>=1.1.391"
 ]
+google-onetap = [
+  "google-auth~=2.38.0",
+  "packaging"
+]
 saml = [
   "python3-saml>=1.5.0",
   # pinned to 5.2 until a new wheel of xmlsec is released
@@ -82,10 +86,6 @@ saml = [
 ]
 shopify = [
   "ShopifyAPI"
-]
-google-onetap = [
-   "google-auth~=2.38.0",
-   "packaging"
 ]
 
 [project.urls]

--- a/social_core/backends/google_onetap.py
+++ b/social_core/backends/google_onetap.py
@@ -1,0 +1,53 @@
+import urllib3
+from google.auth.transport.urllib3 import Request
+from google.oauth2 import id_token
+
+from social_core.backends.base import BaseAuth
+from social_core.backends.google import BaseGoogleAuth
+from social_core.exceptions import AuthException, AuthTokenError
+
+
+class GoogleOneTap(BaseGoogleAuth, BaseAuth):
+    name = "google-onetap"
+    CSRF_KEY = "g_csrf_token"
+    CREDENTIAL_KEY = "credential"
+
+    def auth_url(self):
+        raise AuthException(self, "Cannot start login flow for Google One Tap")
+
+    def verify_csrf(self, request):
+        csrf_token_body = self.data.get(self.CSRF_KEY)
+        csrf_token_cookie = request.COOKIES.get(self.CSRF_KEY)
+
+        if not csrf_token_body:
+            raise AuthTokenError(self, "Missing csrf token from response")
+
+        if not csrf_token_cookie:
+            # csrf_token_cookie can be missing due to
+            # https://issuetracker.google.com/issues/226157137
+            return
+
+        if csrf_token_body != csrf_token_cookie:
+            raise AuthTokenError(
+                self, "csrf token from cookie and response does not match"
+            )
+
+    def get_decoded_info(self):
+        try:
+            idinfo = id_token.verify_oauth2_token(
+                self.data.get(self.CREDENTIAL_KEY),
+                Request(http=urllib3.PoolManager()),
+                self.setting("KEY"),
+            )
+        except ValueError:
+            raise AuthException(self, "Invalid response from Google")
+
+        return idinfo
+
+    def auth_complete(self, *args, **kwargs):
+        self.verify_csrf(kwargs["request"])
+
+        response = self.get_decoded_info()
+        kwargs.update({"response": response, "backend": self})
+
+        return self.strategy.authenticate(*args, **kwargs)

--- a/social_core/backends/google_onetap.py
+++ b/social_core/backends/google_onetap.py
@@ -1,5 +1,4 @@
-import urllib3
-from google.auth.transport.urllib3 import Request
+from google.auth.transport import requests as transport_requests
 from google.oauth2 import id_token
 
 from social_core.backends.base import BaseAuth
@@ -22,9 +21,8 @@ class GoogleOneTap(BaseGoogleAuth, BaseAuth):
         if not csrf_token_body:
             raise AuthTokenError(self, "Missing csrf token from response")
 
-        if not csrf_token_cookie:
-            # csrf_token_cookie can be missing due to
-            # https://issuetracker.google.com/issues/226157137
+        # csrf_token_cookie can be missing due to https://issuetracker.google.com/issues/226157137
+        if not csrf_token_cookie and self.setting("IGNORE_MISSING_CSRF_COOKIE", False):
             return
 
         if csrf_token_body != csrf_token_cookie:
@@ -36,7 +34,7 @@ class GoogleOneTap(BaseGoogleAuth, BaseAuth):
         try:
             idinfo = id_token.verify_oauth2_token(
                 self.data.get(self.CREDENTIAL_KEY),
-                Request(http=urllib3.PoolManager()),
+                transport_requests.Request(),
                 self.setting("KEY"),
             )
         except ValueError:

--- a/social_core/tests/backends/test_google.py
+++ b/social_core/tests/backends/test_google.py
@@ -8,10 +8,10 @@ import jwt
 from httpretty import HTTPretty
 
 from ...actions import do_disconnect
+from ...exceptions import AuthException, AuthTokenError
 from ..models import User
 from .oauth import BaseAuthUrlTestMixin, OAuth1AuthUrlTestMixin, OAuth1Test, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
-from ...exceptions import AuthException, AuthTokenError
 
 
 class GoogleOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_google.py
+++ b/social_core/tests/backends/test_google.py
@@ -10,6 +10,7 @@ from httpretty import HTTPretty
 from ...actions import do_disconnect
 from ...exceptions import AuthException, AuthTokenError
 from ..models import User
+from .base import BaseBackendTest
 from .oauth import BaseAuthUrlTestMixin, OAuth1AuthUrlTestMixin, OAuth1Test, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
 
@@ -170,7 +171,7 @@ class GoogleOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test):
     )
 
 
-class GoogleOneTapTest(OAuth2Test):
+class GoogleOneTapTest(BaseBackendTest):
     backend_path = "social_core.backends.google_onetap.GoogleOneTap"
     private_key = """-----BEGIN RSA PRIVATE KEY-----
 MIICXQIBAAKBgQC6lDOJ0zKiNKJM3p0nTOJgaaHhxPoIJARcRzNSkzG0vC4QnXbB

--- a/social_core/tests/backends/test_google.py
+++ b/social_core/tests/backends/test_google.py
@@ -1,14 +1,17 @@
 # pyright: reportAttributeAccessIssue=false
-
 import json
+import time
+from unittest import mock
 from urllib.parse import urlencode
 
+import jwt
 from httpretty import HTTPretty
 
 from ...actions import do_disconnect
 from ..models import User
 from .oauth import BaseAuthUrlTestMixin, OAuth1AuthUrlTestMixin, OAuth1Test, OAuth2Test
 from .test_open_id_connect import OpenIdConnectTestMixin
+from ...exceptions import AuthException, AuthTokenError
 
 
 class GoogleOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
@@ -165,3 +168,107 @@ class GoogleOpenIdConnectTest(OpenIdConnectTestMixin, OAuth2Test):
             ],
         }
     )
+
+
+class GoogleOneTapTest(OAuth2Test):
+    backend_path = "social_core.backends.google_onetap.GoogleOneTap"
+    private_key = """-----BEGIN RSA PRIVATE KEY-----
+MIICXQIBAAKBgQC6lDOJ0zKiNKJM3p0nTOJgaaHhxPoIJARcRzNSkzG0vC4QnXbB
+I3E42elTL3Nujyt80frzIji12KIJqAZIFsG6SSzKcYNeXf+dPwehIrWa7z/N5HD4
+x9Fufj5GDT7SyHCAHi3BDHkA599fpOw8odBambK2cshMNkjyNDP+MvGORQIDAQAB
+AoGBAJUZYaY+VDQzg4+SRlvloPIS9/6HfpeK0ME9VNIkNpCL4PP+IaxuOkiIO2Dy
+hnhPiR0SYExziIYpPDQjRgHNzblGXa2jq+jy/SWj+t0+E0vPhg0kBSA4cYclH+c/
+xwp0iW0ocVjod4RxFu6qSMU1TY83NNc4khBON3/GZiU99ImBAkEA5+17SuWvbUA/
+jQhuAmzMND1QK4cteYFUnkpqpMQsitq/SC/NgcqUKdqteghPPoJOlGH8UfaM+0EK
+uf0Dd327XQJBAM3xw6M8TyiPOY6Qvfadk+IqBdsUb9T7Q9xIB0kMEcfwRdKJ3KgR
+CvUjxBdXNf7ZuhykIDle80we41yzZK+2WAkCQCM2PQfMA2xU2tEwvHMFzaMIxAk3
+xsGxzwURS0uktRaHy47MIylXdlM8biYe6NkWs5N3pPVUt2bWIyjFrycPIckCQQCe
+cmGol1/3vqnzy9y7fuUmXlp/AaxA2siNFEW2p7iOcYfmwfaov+QEUu4tXwXF+9G6
+83NvcGQTrrgSvFq87bexAkB2f5dFbl2tYWRQ7wGmmX++JDuHwHDI99rnsUxVhSFk
+1LiRk3XACJa5y1peU9rkTfWeu5aoFb5WyheQacNQcu80
+-----END RSA PRIVATE KEY-----"""
+    public_key = """-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC6lDOJ0zKiNKJM3p0nTOJgaaHh
+xPoIJARcRzNSkzG0vC4QnXbBI3E42elTL3Nujyt80frzIji12KIJqAZIFsG6SSzK
+cYNeXf+dPwehIrWa7z/N5HD4x9Fufj5GDT7SyHCAHi3BDHkA599fpOw8odBambK2
+cshMNkjyNDP+MvGORQIDAQAB
+-----END PUBLIC KEY-----"""
+    client_id = "a-key"
+
+    def setUp(self):
+        super().setUp()
+        HTTPretty.register_uri(
+            HTTPretty.GET,
+            "https://www.googleapis.com/oauth2/v1/certs",
+            status=200,
+            body=json.dumps({"test_key": self.public_key}),
+        )
+
+    def _get_jwt_payload(self):
+        claimed_at = int(time.time())
+        return {
+            "given_name": "test name",
+            "email": "test@test.com",
+            "aud": self.client_id,
+            "iat": claimed_at,
+            "exp": claimed_at + 30,
+            "iss": "accounts.google.com",
+        }
+
+    def test_auth_url(self):
+        with self.assertRaises(AuthException):
+            self.backend.start()
+
+    def test_verify_csrf_no_csrf_token_body(self):
+        with self.assertRaises(AuthTokenError):
+            self.backend.verify_csrf(request=mock.Mock())
+
+    def test_verify_csrf_no_csrf_token_cookie_not_ignored(self):
+        self.backend.data = {"g_csrf_token": "csrf"}
+        with self.assertRaises(AuthTokenError):
+            self.backend.verify_csrf(request=mock.Mock(COOKIES={}))
+
+    def test_verify_csrf_no_csrf_token_cookie_ignored(self):
+        self.strategy.set_settings(
+            {"SOCIAL_AUTH_GOOGLE_ONETAP_IGNORE_MISSING_CSRF_COOKIE": True}
+        )
+        self.backend.data = {"g_csrf_token": "csrf"}
+        self.backend.verify_csrf(request=mock.Mock(COOKIES={}))
+
+    def test_verify_csrf_valid(self):
+        self.backend.data = {"g_csrf_token": "csrf"}
+        self.backend.verify_csrf(request=mock.Mock(COOKIES={"g_csrf_token": "csrf"}))
+
+    def test_get_decoded_info_error(self):
+        payload = self._get_jwt_payload()
+        payload["exp"] -= 31
+        self.backend.data = {
+            "credential": jwt.encode(
+                payload,
+                self.private_key,
+                algorithm="RS256",
+                headers={"kid": "test_key"},
+            ),
+            "g_csrf_token": "csrf",
+        }
+        request = mock.Mock(COOKIES={"g_csrf_token": "csrf"})
+
+        with self.assertRaises(AuthException):
+            self.backend.auth_complete(request=request)
+
+    def test_get_decoded_info_success(self):
+        self.backend.data = {
+            "credential": jwt.encode(
+                self._get_jwt_payload(),
+                self.private_key,
+                algorithm="RS256",
+                headers={"kid": "test_key"},
+            ),
+            "g_csrf_token": "csrf",
+        }
+        request = mock.Mock(COOKIES={"g_csrf_token": "csrf"})
+
+        user = self.backend.auth_complete(request=request)
+
+        self.assertEqual(user.email, "test@test.com")
+        self.assertEqual(user.first_name, "test name")


### PR DESCRIPTION
## Proposed changes

The changes adds Google One Tap as a backend

## Checklist


- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added documentation to https://github.com/python-social-auth/social-docs

## Other information

You can test the changes with this dummy project https://github.com/kviktor/django-onetap-example

I haven't yet added tests or documentation but if the changes look okay I'll add them too.

I have 2 questions tho I'm not exactly sure about, maybe someone can help out
- I've added google-auth as a dependency, technically it's just downloading Google's cert files then verifying the jwt token however I didn't want to reimplement the wheel for it and it's a bit safer this way imo
- as it requires a new dependency I've added a new Python module for it, is that ok? (I can move it into `google.py` with catching ImportError and raising an exception if the library is missing in the class)

Docs at https://github.com/python-social-auth/social-docs/pull/256