### PR TITLE
feat: allow to configure JWT leeway in open_id_connect and increase default to 1 second

### DIFF
--- a/social_core/backends/open_id_connect.py
+++ b/social_core/backends/open_id_connect.py
@@ -61,7 +61,7 @@ class OpenIdConnectAuth(BaseOAuth2):
     USERNAME_KEY = "preferred_username"
     JWT_ALGORITHMS = ["RS256"]
     JWT_DECODE_OPTIONS: dict[str, Any] = {}
-    JWT_LEEWAY : float = 1.0  # seconds
+    JWT_LEEWAY: float = 1.0  # seconds
     # When these options are unspecified, server will choose via openid autoconfiguration
     ID_TOKEN_ISSUER = ""
     ACCESS_TOKEN_URL = ""


### PR DESCRIPTION
## Proposed changes

The default value defined in the jwt module is 0 seconds, so when the time is off just by a few milliseconds, the token validation fails with error "The token is not yet valid (iat)".

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
   - This feature is already in the azuread_b2c and mediawiki backends, but there are no tests for it, so I don’t have any reference to based it on and don’t have time to figure it out myself.
- [ ] I have added documentation to https://github.com/python-social-auth/social-docs
    - I don’t see any documentation for the generic open_id_connect backend in https://github.com/python-social-auth/social-docs/tree/master/docs/backends.
