### PR TITLE
fix(backens): avoid passing pipeline data as kwargs

### DIFF
--- a/social_core/backends/asana.py
+++ b/social_core/backends/asana.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import datetime
+from typing import Any
 
 from .oauth import BaseOAuth2
 
@@ -32,8 +35,15 @@ class AsanaOAuth2(BaseOAuth2):
             self.USER_DATA_URL, headers={"Authorization": f"Bearer {access_token}"}
         )
 
-    def extra_data(self, user, uid, response, details=None, *args, **kwargs):
-        data = super().extra_data(user, uid, response, details)
+    def extra_data(
+        self,
+        user,
+        uid: str,
+        response: dict[str, Any],
+        details: dict[str, Any],
+        pipeline_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        data = super().extra_data(user, uid, response, details, pipeline_kwargs)
         if self.setting("ESTIMATE_EXPIRES_ON"):
             expires_on = datetime.datetime.now(
                 datetime.timezone.utc

--- a/social_core/backends/azuread.py
+++ b/social_core/backends/azuread.py
@@ -27,7 +27,10 @@ Azure AD OAuth2 backend, docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/azuread.html
 """
 
+from __future__ import annotations
+
 import time
+from typing import Any
 
 import jwt
 
@@ -120,10 +123,17 @@ class AzureADOAuth2(BaseOAuth2):
             extra_arguments.update({"resource": resource})
         return extra_arguments
 
-    def extra_data(self, user, uid, response, details=None, *args, **kwargs):
+    def extra_data(
+        self,
+        user,
+        uid: str,
+        response: dict[str, Any],
+        details: dict[str, Any],
+        pipeline_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
         """Return access_token and extra defined names to store in
         extra_data field"""
-        data = super().extra_data(user, uid, response, details, *args, **kwargs)
+        data = super().extra_data(user, uid, response, details, pipeline_kwargs)
         data["resource"] = self.setting("RESOURCE")
         return data
 

--- a/social_core/backends/base.py
+++ b/social_core/backends/base.py
@@ -139,8 +139,7 @@ class BaseAuth:
         uid: str,
         response: dict[str, Any],
         details: dict[str, Any],
-        *args,
-        **kwargs,
+        pipeline_kwargs: dict[str, Any],
     ) -> dict[str, Any]:
         """Return default extra data to store in extra_data field"""
         data: dict[str, Any] = {

--- a/social_core/backends/behance.py
+++ b/social_core/backends/behance.py
@@ -3,6 +3,10 @@ Behance OAuth2 backend, docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/behance.html
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 from .oauth import BaseOAuth2
 
 
@@ -33,10 +37,17 @@ class BehanceOAuth2(BaseOAuth2):
             "email": "",
         }
 
-    def extra_data(self, user, uid, response, details=None, *args, **kwargs):
+    def extra_data(
+        self,
+        user,
+        uid: str,
+        response: dict[str, Any],
+        details: dict[str, Any],
+        pipeline_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
         # Pull up the embedded user attributes so they can be found as extra
         # data. See the example token response for possible attributes:
         # http://www.behance.net/dev/authentication#step-by-step
         data = response.copy()
         data.update(response["user"])
-        return super().extra_data(user, uid, data, details, *args, **kwargs)
+        return super().extra_data(user, uid, response, details, pipeline_kwargs)

--- a/social_core/backends/disqus.py
+++ b/social_core/backends/disqus.py
@@ -3,6 +3,10 @@ Disqus OAuth2 backend, docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/disqus.html
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 from .oauth import BaseOAuth2
 
 
@@ -38,9 +42,16 @@ class DisqusOAuth2(BaseOAuth2):
             "name": rr.get("name", ""),
         }
 
-    def extra_data(self, user, uid, response, details=None, *args, **kwargs):
+    def extra_data(
+        self,
+        user,
+        uid: str,
+        response: dict[str, Any],
+        details: dict[str, Any],
+        pipeline_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
         meta_response = dict(response, **response.get("response", {}))
-        return super().extra_data(user, uid, meta_response, details, *args, **kwargs)
+        return super().extra_data(user, uid, meta_response, details, pipeline_kwargs)
 
     def user_data(self, access_token, *args, **kwargs):
         """Loads user data from service"""

--- a/social_core/backends/evernote.py
+++ b/social_core/backends/evernote.py
@@ -3,6 +3,10 @@ Evernote OAuth1 backend (with sandbox mode support), docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/evernote.html
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 from requests import HTTPError
 
 from social_core.exceptions import AuthCanceled
@@ -57,8 +61,15 @@ class EvernoteOAuth(BaseOAuth1):
                 raise AuthCanceled(self, response=err.response)
             raise
 
-    def extra_data(self, user, uid, response, details, *args, **kwargs):
-        data = super().extra_data(user, uid, response, details, *args, **kwargs)
+    def extra_data(
+        self,
+        user,
+        uid: str,
+        response: dict[str, Any],
+        details: dict[str, Any],
+        pipeline_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        data = super().extra_data(user, uid, response, details, pipeline_kwargs)
         # Evernote returns expiration timestamp in milliseconds, so it needs to
         # be normalized.
         if "expires" in data:

--- a/social_core/backends/exacttarget.py
+++ b/social_core/backends/exacttarget.py
@@ -4,7 +4,10 @@ Support Authentication from IMH using JWT token and pre-shared key.
 Requires package pyjwt
 """
 
+from __future__ import annotations
+
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 import jwt
 
@@ -74,7 +77,14 @@ class ExactTargetOAuth2(BaseOAuth2):
             raise AuthFailed(self, "Authentication Failed")
         return self.do_auth(token, *args, **kwargs)
 
-    def extra_data(self, user, uid, response, details=None, *args, **kwargs):
+    def extra_data(
+        self,
+        user,
+        uid: str,
+        response: dict[str, Any],
+        details: dict[str, Any],
+        pipeline_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
         """Load extra details from the JWT token"""
         data = {
             "id": details.get("id"),

--- a/social_core/backends/itembase.py
+++ b/social_core/backends/itembase.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import time
+from typing import Any
 
 from social_core.utils import handle_http_errors
 
@@ -30,14 +33,19 @@ class ItembaseOAuth2(BaseOAuth2):
         ("preferred_currency", "preferred_currency"),
     ]
 
-    def add_expires(self, data):
+    def add_expires(self, data: dict[str, Any]) -> dict[str, Any]:
         data["expires"] = int(time.time()) + data.get("expires_in", 0)
         return data
 
-    def extra_data(self, user, uid, response, details=None, *args, **kwargs):
-        data = BaseOAuth2.extra_data(
-            self, user, uid, response, *args, details=details, **kwargs
-        )
+    def extra_data(
+        self,
+        user,
+        uid: str,
+        response: dict[str, Any],
+        details: dict[str, Any],
+        pipeline_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        data = super().extra_data(user, uid, response, details, pipeline_kwargs)
         return self.add_expires(data)
 
     def process_refresh_token_response(self, response, *args, **kwargs):

--- a/social_core/backends/oauth.py
+++ b/social_core/backends/oauth.py
@@ -61,11 +61,18 @@ class OAuthAuth(BaseAuth):
     REDIRECT_STATE = False
     STATE_PARAMETER = False
 
-    def extra_data(self, user, uid, response, details=None, *args, **kwargs):
+    def extra_data(
+        self,
+        user,
+        uid: str,
+        response: dict[str, Any],
+        details: dict[str, Any],
+        pipeline_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
         """Return access_token and extra defined names to store in
         extra_data field"""
-        data = super().extra_data(user, uid, response, details, *args, **kwargs)
-        data["access_token"] = response.get("access_token", "") or kwargs.get(
+        data = super().extra_data(user, uid, response, details, pipeline_kwargs)
+        data["access_token"] = response.get("access_token") or pipeline_kwargs.get(
             "access_token"
         )
         return data
@@ -401,11 +408,20 @@ class BaseOAuth2(OAuthAuth):
             "Accept": "application/json",
         }
 
-    def extra_data(self, user, uid, response, details, *args, **kwargs):
+    def extra_data(
+        self,
+        user,
+        uid: str,
+        response: dict[str, Any],
+        details: dict[str, Any],
+        pipeline_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
         """Return access_token, token_type, and extra defined names to store in
         extra_data field"""
-        data = super().extra_data(user, uid, response, *args, details=details, **kwargs)
-        data["token_type"] = response.get("token_type") or kwargs.get("token_type")
+        data = super().extra_data(user, uid, response, details, pipeline_kwargs)
+        data["token_type"] = response.get("token_type") or pipeline_kwargs.get(
+            "token_type"
+        )
         return data
 
     def request_access_token(

--- a/social_core/backends/odnoklassniki.py
+++ b/social_core/backends/odnoklassniki.py
@@ -3,7 +3,10 @@ Odnoklassniki OAuth2 and Iframe Application backends, docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/odnoklassnikiru.html
 """
 
+from __future__ import annotations
+
 from hashlib import md5
+from typing import Any
 from urllib.parse import unquote
 
 from social_core.exceptions import AuthFailed
@@ -63,7 +66,14 @@ class OdnoklassnikiApp(BaseAuth):
     name = "odnoklassniki-app"
     ID_KEY = "uid"
 
-    def extra_data(self, user, uid, response, details=None, *args, **kwargs):
+    def extra_data(
+        self,
+        user,
+        uid: str,
+        response: dict[str, Any],
+        details: dict[str, Any],
+        pipeline_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
         return {
             key: value
             for key, value in response.items()

--- a/social_core/backends/open_id.py
+++ b/social_core/backends/open_id.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from openid.consumer.consumer import CANCEL, FAILURE, SUCCESS, Consumer
 from openid.consumer.discover import DiscoveryFailure
 from openid.extensions import ax, pape, sreg
@@ -127,7 +129,14 @@ class OpenIdAuth(BaseAuth):
         )
         return values
 
-    def extra_data(self, user, uid, response, details=None, *args, **kwargs):
+    def extra_data(
+        self,
+        user,
+        uid: str,
+        response: dict[str, Any],
+        details: dict[str, Any],
+        pipeline_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
         """Return defined extra data names to store in extra_data field.
         Settings will be inspected to get more values names that should be
         stored on extra_data field. Setting name is created from current
@@ -141,7 +150,7 @@ class OpenIdAuth(BaseAuth):
         sreg_names = self.setting("SREG_EXTRA_DATA")
         ax_names = self.setting("AX_EXTRA_DATA")
         values = self.values_from_response(response, sreg_names, ax_names)
-        from_details = super().extra_data(user, uid, {}, details, *args, **kwargs)
+        from_details = super().extra_data(user, uid, {}, details, pipeline_kwargs)
         values.update(from_details)
         return values
 

--- a/social_core/backends/persona.py
+++ b/social_core/backends/persona.py
@@ -3,6 +3,10 @@ Mozilla Persona authentication backend, docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/persona.html
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 from social_core.exceptions import AuthFailed, AuthMissingParameter
 from social_core.utils import handle_http_errors
 
@@ -34,7 +38,14 @@ class PersonaAuth(BaseAuth):
             "last_name": "",
         }
 
-    def extra_data(self, user, uid, response, details=None, *args, **kwargs):
+    def extra_data(
+        self,
+        user,
+        uid: str,
+        response: dict[str, Any],
+        details: dict[str, Any],
+        pipeline_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
         """Return users extra data"""
         return {"audience": response["audience"], "issuer": response["issuer"]}
 

--- a/social_core/backends/pocket.py
+++ b/social_core/backends/pocket.py
@@ -3,6 +3,10 @@ Pocket OAuth2 backend, docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/pocket.html
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 from social_core.utils import handle_http_errors
 
 from .base import BaseAuth
@@ -23,7 +27,14 @@ class PocketAuth(BaseAuth):
     def get_user_details(self, response):
         return {"username": response["username"]}
 
-    def extra_data(self, user, uid, response, details=None, *args, **kwargs):
+    def extra_data(
+        self,
+        user,
+        uid: str,
+        response: dict[str, Any],
+        details: dict[str, Any],
+        pipeline_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
         return response
 
     def auth_url(self) -> str:

--- a/social_core/backends/saml.py
+++ b/social_core/backends/saml.py
@@ -11,6 +11,7 @@ Terminology:
 from __future__ import annotations
 
 import json
+from typing import Any
 
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
 from onelogin.saml2.settings import OneLogin_Saml2_Settings
@@ -436,9 +437,16 @@ class SAMLAuth(BaseAuth):
         kwargs.update({"response": response, "backend": self})
         return self.strategy.authenticate(*args, **kwargs)
 
-    def extra_data(self, user, uid, response, details=None, *args, **kwargs):
+    def extra_data(
+        self,
+        user,
+        uid: str,
+        response: dict[str, Any],
+        details: dict[str, Any],
+        pipeline_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
         extra_data = super().extra_data(
-            user, uid, response["attributes"], *args, details=details, **kwargs
+            user, uid, response["attributes"], details, pipeline_kwargs
         )
         extra_data["session_index"] = response["session_index"]
         extra_data["name_id"] = response["attributes"]["name_id"]

--- a/social_core/backends/shopify.py
+++ b/social_core/backends/shopify.py
@@ -3,6 +3,10 @@ Shopify OAuth2 backend, docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/shopify.html
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 import shopify
 
 from social_core.exceptions import AuthCanceled, AuthFailed
@@ -27,10 +31,17 @@ class ShopifyOAuth2(BaseOAuth2):
         """Use the shopify store name as the username"""
         return {"username": str(response.get("shop", "")).replace(".myshopify.com", "")}
 
-    def extra_data(self, user, uid, response, details=None, *args, **kwargs):
+    def extra_data(
+        self,
+        user,
+        uid: str,
+        response: dict[str, Any],
+        details: dict[str, Any],
+        pipeline_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
         """Return access_token and extra defined names to store in
         extra_data field"""
-        data = super().extra_data(user, uid, response, details, *args, **kwargs)
+        data = super().extra_data(user, uid, response, details, pipeline_kwargs)
         session = shopify.Session(
             self.data.get("shop").strip(), version=self.shopify_api_version
         )

--- a/social_core/backends/telegram.py
+++ b/social_core/backends/telegram.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import hashlib
 import hmac
 import time
+from typing import Any
 
 from social_core.exceptions import AuthFailed, AuthMissingParameter
 from social_core.utils import handle_http_errors
@@ -36,7 +39,14 @@ class TelegramAuth(BaseAuth):
         if built_hash != received_hash_string:
             raise AuthFailed(self, "Invalid hash supplied")
 
-    def extra_data(self, user, uid, response, details=None, *args, **kwargs):
+    def extra_data(
+        self,
+        user,
+        uid: str,
+        response: dict[str, Any],
+        details: dict[str, Any],
+        pipeline_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
         return response
 
     def get_user_details(self, response):

--- a/social_core/pipeline/social_auth.py
+++ b/social_core/pipeline/social_auth.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from social_core.exceptions import AuthAlreadyAssociated, AuthException, AuthForbidden
 
 
@@ -88,5 +90,5 @@ def load_extra_data(backend, details, response, uid, user, *args, **kwargs) -> N
         backend.name, uid
     )
     if social:
-        extra_data = backend.extra_data(user, uid, response, details, *args, **kwargs)
+        extra_data = backend.extra_data(user, uid, response, details, kwargs)
         social.set_extra_data(extra_data)

--- a/social_core/storage.py
+++ b/social_core/storage.py
@@ -49,7 +49,9 @@ class UserMixin:
         backend = self.get_backend_instance(strategy)
         if token and backend and hasattr(backend, "refresh_token"):
             response = backend.refresh_token(token, *args, **kwargs)
-            extra_data = backend.extra_data(self, self.uid, response, self.extra_data)
+            extra_data = backend.extra_data(
+                self, self.uid, response, self.extra_data, {}
+            )
             if self.set_extra_data(extra_data):
                 self.save()
 
@@ -102,14 +104,14 @@ class UserMixin:
             self.refresh_token(strategy)
         return self.access_token
 
-    def set_extra_data(self, extra_data: dict[str, Any] | None = None) -> bool | None:
+    def set_extra_data(self, extra_data: dict[str, Any] | None = None) -> bool:
         if extra_data and self.extra_data != extra_data:
             if self.extra_data and not isinstance(self.extra_data, str):
                 self.extra_data.update(extra_data)
             else:
                 self.extra_data = extra_data
             return True
-        return None
+        return False
 
     @classmethod
     def clean_username(cls, value):


### PR DESCRIPTION
The pipeline can be customized to contain any arbitrary data and that could result in passing duplicate parameters to the extra_data method. Passing the pipeline kwargs in a separate dict avoids that. Passing positional args is dropped as that can break in various ways.

This is possibly a breaking change for third-party backends.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
