### PR TITLE
fix(vend): scope OAuth UID by shop

### DIFF
--- a/social_core/backends/vend.py
+++ b/social_core/backends/vend.py
@@ -2,7 +2,10 @@
 Vend  OAuth2 backend:
 """
 
+import re
 from typing import Any
+
+from social_core.exceptions import AuthInvalidParameter, AuthMissingParameter
 
 from .oauth import BaseOAuth2
 
@@ -16,9 +19,52 @@ class VendOAuth2(BaseOAuth2):
         ("refresh_token", "refresh_token"),
         ("domain_prefix", "domain_prefix"),
     ]
+    DOMAIN_PREFIX_RE = re.compile(
+        r"(?=.{1,63}\Z)[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\Z"
+    )
+
+    def domain_prefix(self, response=None) -> str:
+        prefix = (response or {}).get("domain_prefix") or self.data.get("domain_prefix")
+        if not prefix:
+            raise AuthMissingParameter(self, "domain_prefix")
+        if isinstance(prefix, (list, tuple)):
+            prefix = prefix[0] if prefix else ""
+        prefix = str(prefix).lower()
+        if not self.DOMAIN_PREFIX_RE.match(prefix):
+            raise AuthInvalidParameter(self, "domain_prefix")
+        return prefix
+
+    def scoped_uid(self, response) -> str:
+        user_id = response.get("id")
+        if user_id in (None, ""):
+            raise AuthMissingParameter(self, "id")
+        return f"{self.domain_prefix(response)}:{user_id}"
 
     def access_token_url(self):
-        return self.ACCESS_TOKEN_URL.format(self.data["domain_prefix"])
+        return self.ACCESS_TOKEN_URL.format(self.domain_prefix())
+
+    def get_user_id(self, details, response):
+        domain_prefix = self.domain_prefix(response)
+        uid = self.scoped_uid(response)
+        if self.strategy.storage.user.get_social_auth(self.name, uid):
+            return uid
+
+        # Previous versions stored only Vend's shop-local numeric user ID.
+        # Migrate that legacy association only when its saved shop matches this
+        # login; otherwise the old cross-shop collision would remain possible.
+        legacy_uid = str(response.get("id"))
+        legacy_social = self.strategy.storage.user.get_social_auth(
+            self.name, legacy_uid
+        )
+        if legacy_social:
+            legacy_domain_prefix = legacy_social.extra_data.get("domain_prefix")
+            if (
+                legacy_domain_prefix
+                and str(legacy_domain_prefix).lower() == domain_prefix
+            ):
+                legacy_social.uid = uid
+                legacy_social.save()
+        return uid
 
     def get_user_details(self, response):
         email = response["email"]
@@ -33,7 +79,9 @@ class VendOAuth2(BaseOAuth2):
 
     def user_data(self, access_token: str, *args, **kwargs) -> dict[str, Any] | None:
         """Loads user data from service"""
-        prefix = kwargs["response"]["domain_prefix"]
+        prefix = self.domain_prefix(kwargs.get("response"))
         url = f"https://{prefix}.vendhq.com/api/users"
         data = self.get_json(url, headers={"Authorization": f"Bearer {access_token}"})
-        return data["users"][0] if data.get("users") else {}
+        if data.get("users"):
+            return dict(data["users"][0], domain_prefix=prefix)
+        return {"domain_prefix": prefix}

--- a/social_core/storage.py
+++ b/social_core/storage.py
@@ -265,7 +265,7 @@ class UserMixin:
         raise NotImplementedError("Implement in subclass")
 
     @classmethod
-    def get_social_auth(cls, provider: str, uid: int):
+    def get_social_auth(cls, provider: str, uid: str):
         """Return UserSocialAuth for given provider and uid"""
         raise NotImplementedError("Implement in subclass")
 
@@ -281,7 +281,7 @@ class UserMixin:
         raise NotImplementedError("Implement in subclass")
 
     @classmethod
-    def create_social_auth(cls, user: UserProtocol, uid: int, provider: str):
+    def create_social_auth(cls, user: UserProtocol, uid: str, provider: str):
         """Create a UserSocialAuth instance for given user"""
         raise NotImplementedError("Implement in subclass")
 

--- a/social_core/tests/backends/test_vend.py
+++ b/social_core/tests/backends/test_vend.py
@@ -1,0 +1,122 @@
+import json
+from typing import cast
+
+import responses
+
+from social_core.exceptions import AuthInvalidParameter
+from social_core.tests.models import TestUserSocialAuth, User
+
+from .oauth import OAuth2Test
+
+
+class VendOAuth2Test(OAuth2Test):
+    backend_path = "social_core.backends.vend.VendOAuth2"
+    expected_username = "victim_shop_a"
+
+    def vend_login(
+        self,
+        domain_prefix: str,
+        username: str,
+        email: str,
+        vend_id: int = 7,
+    ) -> User:
+        self.strategy.set_request_data({"domain_prefix": domain_prefix}, self.backend)
+        self.access_token_body = json.dumps(
+            {
+                "access_token": f"{domain_prefix}-token",
+                "refresh_token": f"{domain_prefix}-refresh-token",
+            }
+        )
+        self.user_data_url = f"https://{domain_prefix}.vendhq.com/api/users"
+        self.user_data_body = json.dumps(
+            {
+                "users": [
+                    {
+                        "id": vend_id,
+                        "username": username,
+                        "email": email,
+                    }
+                ]
+            }
+        )
+        return cast("User", self.do_start())
+
+    def test_login(self) -> None:
+        user = self.vend_login("shop-a", "victim_shop_a", "victim@example.com")
+
+        self.assertEqual(user.username, "victim_shop_a")
+        self.assertEqual(len(user.social), 1)
+        social = user.social[0]
+        self.assertEqual(social.uid, "shop-a:7")
+        self.assertEqual(social.extra_data["domain_prefix"], "shop-a")
+        self.assertEqual(social.extra_data["refresh_token"], "shop-a-refresh-token")
+
+        request_urls = [call.request.url for call in responses.calls]
+        self.assertIn("https://shop-a.vendhq.com/api/1.0/token", request_urls)
+        self.assertIn("https://shop-a.vendhq.com/api/users", request_urls)
+
+    def test_same_numeric_id_from_different_shops_creates_new_association(self) -> None:
+        victim = self.vend_login("shop-a", "victim_shop_a", "victim@example.com")
+        attacker = self.vend_login("shop-b", "attacker_shop_b", "attacker@example.com")
+
+        self.assertIsNot(attacker, victim)
+        self.assertEqual(attacker.username, "attacker_shop_b")
+        self.assertEqual(len(User.cache), 2)
+        self.assertEqual(victim.social[0].uid, "shop-a:7")
+        self.assertEqual(attacker.social[0].uid, "shop-b:7")
+        self.assertIs(
+            TestUserSocialAuth.get_social_auth("vend", "shop-a:7").user,
+            victim,
+        )
+        self.assertIs(
+            TestUserSocialAuth.get_social_auth("vend", "shop-b:7").user,
+            attacker,
+        )
+
+    def test_migrates_matching_legacy_association(self) -> None:
+        victim = User("victim_shop_a", email="victim@example.com")
+        legacy_social = TestUserSocialAuth(
+            victim,
+            "vend",
+            "7",
+            extra_data={"domain_prefix": "shop-a"},
+        )
+
+        user = self.vend_login("shop-a", "victim_shop_a", "victim@example.com")
+
+        self.assertIs(user, victim)
+        self.assertEqual(len(User.cache), 1)
+        self.assertEqual(legacy_social.uid, "shop-a:7")
+        self.assertIsNone(TestUserSocialAuth.get_social_auth("vend", "7"))
+        self.assertIs(
+            TestUserSocialAuth.get_social_auth("vend", "shop-a:7"),
+            legacy_social,
+        )
+
+    def test_does_not_migrate_mismatched_legacy_association(self) -> None:
+        victim = User("victim_shop_a", email="victim@example.com")
+        legacy_social = TestUserSocialAuth(
+            victim,
+            "vend",
+            "7",
+            extra_data={"domain_prefix": "shop-a"},
+        )
+
+        attacker = self.vend_login("shop-b", "attacker_shop_b", "attacker@example.com")
+
+        self.assertIsNot(attacker, victim)
+        self.assertEqual(len(User.cache), 2)
+        self.assertEqual(legacy_social.uid, "7")
+        self.assertIs(
+            TestUserSocialAuth.get_social_auth("vend", "7"),
+            legacy_social,
+        )
+        self.assertEqual(attacker.social[0].uid, "shop-b:7")
+
+    def test_rejects_invalid_domain_prefix(self) -> None:
+        self.strategy.set_request_data(
+            {"domain_prefix": "shop-a.example"}, self.backend
+        )
+
+        with self.assertRaises(AuthInvalidParameter):
+            self.backend.access_token_url()

--- a/social_core/tests/models.py
+++ b/social_core/tests/models.py
@@ -89,7 +89,7 @@ class TestUserSocialAuth(UserMixin, BaseModel):
 
     NEXT_ID = 1
     cache: dict[int, TestUserSocialAuth] = {}
-    cache_by_uid: dict[int, TestUserSocialAuth] = {}
+    cache_by_uid: dict[str, TestUserSocialAuth] = {}
 
     def __init__(self, user: User, provider, uid, extra_data=None) -> None:
         self.id = TestUserSocialAuth.next_id()
@@ -101,7 +101,10 @@ class TestUserSocialAuth(UserMixin, BaseModel):
         TestUserSocialAuth.cache_by_uid[uid] = self
 
     def save(self) -> None:
-        pass
+        for uid, social_auth in list(TestUserSocialAuth.cache_by_uid.items()):
+            if social_auth is self:
+                del TestUserSocialAuth.cache_by_uid[uid]
+        TestUserSocialAuth.cache_by_uid[self.uid] = self
 
     @classmethod
     def reset_cache(cls) -> None:
@@ -149,7 +152,7 @@ class TestUserSocialAuth(UserMixin, BaseModel):
         return None
 
     @classmethod
-    def get_social_auth(cls, provider: str, uid: int):
+    def get_social_auth(cls, provider: str, uid: str):
         social_user = cls.cache_by_uid.get(uid)
         if social_user and social_user.provider == provider:
             return social_user
@@ -170,7 +173,7 @@ class TestUserSocialAuth(UserMixin, BaseModel):
         ]
 
     @classmethod
-    def create_social_auth(cls, user: UserProtocol, uid: int, provider: str):
+    def create_social_auth(cls, user: UserProtocol, uid: str, provider: str):
         return cls(user=cast("User", user), provider=provider, uid=uid)
 
     @classmethod

--- a/social_core/tests/test_storage.py
+++ b/social_core/tests/test_storage.py
@@ -66,7 +66,7 @@ class BrokenUserTests(unittest.TestCase):
 
     def test_get_social_auth(self) -> None:
         with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
-            self.user.get_social_auth("foo", 1)
+            self.user.get_social_auth("foo", "1")
 
     def test_get_social_auth_for_user(self) -> None:
         with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
@@ -74,7 +74,7 @@ class BrokenUserTests(unittest.TestCase):
 
     def test_create_social_auth(self) -> None:
         with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
-            self.user.create_social_auth(User("foobar"), 1, "foo")
+            self.user.create_social_auth(User("foobar"), "1", "foo")
 
     def test_disconnect(self) -> None:
         with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):


### PR DESCRIPTION
- Scope Vend social-auth UIDs with domain_prefix to prevent cross-shop numeric ID collisions.
- Validate and propagate domain_prefix through token/user data handling and stored extra data.
- Securely migrate legacy numeric associations only when their saved shop matches the current login.
- Add Vend regression tests and align storage UID typing/test indexes with string UIDs.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
