### PR TITLE
Change domains for VK backend

### DIFF
--- a/social_core/backends/vk.py
+++ b/social_core/backends/vk.py
@@ -93,8 +93,8 @@ class VKOAuth2(BaseOAuth2):
 
     name = "vk-oauth2"
     ID_KEY = "id"
-    AUTHORIZATION_URL = "https://oauth.vk.com/authorize"
-    ACCESS_TOKEN_URL = "https://oauth.vk.com/access_token"
+    AUTHORIZATION_URL = "https://oauth.vk.ru/authorize"
+    ACCESS_TOKEN_URL = "https://oauth.vk.ru/access_token"
     EXTRA_DATA = [("id", "id"), ("expires_in", "expires")]
 
     def get_user_details(self, response):
@@ -158,11 +158,11 @@ class VKOAuth2(BaseOAuth2):
 
             data["method"] = method
             data["format"] = "json"
-            url = "https://api.vk.com/api.php"
+            url = "https://api.vk.ru/api.php"
             param_list = sorted(item + "=" + data[item] for item in data)
             data["sig"] = vk_sig("".join(param_list) + secret)
         else:
-            url = "https://api.vk.com/method/" + method
+            url = "https://api.vk.ru/method/" + method
 
         try:
             return self.get_json(url, params=data)

--- a/social_core/tests/backends/test_vk.py
+++ b/social_core/tests/backends/test_vk.py
@@ -5,7 +5,7 @@ from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 class VKOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     backend_path = "social_core.backends.vk.VKOAuth2"
-    user_data_url = "https://api.vk.com/method/users.get"
+    user_data_url = "https://api.vk.ru/method/users.get"
     expected_username = "durov"
     access_token_body = json.dumps({"access_token": "foobar", "token_type": "bearer"})
     user_data_body = json.dumps(


### PR DESCRIPTION
VK has started sending out such a message to everyone who has OAuth integration:

<img width="648" height="224" alt="image" src="https://github.com/user-attachments/assets/3fc5456e-bb89-4aab-b1b8-2987db48da86" />

Eng translation:
> VKontakte switches to a domain vk.ru - now all API integrations and authorizations will be available only through it.
> 
> To ensure that your services work correctly, change their domains by September 30th, for example:
> - vk.ru/dev instead of vk.com/dev
> - oauth.vk.ru instead of oauth.vk.com
> - api.vk.ru instead of api.vk.com
> 
> If you have any questions, please contact Support: dev.vk.com/ru/support