### PR TITLE
feat(backend): add opt-in PKCE support of OIDC

### DIFF
--- a/social_core/backends/open_id_connect.py
+++ b/social_core/backends/open_id_connect.py
@@ -17,7 +17,7 @@ from jwt import (
 )
 from jwt.utils import base64url_decode
 
-from social_core.backends.oauth import BaseOAuth2
+from social_core.backends.oauth import BaseOAuth2PKCE
 from social_core.exceptions import (
     AuthInvalidParameter,
     AuthMissingParameter,
@@ -45,7 +45,7 @@ class OpenIdConnectAssociation:
         self.assoc_type = assoc_type  # as state
 
 
-class OpenIdConnectAuth(BaseOAuth2):
+class OpenIdConnectAuth(BaseOAuth2PKCE):
     """
     Base class for Open ID Connect backends.
     Currently only the code response type is supported.
@@ -56,6 +56,7 @@ class OpenIdConnectAuth(BaseOAuth2):
     SOCIAL_AUTH_OIDC_OIDC_ENDPOINT = 'https://.....'  # endpoint without /.well-known/openid-configuration
     SOCIAL_AUTH_OIDC_KEY = '<client_id>'
     SOCIAL_AUTH_OIDC_SECRET = '<client_secret>'
+    SOCIAL_AUTH_OIDC_USE_PKCE = True  # optional, enables PKCE for this backend
     """
 
     name = "oidc"
@@ -89,6 +90,8 @@ class OpenIdConnectAuth(BaseOAuth2):
     ID_TOKEN_HINT: str | None = None
     LOGIN_HINT: str | None = None
     ACR_VALUES: str | None = None
+    PKCE_DEFAULT_CODE_CHALLENGE_METHOD = "S256"
+    DEFAULT_USE_PKCE = False
 
     def __init__(
         self, strategy: BaseStrategy | None = None, redirect_uri: str | None = None

--- a/social_core/tests/backends/open_id_connect.py
+++ b/social_core/tests/backends/open_id_connect.py
@@ -66,6 +66,7 @@ class OpenIdConnectTest(
         if self.__class__.__name__ == "OpenIdConnectTest":
             self.skipTest("base class")
         super().setUp()
+        self.access_token_kwargs = {}
         self.key = JWK_KEY.copy()
         self.public_key = JWK_PUBLIC_KEY.copy()
 

--- a/social_core/tests/backends/test_google.py
+++ b/social_core/tests/backends/test_google.py
@@ -12,6 +12,7 @@ import responses
 from social_core.actions import do_disconnect
 from social_core.exceptions import AuthException, AuthTokenError
 from social_core.tests.models import User
+from social_core.utils import get_querystring, parse_qs
 
 from .base import BaseBackendTest
 from .oauth import BaseAuthUrlTestMixin, OAuth1AuthUrlTestMixin, OAuth1Test, OAuth2Test
@@ -171,6 +172,50 @@ class GoogleOpenIdConnectTest(OpenIdConnectTest):
             ],
         }
     )
+
+    def test_pkce_can_be_enabled_by_setting(self) -> None:
+        self.strategy.set_settings(
+            {
+                **self.extra_settings(),
+                f"SOCIAL_AUTH_{self.name}_USE_PKCE": True,
+            }
+        )
+        responses.add(
+            responses.GET,
+            url="https://openidconnect.googleapis.com/v1/userinfo",
+            status=200,
+            body=json.dumps({"preferred_username": "foo@bar.com"}),
+            content_type="text/json",
+        )
+
+        self.do_start()
+
+        auth_request = next(
+            r.request
+            for r in responses.calls
+            if cast("str", r.request.url).startswith(self.backend.authorization_url())
+        )
+        code_challenge = get_querystring(cast("str", auth_request.url)).get(
+            "code_challenge"
+        )
+        code_challenge_method = get_querystring(cast("str", auth_request.url)).get(
+            "code_challenge_method"
+        )
+
+        self.assertIsNotNone(code_challenge)
+        self.assertEqual(code_challenge_method, "S256")
+
+        auth_complete = next(
+            r.request
+            for r in responses.calls
+            if cast("str", r.request.url).startswith(self.backend.access_token_url())
+        )
+        code_verifier = parse_qs(auth_complete.body).get("code_verifier")
+
+        self.assertEqual(
+            self.backend.generate_code_challenge(code_verifier, code_challenge_method),
+            code_challenge,
+        )
 
 
 class GoogleOneTapTest(BaseBackendTest):

--- a/social_core/tests/backends/test_open_id_connect.py
+++ b/social_core/tests/backends/test_open_id_connect.py
@@ -1,17 +1,82 @@
 from __future__ import annotations
 
 import json
+from typing import Protocol, cast
 
 import responses
 
 from social_core.backends.open_id_connect import OpenIdConnectAuth
 from social_core.exceptions import AuthInvalidParameter
+from social_core.utils import get_querystring, parse_qs
 
 from .oauth import BaseAuthUrlTestMixin
 from .open_id_connect import OpenIdConnectTest
 
 
