### PR TITLE
Auth0 OIDC backend

### DIFF
--- a/social_core/backends/auth0_openidconnect.py
+++ b/social_core/backends/auth0_openidconnect.py
@@ -1,0 +1,45 @@
+from social_core.backends.open_id_connect import OpenIdConnectAuth
+
+
+class Auth0OpenIdConnectAuth(OpenIdConnectAuth):
+    """
+    Auth0 OpenID Connect authentication backend.
+
+    Uses Auth0's OpenID Connect implementation with automatic endpoint discovery.
+
+    Settings:
+        SOCIAL_AUTH_AUTH0_OPENIDCONNECT_DOMAIN = 'your-domain.auth0.com'
+        SOCIAL_AUTH_AUTH0_OPENIDCONNECT_KEY = '<client_id>'
+        SOCIAL_AUTH_AUTH0_OPENIDCONNECT_SECRET = '<client_secret>'
+    """
+
+    name = "auth0_openidconnect"
+    USERNAME_KEY = "nickname"
+    EXTRA_DATA = ["id_token", "refresh_token", ("sub", "id"), "picture"]
+
+    def api_path(self, path=""):
+        """Build API path for Auth0 domain"""
+        return "https://{domain}/{path}".format(
+            domain=self.setting("DOMAIN"), path=path.lstrip("/")
+        )
+
+    def oidc_endpoint(self) -> str:
+        """Override to use Auth0 domain instead of OIDC_ENDPOINT setting"""
+        return self.api_path("")
+
+    def get_user_id(self, details, response):
+        """Return current user id."""
+        return details["user_id"]
+
+    def get_user_details(self, response):
+        """Extract user details from Auth0 response"""
+        details = super().get_user_details(response)
+        # Auth0 specific extra data
+        details.update({
+            "email_verified": response.get("email_verified", False),
+            "picture": response.get("picture"),
+            "locale": response.get("locale"),
+            "user_id": response.get("sub"),
+        })
+
+        return details

--- a/social_core/backends/auth0_openidconnect.py
+++ b/social_core/backends/auth0_openidconnect.py
@@ -35,11 +35,13 @@ class Auth0OpenIdConnectAuth(OpenIdConnectAuth):
         """Extract user details from Auth0 response"""
         details = super().get_user_details(response)
         # Auth0 specific extra data
-        details.update({
-            "email_verified": response.get("email_verified", False),
-            "picture": response.get("picture"),
-            "locale": response.get("locale"),
-            "user_id": response.get("sub"),
-        })
+        details.update(
+            {
+                "email_verified": response.get("email_verified", False),
+                "picture": response.get("picture"),
+                "locale": response.get("locale"),
+                "user_id": response.get("sub"),
+            }
+        )
 
         return details

--- a/social_core/tests/backends/test_auth0_openidconnect.py
+++ b/social_core/tests/backends/test_auth0_openidconnect.py
@@ -2,8 +2,8 @@ import json
 
 import responses
 
-from social_core.tests.backends.open_id_connect import OpenIdConnectTest
 from social_core.tests.backends.oauth import BaseAuthUrlTestMixin
+from social_core.tests.backends.open_id_connect import OpenIdConnectTest
 
 
 class Auth0OpenIdConnectTest(OpenIdConnectTest, BaseAuthUrlTestMixin):
@@ -11,23 +11,27 @@ class Auth0OpenIdConnectTest(OpenIdConnectTest, BaseAuthUrlTestMixin):
     domain = "example.auth0.com"
     issuer = f"https://{domain}/"
 
-    openid_config_body = json.dumps({
-        "issuer": issuer,
-        "authorization_endpoint": f"https://{domain}/authorize",
-        "token_endpoint": f"https://{domain}/oauth/token",
-        "userinfo_endpoint": f"https://{domain}/userinfo",
-        "revocation_endpoint": f"https://{domain}/oauth/revoke",
-        "jwks_uri": f"https://{domain}/.well-known/jwks.json",
-    })
+    openid_config_body = json.dumps(
+        {
+            "issuer": issuer,
+            "authorization_endpoint": f"https://{domain}/authorize",
+            "token_endpoint": f"https://{domain}/oauth/token",
+            "userinfo_endpoint": f"https://{domain}/userinfo",
+            "revocation_endpoint": f"https://{domain}/oauth/revoke",
+            "jwks_uri": f"https://{domain}/.well-known/jwks.json",
+        }
+    )
 
     expected_username = "testuser"
 
     def extra_settings(self):
         settings = super().extra_settings()
-        settings.update({
-            "SOCIAL_AUTH_AUTH0_OPENIDCONNECT_DOMAIN": self.domain,
-            "SOCIAL_AUTH_AUTH0_OPENIDCONNECT_USERNAME_KEY": "nickname",
-        })
+        settings.update(
+            {
+                "SOCIAL_AUTH_AUTH0_OPENIDCONNECT_DOMAIN": self.domain,
+                "SOCIAL_AUTH_AUTH0_OPENIDCONNECT_USERNAME_KEY": "nickname",
+            }
+        )
         return settings
 
     def pre_complete_callback(self, start_url) -> None:
@@ -38,29 +42,29 @@ class Auth0OpenIdConnectTest(OpenIdConnectTest, BaseAuthUrlTestMixin):
             "GET",
             url=self.backend.userinfo_url(),
             status=200,
-            body=json.dumps({
-                "nickname": self.expected_username,
-                "email": "test@example.com",
-                "email_verified": True,
-                "picture": "https://example.com/avatar.jpg",
-                "locale": "en-US",
-                "sub": "auth0|123456789",
-                "name": "Test User",
-                "given_name": "Test",
-                "family_name": "User",
-            }),
+            body=json.dumps(
+                {
+                    "nickname": self.expected_username,
+                    "email": "test@example.com",
+                    "email_verified": True,
+                    "picture": "https://example.com/avatar.jpg",
+                    "locale": "en-US",
+                    "sub": "auth0|123456789",
+                    "name": "Test User",
+                    "given_name": "Test",
+                    "family_name": "User",
+                }
+            ),
             content_type="application/json",
         )
 
     def test_domain_configuration(self):
         """Test that domain-based URLs are constructed correctly"""
         self.assertEqual(
-            self.backend.authorization_url(),
-            f"https://{self.domain}/authorize"
+            self.backend.authorization_url(), f"https://{self.domain}/authorize"
         )
         self.assertEqual(
-            self.backend.access_token_url(),
-            f"https://{self.domain}/oauth/token"
+            self.backend.access_token_url(), f"https://{self.domain}/oauth/token"
         )
 
     def test_auth0_user_details(self):

--- a/social_core/tests/backends/test_auth0_openidconnect.py
+++ b/social_core/tests/backends/test_auth0_openidconnect.py
@@ -1,0 +1,89 @@
+import json
+
+import responses
+
+from social_core.tests.backends.open_id_connect import OpenIdConnectTest
+from social_core.tests.backends.oauth import BaseAuthUrlTestMixin
+
+
+class Auth0OpenIdConnectTest(OpenIdConnectTest, BaseAuthUrlTestMixin):
+    backend_path = "social_core.backends.auth0_openidconnect.Auth0OpenIdConnectAuth"
+    domain = "example.auth0.com"
+    issuer = f"https://{domain}/"
+
+    openid_config_body = json.dumps({
+        "issuer": issuer,
+        "authorization_endpoint": f"https://{domain}/authorize",
+        "token_endpoint": f"https://{domain}/oauth/token",
+        "userinfo_endpoint": f"https://{domain}/userinfo",
+        "revocation_endpoint": f"https://{domain}/oauth/revoke",
+        "jwks_uri": f"https://{domain}/.well-known/jwks.json",
+    })
+
+    expected_username = "testuser"
+
+    def extra_settings(self):
+        settings = super().extra_settings()
+        settings.update({
+            "SOCIAL_AUTH_AUTH0_OPENIDCONNECT_DOMAIN": self.domain,
+            "SOCIAL_AUTH_AUTH0_OPENIDCONNECT_USERNAME_KEY": "nickname",
+        })
+        return settings
+
+    def pre_complete_callback(self, start_url) -> None:
+        super().pre_complete_callback(start_url)
+
+        # Mock userinfo response with Auth0-specific fields
+        responses.add(
+            "GET",
+            url=self.backend.userinfo_url(),
+            status=200,
+            body=json.dumps({
+                "nickname": self.expected_username,
+                "email": "test@example.com",
+                "email_verified": True,
+                "picture": "https://example.com/avatar.jpg",
+                "locale": "en-US",
+                "sub": "auth0|123456789",
+                "name": "Test User",
+                "given_name": "Test",
+                "family_name": "User",
+            }),
+            content_type="application/json",
+        )
+
+    def test_domain_configuration(self):
+        """Test that domain-based URLs are constructed correctly"""
+        self.assertEqual(
+            self.backend.authorization_url(),
+            f"https://{self.domain}/authorize"
+        )
+        self.assertEqual(
+            self.backend.access_token_url(),
+            f"https://{self.domain}/oauth/token"
+        )
+
+    def test_auth0_user_details(self):
+        """Test Auth0-specific user detail extraction"""
+        response = {
+            "nickname": "testuser",
+            "email": "test@example.com",
+            "email_verified": True,
+            "picture": "https://example.com/avatar.jpg",
+            "locale": "en-US",
+            "sub": "auth0|123456789",
+            "name": "Test User",
+            "given_name": "Test",
+            "family_name": "User",
+        }
+
+        details = self.backend.get_user_details(response)
+
+        self.assertEqual(details["username"], "testuser")
+        self.assertEqual(details["email"], "test@example.com")
+        self.assertTrue(details["email_verified"])
+        self.assertEqual(details["picture"], "https://example.com/avatar.jpg")
+        self.assertEqual(details["user_id"], "auth0|123456789")
+
+    def test_everything_works(self) -> None:
+        self.do_login()


### PR DESCRIPTION
I have been using the generic OIDC backend for Auth0 and it more or less works, so I don't think too many changes are required from the generic OIDC backend. However, I'm running into issues with the provider name etc. that that I think would be solved by having an auth0 specific implementation.

Please let me know what else would be required in terms of tests etc., I need to do a bit of further testing of the refresh tokens.