### PR TITLE
feat: implement session restore when cookies are not reliable

### DIFF
--- a/social_core/backends/base.py
+++ b/social_core/backends/base.py
@@ -224,7 +224,7 @@ class BaseAuth:
             self, pipeline_index=partial.next_step, *partial.args, **partial.kwargs
         )
 
-    def auth_extra_arguments(self):
+    def auth_extra_arguments(self) -> dict[str, str]:
         """Return extra arguments needed on auth process. The defaults can be
         overridden by GET parameters."""
         extra_arguments = self.setting("AUTH_EXTRA_ARGUMENTS", {}).copy()

--- a/social_core/backends/oauth.py
+++ b/social_core/backends/oauth.py
@@ -280,8 +280,8 @@ class BaseOAuth1(OAuthAuth):
             token = parse_qs(token)
         params = self.auth_extra_arguments() or {}
         params.update(self.get_scope_argument())
-        params[self.OAUTH_TOKEN_PARAMETER_NAME] = token.get(
-            self.OAUTH_TOKEN_PARAMETER_NAME
+        params[self.OAUTH_TOKEN_PARAMETER_NAME] = cast(
+            "str", token.get(self.OAUTH_TOKEN_PARAMETER_NAME)
         )
         state = self.get_or_create_state()
         params[self.REDIRECT_URI_PARAMETER_NAME] = self.get_redirect_uri(state)

--- a/social_core/backends/open_id.py
+++ b/social_core/backends/open_id.py
@@ -144,20 +144,25 @@ class OpenIdAuth(BaseAuth):
         values.update(from_details)
         return values
 
+    def get_return_to(self) -> str:
+        params: dict[str, str] = {}
+        if session_id := self.strategy.get_session_id():
+            params[self.strategy.SESSION_SAVE_KEY] = session_id
+
+        return url_add_parameters(self.strategy.absolute_uri(self.redirect_uri), params)
+
     def auth_url(self):
         """Return auth URL returned by service"""
         openid_request = self.setup_request(self.auth_extra_arguments())
         # Construct completion URL, including page we should redirect to
-        return_to = self.strategy.absolute_uri(self.redirect_uri)
-        return openid_request.redirectURL(self.trust_root(), return_to)
+        return openid_request.redirectURL(self.trust_root(), self.get_return_to())
 
     def auth_html(self):
         """Return auth HTML returned by service"""
         openid_request = self.setup_request(self.auth_extra_arguments())
-        return_to = self.strategy.absolute_uri(self.redirect_uri)
         form_tag = {"id": "openid_message"}
         return openid_request.htmlMarkup(
-            self.trust_root(), return_to, form_tag_attrs=form_tag
+            self.trust_root(), self.get_return_to(), form_tag_attrs=form_tag
         )
 
     def trust_root(self):
@@ -167,7 +172,7 @@ class OpenIdAuth(BaseAuth):
     def continue_pipeline(self, partial):
         """Continue previous halted pipeline"""
         response = self.consumer().complete(
-            dict(self.data.items()), self.strategy.absolute_uri(self.redirect_uri)
+            dict(self.data.items()), self.get_return_to()
         )
         return self.strategy.authenticate(
             self,
@@ -180,9 +185,11 @@ class OpenIdAuth(BaseAuth):
     def auth_complete(self, *args, **kwargs):
         """Complete auth process"""
         response = self.consumer().complete(
-            dict(self.data.items()), self.strategy.absolute_uri(self.redirect_uri)
+            dict(self.data.items()), self.get_return_to()
         )
         self.process_error(response)
+        if session_id := self.data.get(self.strategy.SESSION_SAVE_KEY):
+            self.strategy.restore_session(session_id, kwargs)
         return self.strategy.authenticate(self, response=response, *args, **kwargs)
 
     def process_error(self, data):

--- a/social_core/exceptions.py
+++ b/social_core/exceptions.py
@@ -10,9 +10,22 @@ class SocialAuthBaseException(ValueError):
     """Base class for pipeline exceptions."""
 
 
+class StrategyMissingFeatureError(SocialAuthBaseException):
+    """Strategy does not support this."""
+
+    def __init__(self, strategy_name: str, feature_name: str):
+        self.strategy_name = strategy_name
+        self.feature_name = feature_name
+        super().__init__()
+
+    def __str__(self):
+        return f"Strategy {self.strategy_name} does not support {self.feature_name}"
+
+
 class WrongBackend(SocialAuthBaseException):
     def __init__(self, backend_name: str):
         self.backend_name = backend_name
+        super().__init__()
 
     def __str__(self):
         return f'Incorrect authentication service "{self.backend_name}"'


### PR DESCRIPTION
When cookies are created with SameSite policy, they won't be available during the authentication flow which uses POST such as OpenID or SAML. This adds support in Strategy to get session ID and restore it later in the login flow.

See https://github.com/python-social-auth/social-app-django/issues/481

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
