### PR TITLE
Catch ValueError in `sanitize_redirect`

### DIFF
--- a/social_core/tests/test_utils.py
+++ b/social_core/tests/test_utils.py
@@ -55,6 +55,12 @@ class SanitizeRedirectTest(unittest.TestCase):
             url = f"http://{host}/path/"
             self.assertEqual(sanitize_redirect(allowed_hosts, url), url)
 
+    def test_invalid_unicode_nfkc_redirect(self) -> None:
+        """URLs with invalid netloc chars under NFKC like \u2100 should return None"""
+        self.assertEqual(
+            sanitize_redirect(["myapp.com"], "https://evil.c\u2100.myapp.com"), None
+        )
+
     def test_multiple_hosts_wrong_host(self) -> None:
         self.assertEqual(
             sanitize_redirect(

--- a/social_core/utils.py
+++ b/social_core/utils.py
@@ -88,7 +88,7 @@ def sanitize_redirect(hosts: list[str], redirect_to: str | Any) -> str | None:
     try:
         # Don't redirect to a host that's not in the list
         netloc = urlparse(redirect_to)[1] or hosts[0]
-    except (TypeError, AttributeError):
+    except (TypeError, AttributeError, ValueError):
         return None
 
     if netloc in hosts:


### PR DESCRIPTION
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
`ValueError netloc 'some-url-here' contains invalid characters under NFKC normalization` exception can be obtained if using characters like in added test.

Originally during `/login/google-oauth2?next=https://evil.garbages.com` redirect in django app using social-auth-app-django.
