### PR TITLE
OIDC: use info in id_token if not in response

### DIFF
--- a/social_core/backends/open_id_connect.py
+++ b/social_core/backends/open_id_connect.py
@@ -337,6 +337,10 @@ class OpenIdConnectAuth(BaseOAuth2):
 
     def get_user_details(self, response):
         username_key = self.setting("USERNAME_KEY", self.USERNAME_KEY)
+        # populate response with id_token if needed
+        for key in [username_key, "email", "name", "given_name", "family_name"]:
+            if response.get(key) is None and self.id_token is not None:
+                response[key] = self.id_token.get(key)
         return {
             "username": response.get(username_key),
             "email": response.get("email"),

--- a/social_core/backends/open_id_connect.py
+++ b/social_core/backends/open_id_connect.py
@@ -337,7 +337,6 @@ class OpenIdConnectAuth(BaseOAuth2):
 
     def get_user_details(self, response):
         username_key = self.setting("USERNAME_KEY", self.USERNAME_KEY)
-        # populate response with id_token if needed
         user_details = {}
         for key in [username_key, "email", "name", "given_name", "family_name"]:
             if key in response:

--- a/social_core/backends/open_id_connect.py
+++ b/social_core/backends/open_id_connect.py
@@ -337,10 +337,11 @@ class OpenIdConnectAuth(BaseOAuth2):
 
     def get_user_details(self, response):
         username_key = self.setting("USERNAME_KEY", self.USERNAME_KEY)
+
         def get_value(key):
             if key in response:
                 return response.get(key)
-            elif self.id_token is not None:
+            if self.id_token is not None:
                 return self.id_token.get(key)
             return None
 

--- a/social_core/backends/open_id_connect.py
+++ b/social_core/backends/open_id_connect.py
@@ -337,18 +337,19 @@ class OpenIdConnectAuth(BaseOAuth2):
 
     def get_user_details(self, response):
         username_key = self.setting("USERNAME_KEY", self.USERNAME_KEY)
-        user_details = {}
-        for key in [username_key, "email", "name", "given_name", "family_name"]:
+        def get_value(key):
             if key in response:
-                user_details[key] = response.get(key)
+                return response.get(key)
             elif self.id_token is not None:
-                user_details[key] = self.id_token.get(key)
+                return self.id_token.get(key)
+            return None
+
         return {
-            "username": user_details.get(username_key),
-            "email": user_details.get("email"),
-            "fullname": user_details.get("name"),
-            "first_name": user_details.get("given_name"),
-            "last_name": user_details.get("family_name"),
+            "username": get_value(username_key),
+            "email": get_value("email"),
+            "fullname": get_value("name"),
+            "first_name": get_value("given_name"),
+            "last_name": get_value("family_name"),
         }
 
     @staticmethod

--- a/social_core/backends/open_id_connect.py
+++ b/social_core/backends/open_id_connect.py
@@ -338,15 +338,18 @@ class OpenIdConnectAuth(BaseOAuth2):
     def get_user_details(self, response):
         username_key = self.setting("USERNAME_KEY", self.USERNAME_KEY)
         # populate response with id_token if needed
+        user_details = {}
         for key in [username_key, "email", "name", "given_name", "family_name"]:
-            if response.get(key) is None and self.id_token is not None:
-                response[key] = self.id_token.get(key)
+            if key in response:
+                user_details[key] = response.get(key)
+            elif self.id_token is not None:
+                user_details[key] = self.id_token.get(key)
         return {
-            "username": response.get(username_key),
-            "email": response.get("email"),
-            "fullname": response.get("name"),
-            "first_name": response.get("given_name"),
-            "last_name": response.get("family_name"),
+            "username": user_details.get(username_key),
+            "email": user_details.get("email"),
+            "fullname": user_details.get("name"),
+            "first_name": user_details.get("given_name"),
+            "last_name": user_details.get("family_name"),
         }
 
     @staticmethod


### PR DESCRIPTION
Dear developpers,
When using the OpenIdConnectAuth class with a ADFS IdP I got an issue because the email and `USERNAME_KEY` was not part of the response but part of the id_token.
The changes I made propose to use the info from the id_token if the key is not present in the response.
I don't know if this makes sense or if this should be a new Class.

I don't know how to make a test for this.