### PR TITLE
chore: remove testing non-working SystemRandom

### DIFF
--- a/social_core/tests/test_storage.py
+++ b/social_core/tests/test_storage.py
@@ -1,4 +1,3 @@
-import random
 import unittest
 
 from social_core.storage import (
@@ -189,14 +188,3 @@ class BrokenStrategyTests(unittest.TestCase):
 
     def test_random_string(self) -> None:
         self.assertTrue(isinstance(self.strategy.random_string(), str))
-
-    def test_random_string_without_systemrandom(self) -> None:
-        def SystemRandom():
-            raise NotImplementedError
-
-        orig_random = getattr(random, "SystemRandom", None)
-        random.SystemRandom = SystemRandom
-
-        strategy = BrokenStrategyWithSettings(storage=BrokenStorage)
-        self.assertTrue(isinstance(strategy.random_string(), str))
-        random.SystemRandom = orig_random


### PR DESCRIPTION
This is merely testing Python internals and actually does nothing as SystemRandom is instationated on import of the secrets module, so the patching done in this test had no effect on the secrets.choice output.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
