### PR TITLE
feat: send user agent by default

### DIFF
--- a/social_core/backends/base.py
+++ b/social_core/backends/base.py
@@ -25,7 +25,7 @@ class BaseAuth:
     EXTRA_DATA: list[str | tuple[str, str] | tuple[str, str, bool]] | None = None
     GET_ALL_EXTRA_DATA = False
     REQUIRES_EMAIL_VALIDATION = False
-    SEND_USER_AGENT = False
+    SEND_USER_AGENT = True
 
     def __init__(self, strategy, redirect_uri=None) -> None:
         self.strategy = strategy

--- a/social_core/backends/github.py
+++ b/social_core/backends/github.py
@@ -22,7 +22,6 @@ class GithubOAuth2(BaseOAuth2):
     SCOPE_SEPARATOR = ","
     REDIRECT_STATE = False
     STATE_PARAMETER = True
-    SEND_USER_AGENT = True
     EXTRA_DATA = [
         ("id", "id"),
         ("expires_in", "expires"),

--- a/social_core/backends/reddit.py
+++ b/social_core/backends/reddit.py
@@ -18,7 +18,6 @@ class RedditOAuth2(BaseOAuth2):
     REDIRECT_STATE = False
     SCOPE_SEPARATOR = ","
     DEFAULT_SCOPE = ["identity"]
-    SEND_USER_AGENT = True
     EXTRA_DATA = [
         ("id", "id"),
         ("name", "username"),

--- a/social_core/backends/simplelogin.py
+++ b/social_core/backends/simplelogin.py
@@ -14,7 +14,6 @@ class SimpleLoginOAuth2(BaseOAuth2):
     ACCESS_TOKEN_URL = "https://app.simplelogin.io/oauth2/token"
     REDIRECT_STATE = False
     STATE_PARAMETER = True
-    SEND_USER_AGENT = True
     EXTRA_DATA = [
         ("name", "name"),
         ("email", "email"),

--- a/social_core/backends/untappd.py
+++ b/social_core/backends/untappd.py
@@ -17,7 +17,6 @@ class UntappdOAuth2(BaseOAuth2):
     ACCESS_TOKEN_METHOD = "GET"
     STATE_PARAMETER = False
     REDIRECT_STATE = False
-    SEND_USER_AGENT = True
     EXTRA_DATA = [
         ("id", "id"),
         ("bio", "bio"),


### PR DESCRIPTION
This is now needed by mediawiki.py (Wikimedia policy has [required it for some 15 years][1], and more recently has enforced it more strictly, see [T400119][2]), but discussion in #1241 concluded that it should really be enabled by default for all sites. If it turns out to break anything, that particular backend can override it to False again.

[1]: https://lists.wikimedia.org/hyperkitty/list/wikitech-l@lists.wikimedia.org/message/R4RU7XTBM5J3BTS6GGQW77NYS2E4WGLI/
[2]: https://phabricator.wikimedia.org/T400119