### PR TITLE
fix(saml): validate responses against AuthnRequest

### DIFF
--- a/social_core/backends/saml.py
+++ b/social_core/backends/saml.py
@@ -11,10 +11,12 @@ Terminology:
 from __future__ import annotations
 
 import json
+from binascii import Error as BinasciiError
 from typing import Any, cast
 
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
 from onelogin.saml2.errors import OneLogin_Saml2_Error
+from onelogin.saml2.response import OneLogin_Saml2_Response
 from onelogin.saml2.settings import OneLogin_Saml2_Settings
 
 from social_core.exceptions import (
@@ -22,6 +24,7 @@ from social_core.exceptions import (
     AuthInvalidParameter,
     AuthMissingParameter,
 )
+from social_core.utils import constant_time_compare, user_is_authenticated
 
 from .base import BaseAuth
 
@@ -276,6 +279,115 @@ class SAMLAuth(BaseAuth):
     name = "saml"
     EXTRA_DATA = []
 
+    def _authn_request_id_session_key(self, idp_name: str) -> str:
+        return f"{self.name}_{idp_name}_authn_request_id"
+
+    def _process_response(
+        self, auth: OneLogin_Saml2_Auth, request_id: str | None = None
+    ) -> None:
+        try:
+            auth.process_response(request_id=request_id)
+        except OneLogin_Saml2_Error as error:
+            raise AuthFailed(self, f"SAML login failed: {error}") from error
+        errors = auth.get_errors()
+        if errors or not auth.is_authenticated():
+            reason = auth.get_last_error_reason()
+            raise AuthFailed(self, f"SAML login failed: {errors} ({reason})")
+
+    def _validate_in_response_to(
+        self, auth: OneLogin_Saml2_Auth, request_id: str
+    ) -> None:
+        in_response_to = auth.get_last_response_in_response_to()
+        if not in_response_to or not constant_time_compare(in_response_to, request_id):
+            raise AuthFailed(self, "SAML login failed: invalid InResponseTo")
+
+    def _response_in_response_to(self, idp: SAMLIdentityProvider) -> str | None:
+        try:
+            saml_response = self.strategy.request_post()["SAMLResponse"]
+            response = OneLogin_Saml2_Response(
+                OneLogin_Saml2_Settings(self.generate_saml_config(idp)),
+                saml_response,
+            )
+        except (BinasciiError, KeyError, OneLogin_Saml2_Error, ValueError):
+            return None
+        return cast("str | None", response.get_in_response_to())
+
+    def _request_id_required(
+        self, request_id: str | None, kwargs: dict[str, Any]
+    ) -> bool:
+        return bool(request_id) or user_is_authenticated(kwargs.get("user"))
+
+    def _check_missing_request_id(
+        self, request_id: str | None, session_id: str | None, kwargs: dict[str, Any]
+    ) -> None:
+        if (
+            self._request_id_required(request_id, kwargs)
+            and not request_id
+            and not session_id
+        ):
+            raise AuthFailed(self, "SAML login failed: missing AuthnRequest ID")
+
+    def _validate_processed_response_request_id(
+        self,
+        auth: OneLogin_Saml2_Auth,
+        request_id: str | None,
+        kwargs: dict[str, Any],
+    ) -> bool:
+        get_in_response_to = getattr(auth, "get_last_response_in_response_to", None)
+        in_response_to = get_in_response_to() if get_in_response_to else None
+        if in_response_to:
+            if not request_id:
+                raise AuthFailed(self, "SAML login failed: missing AuthnRequest ID")
+            self._validate_in_response_to(auth, request_id)
+            return True
+        if user_is_authenticated(kwargs.get("user")):
+            raise AuthFailed(self, "SAML login failed: invalid InResponseTo")
+        return False
+
+    def _validate_auth_response(
+        self,
+        auth: OneLogin_Saml2_Auth,
+        request_id_key: str,
+        request_id: str | None,
+        session_id: str | None,
+        kwargs: dict[str, Any],
+        response_in_response_to: str | None,
+    ) -> tuple[bool, bool]:
+        self._check_missing_request_id(request_id, session_id, kwargs)
+        if session_id:
+            if response_in_response_to:
+                # Authenticate the SAML response before trusting RelayState to
+                # restore another session. The restored request ID is checked
+                # against this response below.
+                self._process_response(auth, response_in_response_to)
+                self.strategy.restore_session(session_id, kwargs)
+                request_id = cast(
+                    "str | None", self.strategy.session_get(request_id_key)
+                )
+                if not request_id:
+                    raise AuthFailed(self, "SAML login failed: missing AuthnRequest ID")
+            else:
+                self._process_response(auth)
+                self.strategy.restore_session(session_id, kwargs)
+                request_id = cast(
+                    "str | None", self.strategy.session_get(request_id_key)
+                )
+                return True, self._validate_processed_response_request_id(
+                    auth, request_id, kwargs
+                )
+            self._validate_in_response_to(auth, request_id)
+            return True, True
+        if response_in_response_to:
+            if not request_id:
+                raise AuthFailed(self, "SAML login failed: missing AuthnRequest ID")
+            self._process_response(auth, request_id)
+            self._validate_in_response_to(auth, request_id)
+            return False, True
+        self._process_response(auth)
+        return False, self._validate_processed_response_request_id(
+            auth, request_id, kwargs
+        )
+
     def get_idp(self, idp_name: str | None) -> SAMLIdentityProvider:
         """Given the name of an IdP, get a SAMLIdentityProvider instance"""
         enabled_idps: dict[str, dict] = cast(
@@ -372,7 +484,8 @@ class SAMLAuth(BaseAuth):
             idp_name = self.strategy.request_data()["idp"]
         except KeyError as error:
             raise AuthMissingParameter(self, "idp") from error
-        auth = self._create_saml_auth(idp=self.get_idp(idp_name))
+        idp = self.get_idp(idp_name)
+        auth = self._create_saml_auth(idp=idp)
         # Below, return_to sets the RelayState, which can contain
         # arbitrary data.  We use it to store the specific SAML IdP
         # name, since we multiple IdPs share the same auth_complete
@@ -383,7 +496,11 @@ class SAMLAuth(BaseAuth):
         }
         if session_id := self.strategy.get_session_id():
             relay_state[self.strategy.SESSION_SAVE_KEY] = session_id
-        return auth.login(return_to=json.dumps(relay_state))
+        url = auth.login(return_to=json.dumps(relay_state))
+        self.strategy.session_set(
+            self._authn_request_id_session_key(idp.name), auth.get_last_request_id()
+        )
+        return url
 
     def get_user_details(self, response):
         """Get user details like full name, email, etc. from the
@@ -442,20 +559,28 @@ class SAMLAuth(BaseAuth):
             next_url = relay_state.get("next")
 
         idp = self.get_idp(idp_name)
-        auth = self._create_saml_auth(idp)
-        try:
-            auth.process_response()
-        except OneLogin_Saml2_Error as error:
-            raise AuthFailed(self, f"SAML login failed: {error}") from error
-        errors = auth.get_errors()
-        if errors or not auth.is_authenticated():
-            reason = auth.get_last_error_reason()
-            raise AuthFailed(self, f"SAML login failed: {errors} ({reason})")
+        request_id_key = self._authn_request_id_session_key(idp.name)
+        request_id = cast("str | None", self.strategy.session_get(request_id_key))
+        if session_id:
+            request_id = None
+        self._check_missing_request_id(request_id, session_id, kwargs)
+        response_in_response_to = self._response_in_response_to(idp)
 
+        auth = self._create_saml_auth(idp)
+        session_restored, request_id_validated = self._validate_auth_response(
+            auth,
+            request_id_key,
+            request_id,
+            session_id,
+            kwargs,
+            response_in_response_to,
+        )
+        if request_id_validated:
+            self.strategy.session_pop(request_id_key)
         attributes = auth.get_attributes()
         attributes["name_id"] = auth.get_nameid()
         self._check_entitlements(idp, attributes)
-        if session_id:
+        if session_id and not session_restored:
             self.strategy.restore_session(session_id, kwargs)
         elif next_url:
             # The do_complete action expects the "next" URL to be in

--- a/social_core/tests/backends/test_saml.py
+++ b/social_core/tests/backends/test_saml.py
@@ -17,6 +17,7 @@ except ImportError:
     SAML_MODULE_ENABLED = False
 
 from social_core.exceptions import AuthFailed, AuthMissingParameter
+from social_core.tests.models import User
 
 from .base import BaseBackendTest
 
@@ -31,6 +32,9 @@ class SAMLTest(BaseBackendTest):
     backend_path = "social_core.backends.saml.SAMLAuth"
     expected_username = "myself"
     response_fixture = "saml_response.txt"
+
+    def authn_request_id_session_key(self, idp_name: str) -> str:
+        return f"{self.backend.name}_{idp_name}_authn_request_id"
 
     def extra_settings(self):
         file = DATA_DIR / "saml_config.json"
@@ -151,7 +155,9 @@ class SAMLTest(BaseBackendTest):
         events = []
 
         class ValidAuth:
-            def process_response(self):
+            def process_response(self, request_id=None):
+                if request_id is not None:
+                    raise AssertionError("request_id should be None")
                 events.append("process_response")
 
             def get_errors(self):
@@ -202,14 +208,289 @@ class SAMLTest(BaseBackendTest):
             ["process_response", "restore_session", "authenticate"],
         )
 
+    def test_relay_state_restored_session_request_id_validates_in_response_to(
+        self,
+    ) -> None:
+        events: list[object] = []
+        victim = User("victim")
+        key = self.authn_request_id_session_key("testshib")
+        self.strategy.session_set(key, "STALE_ID")
+
+        class ValidAuth:
+            def process_response(self, request_id=None):
+                events.append(("process_response", request_id))
+
+            def get_errors(self):
+                return []
+
+            def is_authenticated(self):
+                return True
+
+            def get_last_response_in_response_to(self):
+                return "TEST_ID"
+
+            def get_attributes(self):
+                return {}
+
+            def get_nameid(self):
+                return "name-id"
+
+            def get_session_index(self):
+                return "session-index"
+
+        def restore_session(session_id, kwargs) -> None:
+            events.append("restore_session")
+            self.assertEqual(session_id, "restored-session")
+            self.strategy.session_set(key, "TEST_ID")
+            kwargs["user"] = victim
+
+        def authenticate(*args, **kwargs):
+            events.append(("authenticate", kwargs["user"]))
+            return "user"
+
+        self.strategy.set_request_data(
+            {
+                "RelayState": json.dumps(
+                    {
+                        "idp": "testshib",
+                        self.strategy.SESSION_SAVE_KEY: "restored-session",
+                    }
+                ),
+                "SAMLResponse": "irrelevant",
+            },
+            self.backend,
+        )
+
+        with (
+            patch.object(self.strategy, "restore_session", restore_session),
+            patch.object(self.strategy, "authenticate", authenticate),
+            patch.object(self.backend, "_create_saml_auth", return_value=ValidAuth()),
+        ):
+            self.assertEqual(self.backend.complete(), "user")
+
+        self.assertEqual(
+            events,
+            [
+                ("process_response", None),
+                "restore_session",
+                ("authenticate", victim),
+            ],
+        )
+        self.assertIsNone(self.strategy.session_get(key))
+
+    def test_relay_state_restored_session_skips_no_id_validation_for_in_response_to(
+        self,
+    ) -> None:
+        events: list[object] = []
+        victim = User("victim")
+        key = self.authn_request_id_session_key("testshib")
+
+        class ValidAuth:
+            def process_response(self, request_id=None):
+                if request_id is None:
+                    raise AssertionError(
+                        "request_id should be restored before validation"
+                    )
+                events.append(("process_response", request_id))
+
+            def get_errors(self):
+                return []
+
+            def is_authenticated(self):
+                return True
+
+            def get_last_response_in_response_to(self):
+                return "TEST_ID"
+
+            def get_attributes(self):
+                return {}
+
+            def get_nameid(self):
+                return "name-id"
+
+            def get_session_index(self):
+                return "session-index"
+
+        def restore_session(session_id, kwargs) -> None:
+            events.append("restore_session")
+            self.assertEqual(session_id, "restored-session")
+            self.strategy.session_set(key, "TEST_ID")
+            kwargs["user"] = victim
+
+        def authenticate(*args, **kwargs):
+            events.append(("authenticate", kwargs["user"]))
+            return "user"
+
+        self.strategy.set_request_data(
+            {
+                "RelayState": json.dumps(
+                    {
+                        "idp": "testshib",
+                        self.strategy.SESSION_SAVE_KEY: "restored-session",
+                    }
+                ),
+                "SAMLResponse": "irrelevant",
+            },
+            self.backend,
+        )
+
+        with (
+            patch.object(self.strategy, "restore_session", restore_session),
+            patch.object(self.strategy, "authenticate", authenticate),
+            patch.object(
+                self.backend,
+                "_response_in_response_to",
+                return_value="TEST_ID",
+            ),
+            patch.object(self.backend, "_create_saml_auth", return_value=ValidAuth()),
+        ):
+            self.assertEqual(self.backend.complete(), "user")
+
+        self.assertEqual(
+            events,
+            [
+                ("process_response", "TEST_ID"),
+                "restore_session",
+                ("authenticate", victim),
+            ],
+        )
+        self.assertIsNone(self.strategy.session_get(key))
+
+    def test_relay_state_restored_session_rejects_mismatched_in_response_to(
+        self,
+    ) -> None:
+        events: list[object] = []
+        victim = User("victim")
+        key = self.authn_request_id_session_key("testshib")
+
+        class ValidAuth:
+            def process_response(self, request_id=None):
+                events.append(("process_response", request_id))
+
+            def get_errors(self):
+                return []
+
+            def is_authenticated(self):
+                return True
+
+            def get_last_response_in_response_to(self):
+                return "OTHER_ID"
+
+        def restore_session(session_id, kwargs) -> None:
+            events.append("restore_session")
+            self.assertEqual(session_id, "restored-session")
+            self.strategy.session_set(key, "TEST_ID")
+            kwargs["user"] = victim
+
+        def authenticate(*args, **kwargs):
+            self.fail("authenticate should not be called")
+
+        self.strategy.set_request_data(
+            {
+                "RelayState": json.dumps(
+                    {
+                        "idp": "testshib",
+                        self.strategy.SESSION_SAVE_KEY: "restored-session",
+                    }
+                ),
+                "SAMLResponse": "irrelevant",
+            },
+            self.backend,
+        )
+
+        with (
+            patch.object(self.strategy, "restore_session", restore_session),
+            patch.object(self.strategy, "authenticate", authenticate),
+            patch.object(self.backend, "_create_saml_auth", return_value=ValidAuth()),
+            self.assertRaisesRegex(AuthFailed, "invalid InResponseTo"),
+        ):
+            self.backend.complete()
+
+        self.assertEqual(
+            events,
+            [
+                ("process_response", None),
+                "restore_session",
+            ],
+        )
+        self.assertEqual(self.strategy.session_get(key), "TEST_ID")
+
+    def test_relay_state_restored_session_ignores_transient_request_id(self) -> None:
+        events: list[object] = []
+        victim = User("victim")
+        key = self.authn_request_id_session_key("testshib")
+        self.strategy.session_set(key, "STALE_ID")
+
+        class ValidAuth:
+            def process_response(self, request_id=None):
+                if request_id is None:
+                    raise AssertionError(
+                        "request_id should be restored before validation"
+                    )
+                events.append(("process_response", request_id))
+
+            def get_errors(self):
+                return []
+
+            def is_authenticated(self):
+                return True
+
+            def get_last_response_in_response_to(self):
+                return "STALE_ID"
+
+        def restore_session(session_id, kwargs) -> None:
+            events.append("restore_session")
+            self.assertEqual(session_id, "restored-session")
+            self.strategy.session_set(key, "TEST_ID")
+            kwargs["user"] = victim
+
+        def authenticate(*args, **kwargs):
+            self.fail("authenticate should not be called")
+
+        self.strategy.set_request_data(
+            {
+                "RelayState": json.dumps(
+                    {
+                        "idp": "testshib",
+                        self.strategy.SESSION_SAVE_KEY: "restored-session",
+                    }
+                ),
+                "SAMLResponse": "irrelevant",
+            },
+            self.backend,
+        )
+
+        with (
+            patch.object(self.strategy, "restore_session", restore_session),
+            patch.object(self.strategy, "authenticate", authenticate),
+            patch.object(
+                self.backend,
+                "_response_in_response_to",
+                return_value="STALE_ID",
+            ),
+            patch.object(self.backend, "_create_saml_auth", return_value=ValidAuth()),
+            self.assertRaisesRegex(AuthFailed, "invalid InResponseTo"),
+        ):
+            self.backend.complete()
+
+        self.assertEqual(
+            events,
+            [
+                ("process_response", "STALE_ID"),
+                "restore_session",
+            ],
+        )
+        self.assertEqual(self.strategy.session_get(key), "TEST_ID")
+
     def test_relay_state_session_not_restored_for_invalid_saml_response(self) -> None:
         """
         Invalid SAML responses must not trigger RelayState-derived session changes.
         """
 
         class InvalidAuth:
-            def process_response(self):
-                return None
+            def process_response(self, request_id=None):
+                if request_id is not None:
+                    raise AssertionError("request_id should be None")
 
             def get_errors(self):
                 return ["invalid"]
@@ -250,6 +531,349 @@ class SAMLTest(BaseBackendTest):
 
         self.assertIsNone(self.strategy.session_get("next"))
 
+    def test_relay_state_session_not_restored_for_invalid_in_response_to_response(
+        self,
+    ) -> None:
+        """
+        A parseable InResponseTo alone is not enough to trust RelayState session data.
+        """
+        events: list[object] = []
+
+        class InvalidAuth:
+            def process_response(self, request_id=None):
+                events.append(("process_response", request_id))
+
+            def get_errors(self):
+                return ["invalid"]
+
+            def is_authenticated(self):
+                return False
+
+            def get_last_error_reason(self):
+                return "invalid response"
+
+        def restore_session(session_id, kwargs) -> None:
+            self.fail("restore_session should not be called")
+
+        def authenticate(*args, **kwargs):
+            self.fail("authenticate should not be called")
+
+        self.strategy.set_request_data(
+            {
+                "RelayState": json.dumps(
+                    {
+                        "idp": "testshib",
+                        self.strategy.SESSION_SAVE_KEY: "restored-session",
+                        "next": "/after-login",
+                    }
+                ),
+                "SAMLResponse": "irrelevant",
+            },
+            self.backend,
+        )
+
+        with (
+            patch.object(self.strategy, "restore_session", restore_session),
+            patch.object(self.strategy, "authenticate", authenticate),
+            patch.object(
+                self.backend,
+                "_response_in_response_to",
+                return_value="TEST_ID",
+            ),
+            patch.object(self.backend, "_create_saml_auth", return_value=InvalidAuth()),
+            self.assertRaises(AuthFailed),
+        ):
+            self.backend.complete()
+
+        self.assertEqual(events, [("process_response", "TEST_ID")])
+        self.assertIsNone(self.strategy.session_get("next"))
+
+    def test_authenticated_user_requires_stored_authn_request_id(self) -> None:
+        self.strategy.set_request_data(
+            {
+                "RelayState": json.dumps({"idp": "testshib"}),
+                "SAMLResponse": "irrelevant",
+            },
+            self.backend,
+        )
+
+        with (
+            patch.object(self.backend, "_create_saml_auth") as create_saml_auth,
+            self.assertRaisesRegex(AuthFailed, "missing AuthnRequest ID"),
+        ):
+            self.backend.complete(user=User("victim"))
+
+        create_saml_auth.assert_not_called()
+
+    def test_authenticated_user_requires_matching_in_response_to(self) -> None:
+        request_ids = []
+
+        class ValidAuth:
+            def __init__(self, in_response_to):
+                self.in_response_to = in_response_to
+
+            def process_response(self, request_id=None):
+                request_ids.append(request_id)
+
+            def get_errors(self):
+                return []
+
+            def is_authenticated(self):
+                return True
+
+            def get_last_response_in_response_to(self):
+                return self.in_response_to
+
+        for in_response_to in (None, "OTHER_ID"):
+            with self.subTest(in_response_to=in_response_to):
+                key = self.authn_request_id_session_key("testshib")
+                self.strategy.session_set(key, "TEST_ID")
+                self.strategy.set_request_data(
+                    {
+                        "RelayState": json.dumps({"idp": "testshib"}),
+                        "SAMLResponse": "irrelevant",
+                    },
+                    self.backend,
+                )
+
+                with (
+                    patch.object(
+                        self.backend,
+                        "_response_in_response_to",
+                        return_value=in_response_to,
+                    ),
+                    patch.object(
+                        self.backend,
+                        "_create_saml_auth",
+                        return_value=ValidAuth(in_response_to),
+                    ),
+                    self.assertRaisesRegex(AuthFailed, "invalid InResponseTo"),
+                ):
+                    self.backend.complete(user=User("victim"))
+
+                self.assertEqual(self.strategy.session_get(key), "TEST_ID")
+
+        self.assertEqual(request_ids, [None, "TEST_ID"])
+
+    def test_authenticated_user_accepts_matching_in_response_to(self) -> None:
+        events = []
+        victim = User("victim")
+        key = self.authn_request_id_session_key("testshib")
+        self.strategy.session_set(key, "TEST_ID")
+
+        class ValidAuth:
+            def process_response(self, request_id=None):
+                events.append(("process_response", request_id))
+
+            def get_errors(self):
+                return []
+
+            def is_authenticated(self):
+                return True
+
+            def get_last_response_in_response_to(self):
+                return "TEST_ID"
+
+            def get_attributes(self):
+                return {}
+
+            def get_nameid(self):
+                return "name-id"
+
+            def get_session_index(self):
+                return "session-index"
+
+        def authenticate(*args, **kwargs):
+            events.append(("authenticate", kwargs["user"]))
+            return "user"
+
+        self.strategy.set_request_data(
+            {
+                "RelayState": json.dumps({"idp": "testshib"}),
+                "SAMLResponse": "irrelevant",
+            },
+            self.backend,
+        )
+
+        with (
+            patch.object(self.strategy, "authenticate", authenticate),
+            patch.object(
+                self.backend,
+                "_response_in_response_to",
+                return_value="TEST_ID",
+            ),
+            patch.object(self.backend, "_create_saml_auth", return_value=ValidAuth()),
+        ):
+            self.assertEqual(self.backend.complete(user=victim), "user")
+
+        self.assertEqual(
+            events,
+            [("process_response", "TEST_ID"), ("authenticate", victim)],
+        )
+        self.assertIsNone(self.strategy.session_get(key))
+
+    def test_anonymous_user_allows_unsolicited_saml_response(self) -> None:
+        events = []
+
+        class ValidAuth:
+            def process_response(self, request_id=None):
+                events.append(("process_response", request_id))
+
+            def get_errors(self):
+                return []
+
+            def is_authenticated(self):
+                return True
+
+            def get_attributes(self):
+                return {}
+
+            def get_nameid(self):
+                return "name-id"
+
+            def get_session_index(self):
+                return "session-index"
+
+        def authenticate(*args, **kwargs):
+            events.append(("authenticate", kwargs.get("user")))
+            return "user"
+
+        self.strategy.set_request_data(
+            {
+                "RelayState": json.dumps({"idp": "testshib"}),
+                "SAMLResponse": "irrelevant",
+            },
+            self.backend,
+        )
+
+        with (
+            patch.object(self.strategy, "authenticate", authenticate),
+            patch.object(self.backend, "_create_saml_auth", return_value=ValidAuth()),
+        ):
+            self.assertEqual(self.backend.complete(), "user")
+
+        self.assertEqual(
+            events,
+            [("process_response", None), ("authenticate", None)],
+        )
+
+    def test_anonymous_user_allows_unsolicited_response_with_stale_request_id(
+        self,
+    ) -> None:
+        events = []
+        key = self.authn_request_id_session_key("testshib")
+        self.strategy.session_set(key, "STALE_ID")
+
+        class ValidAuth:
+            def process_response(self, request_id=None):
+                events.append(("process_response", request_id))
+
+            def get_errors(self):
+                return []
+
+            def is_authenticated(self):
+                return True
+
+            def get_last_response_in_response_to(self):
+                return None
+
+            def get_attributes(self):
+                return {}
+
+            def get_nameid(self):
+                return "name-id"
+
+            def get_session_index(self):
+                return "session-index"
+
+        def authenticate(*args, **kwargs):
+            events.append(("authenticate", kwargs.get("user")))
+            return "user"
+
+        self.strategy.set_request_data(
+            {
+                "RelayState": json.dumps({"idp": "testshib"}),
+                "SAMLResponse": "irrelevant",
+            },
+            self.backend,
+        )
+
+        with (
+            patch.object(self.strategy, "authenticate", authenticate),
+            patch.object(self.backend, "_create_saml_auth", return_value=ValidAuth()),
+        ):
+            self.assertEqual(self.backend.complete(), "user")
+
+        self.assertEqual(
+            events,
+            [("process_response", None), ("authenticate", None)],
+        )
+        self.assertEqual(self.strategy.session_get(key), "STALE_ID")
+
+    def test_anonymous_user_with_stored_request_requires_matching_in_response_to(
+        self,
+    ) -> None:
+        class ValidAuth:
+            def process_response(self, request_id=None):
+                if request_id != "TEST_ID":
+                    raise AssertionError("request_id should be TEST_ID")
+
+            def get_errors(self):
+                return []
+
+            def is_authenticated(self):
+                return True
+
+            def get_last_response_in_response_to(self):
+                return "OTHER_ID"
+
+        key = self.authn_request_id_session_key("testshib")
+        self.strategy.session_set(key, "TEST_ID")
+        self.strategy.set_request_data(
+            {
+                "RelayState": json.dumps({"idp": "testshib"}),
+                "SAMLResponse": "irrelevant",
+            },
+            self.backend,
+        )
+
+        with (
+            patch.object(
+                self.backend,
+                "_response_in_response_to",
+                return_value="OTHER_ID",
+            ),
+            patch.object(self.backend, "_create_saml_auth", return_value=ValidAuth()),
+            self.assertRaisesRegex(AuthFailed, "invalid InResponseTo"),
+        ):
+            self.backend.complete()
+
+        self.assertEqual(self.strategy.session_get(key), "TEST_ID")
+
+    def test_anonymous_user_rejects_untracked_in_response_to(self) -> None:
+        class ValidAuth:
+            def process_response(self, request_id=None):
+                raise AssertionError("SAML response should not be processed")
+
+        self.strategy.set_request_data(
+            {
+                "RelayState": json.dumps({"idp": "testshib"}),
+                "SAMLResponse": "irrelevant",
+            },
+            self.backend,
+        )
+
+        with (
+            patch.object(
+                self.backend,
+                "_response_in_response_to",
+                return_value="TEST_ID",
+            ),
+            patch.object(self.backend, "_create_saml_auth", return_value=ValidAuth()),
+            self.assertRaisesRegex(AuthFailed, "missing AuthnRequest ID"),
+        ):
+            self.backend.complete()
+
     def modify_start_url(self, start_url):
         """
         Given a SAML redirect URL, parse it and change the ID to
@@ -263,6 +887,11 @@ class SAMLTest(BaseBackendTest):
         xml = xml.decode()
         xml, changed = re.subn(r'ID="[^"]+"', 'ID="TEST_ID"', xml)
         self.assertEqual(changed, 1)
+        relay_state = self.backend.parse_relay_state(query["RelayState"])
+        self.strategy.session_set(
+            self.authn_request_id_session_key(relay_state["idp"]),
+            "TEST_ID",
+        )
         # Update the URL to use the modified query string:
         query["SAMLRequest"] = OneLogin_Saml2_Utils.deflate_and_base64_encode(xml)
         url_parts = list(url_parts)


### PR DESCRIPTION
- Store generated AuthnRequest IDs per IdP and pass them into python3-saml response validation.
- Reject authenticated account-association callbacks without a matching InResponseTo while preserving anonymous IdP-initiated SSO.
- Revalidate restored-session callbacks after session restore so request IDs stored in the restored session are enforced.
- Add regression tests for missing, mismatched, matching, anonymous, and restored-session SAML response paths.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
