### PR TITLE
feat: Add JWT leeway setting to KeycloakOAuth2 backend

### DIFF
--- a/social_core/backends/keycloak.py
+++ b/social_core/backends/keycloak.py
@@ -133,6 +133,7 @@ class KeycloakOAuth2(BaseOAuth2):  # pylint: disable=abstract-method
             key=self.public_key(),
             algorithms=self.algorithm(),
             audience=self.audience(),
+            leeway=self.setting("JWT_LEEWAY", default=0),
         )
 
     def get_user_details(self, response):


### PR DESCRIPTION
Fixes #1102 by adding support for a `JWT_LEEWAY` setting in the Keycloak backend.