### PR TITLE
feat(saml): do not require RelayState

### DIFF
--- a/social_core/backends/saml.py
+++ b/social_core/backends/saml.py
@@ -284,7 +284,7 @@ class SAMLAuth(BaseAuth):
                 raise AuthMissingParameter(self, "RelayState.idp")
             # Use the only configured IDP
             idp_name = next(iter(enabled_idps))
-        idp_config = self.setting("ENABLED_IDPS")[idp_name]
+        idp_config = enabled_idps[idp_name]
         return SAMLIdentityProvider(self, idp_name, **idp_config)
 
     def generate_saml_config(self, idp: SAMLIdentityProvider | None = None):


### PR DESCRIPTION
The RelayState cannot be present on IdP initiated login flow and it is actually not needed in case only one IdP is configured.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
