### PR TITLE
Fix Auth0 OIDC config paths

### DIFF
--- a/social_core/backends/auth0_openidconnect.py
+++ b/social_core/backends/auth0_openidconnect.py
@@ -1,11 +1,15 @@
+from urllib.parse import urlparse
+
 from social_core.backends.open_id_connect import OpenIdConnectAuth
+from social_core.exceptions import AuthMissingParameter
 
 
 class Auth0OpenIdConnectAuth(OpenIdConnectAuth):
     """
     Auth0 OpenID Connect authentication backend.
 
-    Uses Auth0's OpenID Connect implementation with automatic endpoint discovery.
+    Uses Auth0's OpenID Connect implementation with automatic endpoint discovery
+    based on the domain.
 
     Settings:
         SOCIAL_AUTH_AUTH0_OPENIDCONNECT_DOMAIN = 'your-domain.auth0.com'
@@ -16,6 +20,22 @@ class Auth0OpenIdConnectAuth(OpenIdConnectAuth):
     name = "auth0_openidconnect"
     USERNAME_KEY = "nickname"
     EXTRA_DATA = ["id_token", "refresh_token", ("sub", "id"), "picture"]
+
+    def normalized_domain(self) -> str:
+        """Return Auth0 domain without scheme or surrounding slashes."""
+        domain = self.setting("DOMAIN")
+        if not domain:
+            raise AuthMissingParameter(self, "DOMAIN")
+
+        domain = domain.strip()
+        parsed = urlparse(domain)
+        if parsed.netloc:
+            domain = parsed.netloc
+
+        domain = domain.strip("/")
+        if not domain:
+            raise AuthMissingParameter(self, "DOMAIN")
+        return domain
 
     def api_path(self, path="") -> str:
         """Build API path for Auth0 domain"""

--- a/social_core/backends/auth0_openidconnect.py
+++ b/social_core/backends/auth0_openidconnect.py
@@ -39,11 +39,15 @@ class Auth0OpenIdConnectAuth(OpenIdConnectAuth):
 
     def api_path(self, path="") -> str:
         """Build API path for Auth0 domain"""
-        return f"https://{self.setting('DOMAIN')}/{path.lstrip('/')}"
+        base_url = f"https://{self.normalized_domain()}"
+        path = path.strip("/")
+        if path:
+            return f"{base_url}/{path}"
+        return base_url
 
     def oidc_endpoint(self) -> str:
-        """Override to use Auth0 domain instead of OIDC_ENDPOINT setting"""
-        return self.api_path("")
+        """Return Auth0 OpenID Connect endpoint without trailing slash."""
+        return self.api_path()
 
     def get_user_id(self, details, response):
         """Return current user id."""

--- a/social_core/tests/backends/test_auth0_openidconnect.py
+++ b/social_core/tests/backends/test_auth0_openidconnect.py
@@ -101,9 +101,7 @@ class Auth0OpenIdConnectTest(OpenIdConnectTest, BaseAuthUrlTestMixin):
             self.backend.api_path()
 
     def test_api_path_rejects_missing_domain_after_normalization(self) -> None:
-        self.strategy.set_settings(
-            {"SOCIAL_AUTH_AUTH0_OPENIDCONNECT_DOMAIN": "https://"}
-        )
+        self.strategy.set_settings({"SOCIAL_AUTH_AUTH0_OPENIDCONNECT_DOMAIN": "/"})
         with self.assertRaises(AuthMissingParameter):
             self.backend.api_path()
 

--- a/social_core/tests/backends/test_auth0_openidconnect.py
+++ b/social_core/tests/backends/test_auth0_openidconnect.py
@@ -100,6 +100,11 @@ class Auth0OpenIdConnectTest(OpenIdConnectTest, BaseAuthUrlTestMixin):
         with self.assertRaises(AuthMissingParameter):
             self.backend.api_path()
 
+    def test_api_path_rejects_missing_domain_after_normalization(self) -> None:
+        self.strategy.set_settings({"SOCIAL_AUTH_AUTH0_OPENIDCONNECT_DOMAIN": "https://"})
+        with self.assertRaises(AuthMissingParameter):
+            self.backend.api_path()
+
     def test_oidc_config_uses_correct_discovery_url(self) -> None:
         self.backend.oidc_config.invalidate()
         self.backend.oidc_config()

--- a/social_core/tests/backends/test_auth0_openidconnect.py
+++ b/social_core/tests/backends/test_auth0_openidconnect.py
@@ -101,7 +101,9 @@ class Auth0OpenIdConnectTest(OpenIdConnectTest, BaseAuthUrlTestMixin):
             self.backend.api_path()
 
     def test_api_path_rejects_missing_domain_after_normalization(self) -> None:
-        self.strategy.set_settings({"SOCIAL_AUTH_AUTH0_OPENIDCONNECT_DOMAIN": "https://"})
+        self.strategy.set_settings(
+            {"SOCIAL_AUTH_AUTH0_OPENIDCONNECT_DOMAIN": "https://"}
+        )
         with self.assertRaises(AuthMissingParameter):
             self.backend.api_path()
 

--- a/social_core/tests/backends/test_auth0_openidconnect.py
+++ b/social_core/tests/backends/test_auth0_openidconnect.py
@@ -2,6 +2,7 @@ import json
 
 import responses
 
+from social_core.exceptions import AuthMissingParameter
 from social_core.tests.backends.oauth import BaseAuthUrlTestMixin
 from social_core.tests.backends.open_id_connect import OpenIdConnectTest
 
@@ -67,6 +68,59 @@ class Auth0OpenIdConnectTest(OpenIdConnectTest, BaseAuthUrlTestMixin):
         )
         self.assertEqual(
             self.backend.access_token_url(), f"https://{self.domain}/oauth/token"
+        )
+
+    def test_api_path_normalizes_domain_with_trailing_slash(self) -> None:
+        self.strategy.set_settings(
+            {"SOCIAL_AUTH_AUTH0_OPENIDCONNECT_DOMAIN": f"{self.domain}/"}
+        )
+
+        self.assertEqual(self.backend.api_path(), f"https://{self.domain}")
+        self.assertEqual(
+            self.backend.api_path("/oauth/token/"),
+            f"https://{self.domain}/oauth/token",
+        )
+        self.assertEqual(self.backend.oidc_endpoint(), f"https://{self.domain}")
+
+    def test_api_path_normalizes_domain_with_scheme(self) -> None:
+        self.strategy.set_settings(
+            {"SOCIAL_AUTH_AUTH0_OPENIDCONNECT_DOMAIN": f"https://{self.domain}/"}
+        )
+
+        self.assertEqual(self.backend.api_path(), f"https://{self.domain}")
+        self.assertEqual(
+            self.backend.api_path("/authorize"),
+            f"https://{self.domain}/authorize",
+        )
+        self.assertEqual(self.backend.oidc_endpoint(), f"https://{self.domain}")
+
+    def test_api_path_rejects_missing_domain(self) -> None:
+        self.strategy.set_settings({"SOCIAL_AUTH_AUTH0_OPENIDCONNECT_DOMAIN": ""})
+
+        with self.assertRaises(AuthMissingParameter):
+            self.backend.api_path()
+
+    def test_oidc_config_uses_correct_discovery_url(self) -> None:
+        self.backend.oidc_config.invalidate()
+        self.backend.oidc_config()
+
+        self.assertEqual(
+            responses.calls[-1].request.url,
+            f"https://{self.domain}/.well-known/openid-configuration",
+        )
+
+    def test_oidc_config_uses_correct_discovery_url_with_normalized_domain(
+        self,
+    ) -> None:
+        self.strategy.set_settings(
+            {"SOCIAL_AUTH_AUTH0_OPENIDCONNECT_DOMAIN": f"https://{self.domain}/"}
+        )
+        self.backend.oidc_config.invalidate()
+        self.backend.oidc_config()
+
+        self.assertEqual(
+            responses.calls[-1].request.url,
+            f"https://{self.domain}/.well-known/openid-configuration",
         )
 
     def test_auth0_user_details(self) -> None:


### PR DESCRIPTION
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->

We encountered an issue where the `Auth0OpenIdConnectAuth()` backend failed to look up OIDC config correctly because of a double slash: `https://example.auth0.com//.well-known/openid-configuration`. Looks like this is because it was slightly inconsistent with the base `oidc_endpoint()` implementation, and was including a trailing slash there. I have added some code to make sure we normalize the different URLs involved better, and added tests.

P.S. I contributed this Auth0 OIDC backend, and am actively using it in our projects, so feel free to ping me in future if there's issues with it.