-class BaseOpenIdConnectTest(OpenIdConnectTest, BaseAuthUrlTestMixin):
+class OpenIdConnectPkceAssertionsCapable(Protocol):
+    backend: OpenIdConnectAuth
+
+    def assertEqual(self, first, second, msg=None) -> None: ...
+
+    def assertIsNone(self, obj, msg=None) -> None: ...
+
+    def assertIsNotNone(self, obj, msg=None) -> None: ...
+
+
+class OpenIdConnectPkceAssertionsMixin:
+    backend: OpenIdConnectAuth
+
+    def assert_pkce_enabled(self: OpenIdConnectPkceAssertionsCapable) -> None:
+        auth_request = next(
+            r.request
+            for r in responses.calls
+            if cast("str", r.request.url).startswith(self.backend.authorization_url())
+        )
+        code_challenge = get_querystring(cast("str", auth_request.url)).get(
+            "code_challenge"
+        )
+        code_challenge_method = get_querystring(cast("str", auth_request.url)).get(
+            "code_challenge_method"
+        )
+
+        self.assertIsNotNone(code_challenge)
+        self.assertEqual(code_challenge_method, "S256")
+
+        auth_complete = next(
+            r.request
+            for r in responses.calls
+            if cast("str", r.request.url).startswith(self.backend.access_token_url())
+        )
+        code_verifier = parse_qs(auth_complete.body).get("code_verifier")
+
+        self.assertEqual(
+            self.backend.generate_code_challenge(code_verifier, code_challenge_method),
+            code_challenge,
+        )
+
+    def assert_pkce_disabled(self: OpenIdConnectPkceAssertionsCapable) -> None:
+        auth_request = next(
+            r.request
+            for r in responses.calls
+            if cast("str", r.request.url).startswith(self.backend.authorization_url())
+        )
+        auth_query = get_querystring(cast("str", auth_request.url))
+
+        self.assertIsNone(auth_query.get("code_challenge"))
+        self.assertIsNone(auth_query.get("code_challenge_method"))
+
+        auth_complete = next(
+            r.request
+            for r in responses.calls
+            if cast("str", r.request.url).startswith(self.backend.access_token_url())
+        )
+
+        self.assertIsNone(parse_qs(auth_complete.body).get("code_verifier"))
+
+
+class BaseOpenIdConnectTest(
+    OpenIdConnectTest, BaseAuthUrlTestMixin, OpenIdConnectPkceAssertionsMixin
+):
     backend_path = "social_core.backends.open_id_connect.OpenIdConnectAuth"
     issuer = "https://example.com"
     openid_config_body = json.dumps(
@@ -49,10 +114,31 @@ class BaseOpenIdConnectTest(OpenIdConnectTest, BaseAuthUrlTestMixin):
     def test_everything_works(self) -> None:
         self.do_login()
 
+    def test_pkce_disabled_by_default(self) -> None:
+        self.do_login()
+        self.assert_pkce_disabled()
+
+    def test_pkce_can_be_enabled_by_setting(self) -> None:
+        self.strategy.set_settings(
+            {
+                **self.extra_settings(),
+                f"SOCIAL_AUTH_{self.name}_USE_PKCE": True,
+            }
+        )
+
+        self.do_login()
+
+        self.assert_pkce_enabled()
+
 
 class ExampleOpenIdConnectAuth(OpenIdConnectAuth):
     name = "example123"
     OIDC_ENDPOINT = "https://example.com/oidc"
+
+
+class OpenIdConnectPkceEnabledByDefault(ExampleOpenIdConnectAuth):
+    name = "example123-pkce-default"
+    DEFAULT_USE_PKCE = True
 
 
 class ExampleOpenIdConnectTest(OpenIdConnectTest):
@@ -85,6 +171,54 @@ class ExampleOpenIdConnectTest(OpenIdConnectTest):
 
     def test_everything_works(self) -> None:
         self.do_login()
+
+
+class ExampleOpenIdConnectPkceEnabledByDefaultTest(
+    OpenIdConnectTest, OpenIdConnectPkceAssertionsMixin
+):
+    backend_path = "social_core.tests.backends.test_open_id_connect.OpenIdConnectPkceEnabledByDefault"
+    issuer = "https://example.com"
+    openid_config_body = json.dumps(
+        {
+            "issuer": "https://example.com",
+            "authorization_endpoint": "https://example.com/oidc/auth",
+            "token_endpoint": "https://example.com/oidc/token",
+            "userinfo_endpoint": "https://example.com/oidc/userinfo",
+            "revocation_endpoint": "https://example.com/oidc/revoke",
+            "jwks_uri": "https://example.com/oidc/certs",
+        }
+    )
+
+    expected_username = "cartman"
+
+    def pre_complete_callback(self, start_url) -> None:
+        super().pre_complete_callback(start_url)
+        responses.add(
+            responses.GET,
+            url=self.backend.userinfo_url(),
+            status=200,
+            body=json.dumps({"preferred_username": self.expected_username}),
+            content_type="text/json",
+        )
+
+    def test_everything_works(self) -> None:
+        self.do_login()
+
+    def test_pkce_enabled_by_backend_default(self) -> None:
+        self.do_login()
+        self.assert_pkce_enabled()
+
+    def test_pkce_can_be_disabled_by_setting(self) -> None:
+        self.strategy.set_settings(
+            {
+                **self.extra_settings(),
+                f"SOCIAL_AUTH_{self.name}_USE_PKCE": False,
+            }
+        )
+
+        self.do_login()
+
+        self.assert_pkce_disabled()
 
 
 class OpenIdConnectAuthNoValidateAtHash(ExampleOpenIdConnectAuth):


### PR DESCRIPTION
The OIDC backends can opt-in for PKCE support either on the class level (when provider requires it) or on configuration level.

Issue #1679

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
