### PR TITLE
fix(backends): VKAppOAuth2 now requires auth_key

### DIFF
--- a/social_core/backends/vk.py
+++ b/social_core/backends/vk.py
@@ -10,7 +10,7 @@ from hashlib import md5
 from time import time
 from typing import Any, cast
 
-from social_core.exceptions import AuthException, AuthTokenRevoked
+from social_core.exceptions import AuthException, AuthFailed, AuthTokenRevoked
 from social_core.utils import parse_qs
 
 from .base import BaseAuth
@@ -184,12 +184,13 @@ class VKAppOAuth2(VKOAuth2):
 
         auth_key = self.data.get("auth_key")
 
-        # Verify signature, if present
+        # Verify signature before trusting callback data.
         key, secret = self.get_key_and_secret()
-        if auth_key:
-            check_key = vk_sig(f"{key}_{self.data.get('viewer_id')}_{secret}")
-            if check_key != auth_key:
-                raise ValueError("VK.com authentication failed: invalid auth key")
+        if not auth_key:
+            raise AuthFailed(self, "Missing auth key")
+        check_key = vk_sig(f"{key}_{self.data.get('viewer_id')}_{secret}")
+        if check_key != auth_key:
+            raise AuthFailed(self, "Invalid auth key")
 
         user_check = self.setting("USERMODE")
         user_id = self.data.get("viewer_id")

--- a/social_core/tests/backends/test_vk.py
+++ b/social_core/tests/backends/test_vk.py
@@ -1,6 +1,15 @@
 import json
 
+from social_core.backends.vk import vk_sig
+from social_core.exceptions import AuthFailed
+from social_core.tests.models import TestUserSocialAuth, User
+
+from .base import BaseBackendTest
 from .oauth import BaseAuthUrlTestMixin, OAuth2Test
+
+APP_ID = "12345"
+APP_SECRET = "a-secret-key"
+VIEWER_ID = "424242"
 
 
 class VKOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
@@ -28,3 +37,70 @@ class VKOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
 
     def test_partial_pipeline(self) -> None:
         self.do_partial_pipeline()
+
+
+class VKAppOAuth2Test(BaseBackendTest):
+    backend_path = "social_core.backends.vk.VKAppOAuth2"
+    expected_username = "vkuser"
+
+    def extra_settings(self) -> dict[str, str | list[str]]:
+        return {
+            f"SOCIAL_AUTH_{self.name}_KEY": APP_ID,
+            f"SOCIAL_AUTH_{self.name}_SECRET": APP_SECRET,
+        }
+
+    def auth_key(self, viewer_id: str = VIEWER_ID) -> str:
+        return vk_sig(f"{APP_ID}_{viewer_id}_{APP_SECRET}")
+
+    def request_data(self, viewer_id: str = VIEWER_ID) -> dict[str, str]:
+        return {
+            "is_app_user": "1",
+            "viewer_id": viewer_id,
+            "access_token": "foobar",
+            "api_id": APP_ID,
+            "api_result": json.dumps(
+                {
+                    "response": [
+                        {
+                            "id": viewer_id,
+                            "first_name": "VK",
+                            "last_name": "User",
+                            "screen_name": self.expected_username,
+                        }
+                    ]
+                }
+            ),
+        }
+
+    def signed_request_data(self, viewer_id: str = VIEWER_ID) -> dict[str, str]:
+        data = self.request_data(viewer_id)
+        data["auth_key"] = self.auth_key(viewer_id)
+        return data
+
+    def do_start(self):
+        self.strategy.set_request_data(self.signed_request_data(), self.backend)
+        return self.backend.complete()
+
+    def test_login(self) -> None:
+        user = self.do_login()
+
+        self.assertEqual(user.social[0].uid, VIEWER_ID)
+        self.assertEqual(user.social[0].provider, self.backend.name)
+
+    def test_rejects_missing_auth_key_before_authentication(self) -> None:
+        self.strategy.set_request_data(self.request_data(), self.backend)
+
+        with self.assertRaisesRegex(AuthFailed, "Missing auth key"):
+            self.backend.complete()
+
+        self.assertIsNone(self.strategy.session_get("username"))
+        self.assertEqual(User.cache, {})
+        self.assertEqual(TestUserSocialAuth.cache_by_uid, {})
+
+    def test_rejects_invalid_auth_key(self) -> None:
+        data = self.request_data()
+        data["auth_key"] = "0" * 32
+        self.strategy.set_request_data(data, self.backend)
+
+        with self.assertRaisesRegex(AuthFailed, "Invalid auth key"):
+            self.backend.complete()


### PR DESCRIPTION
Tighten the VK app backend key validation to reject payload without signature.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
