### PR TITLE
Set SEND_USER_AGENT as True on MediaWiki backend

### DIFF
--- a/social_core/backends/mediawiki.py
+++ b/social_core/backends/mediawiki.py
@@ -32,6 +32,7 @@ class MediaWiki(BaseOAuth1):
     name = "mediawiki"
     MEDIAWIKI_URL = "https://meta.wikimedia.org/w/index.php"
     SOCIAL_AUTH_MEDIAWIKI_CALLBACK = "oob"
+    SEND_USER_AGENT = True
     LEEWAY = 10.0
 
     def unauthorized_token(self):


### PR DESCRIPTION
Sending the user-agent is now mandatory when using the Wikimedia APIs (Wikipedia, Wikidata, ...). Without it, the server returns a 403 with the following message:
`Please set a user-agent and respect our robot policy https://w.wiki/4wJS. See also T400119` ([link](https://phabricator.wikimedia.org/T400119))