### PR TITLE
fix(twilio): validate connect callback state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - LoginRadius backend now validates callback state to prevent login CSRF.
 - Partial pipeline resume now requires session ownership or explicit external
   resume confirmation to prevent login CSRF.
+- Twilio backend now preserves HTTPS callback URLs and validates callback state
+  to prevent login CSRF.
 
 ### Removed
 

--- a/social_core/backends/twilio.py
+++ b/social_core/backends/twilio.py
@@ -3,8 +3,15 @@ Twilio auth backend, docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/twilio.html
 """
 
-from re import sub
 from urllib.parse import urlencode
+
+from social_core.exceptions import (
+    AuthFailed,
+    AuthMissingParameter,
+    AuthStateForbidden,
+    AuthStateMissing,
+)
+from social_core.utils import constant_time_compare, url_add_parameters
 
 from .base import BaseAuth
 
@@ -12,6 +19,7 @@ from .base import BaseAuth
 class TwilioAuth(BaseAuth):
     name = "twilio"
     ID_KEY = "AccountSid"
+    REDIRECT_STATE = True
 
     def get_user_details(self, response):
         """Return twilio details, Twilio only provides AccountSID as
@@ -28,15 +36,53 @@ class TwilioAuth(BaseAuth):
     def auth_url(self) -> str:
         """Return authorization redirect url."""
         key, _secret = self.get_key_and_secret()
-        callback = self.strategy.absolute_uri(self.redirect_uri)
-        callback = sub(r"^https", "http", callback)
+        callback = self.get_redirect_uri(self.get_or_create_state())
         query = urlencode({"cb": callback})
         return f"https://www.twilio.com/authorize/{key}?{query}"
+
+    def state_token(self):
+        """Generate csrf token to include in the callback URL."""
+        return self.strategy.random_string(32)
+
+    def get_or_create_state(self) -> str:
+        name = f"{self.name}_state"
+        state = self.strategy.session_get(name)
+        if state is None:
+            state = self.state_token()
+            self.strategy.session_set(name, state)
+        return state
+
+    def get_session_state(self):
+        return self.strategy.session_get(f"{self.name}_state")
+
+    def get_request_state(self):
+        request_state = self.data.get("redirect_state")
+        if request_state and isinstance(request_state, list):
+            request_state = request_state[0]
+        return request_state
+
+    def validate_state(self):
+        """Validate state value. Raises exception on error."""
+        state = self.get_session_state()
+        request_state = self.get_request_state()
+        if not request_state:
+            raise AuthMissingParameter(self, "state")
+        if not state:
+            raise AuthStateMissing(self, "state")
+        if not constant_time_compare(request_state, state):
+            raise AuthStateForbidden(self)
+
+    def get_redirect_uri(self, state: str | None = None) -> str:
+        uri = self.strategy.absolute_uri(self.redirect_uri)
+        if self.REDIRECT_STATE and state:
+            uri = url_add_parameters(uri, {"redirect_state": state})
+        return uri
 
     def auth_complete(self, *args, **kwargs):
         """Completes login process, must return user instance"""
         account_sid = self.data.get("AccountSid")
         if not account_sid:
-            raise ValueError("No AccountSid returned")
+            raise AuthFailed(self, "Missing AccountSid")
+        self.validate_state()
         kwargs.update({"response": self.data, "backend": self})
         return self.strategy.authenticate(*args, **kwargs)

--- a/social_core/tests/backends/test_twilio.py
+++ b/social_core/tests/backends/test_twilio.py
@@ -1,0 +1,92 @@
+from social_core.exceptions import (
+    AuthFailed,
+    AuthMissingParameter,
+    AuthStateForbidden,
+    AuthStateMissing,
+)
+from social_core.utils import get_querystring
+
+from .base import BaseBackendTest
+
+ACCOUNT_SID = "ACc65ea16c9ebd4d4684edf814995b27e"
+APP_SID = "AP11111111111111111111111111111111"
+
+
+class TwilioAuthTest(BaseBackendTest):
+    backend_path = "social_core.backends.twilio.TwilioAuth"
+    expected_username = ACCOUNT_SID
+
+    def extra_settings(self) -> dict[str, str | list[str]]:
+        return {
+            "SOCIAL_AUTH_TWILIO_KEY": APP_SID,
+            "SOCIAL_AUTH_TWILIO_SECRET": "twilio-auth-token",
+        }
+
+    def do_start(self):
+        start_url = self.backend.start().url
+        callback = get_querystring(start_url)["cb"]
+        state = get_querystring(callback)["redirect_state"]
+        data = {"AccountSid": ACCOUNT_SID, "redirect_state": state}
+        self.strategy.set_request_data(data, self.backend)
+        return self.backend.complete()
+
+    def test_auth_url_preserves_https_callback(self) -> None:
+        self.backend.redirect_uri = "https://myapp.com/complete/twilio"
+
+        callback = get_querystring(self.backend.auth_url())["cb"]
+        query = get_querystring(callback)
+
+        self.assertEqual(
+            callback,
+            "https://myapp.com/complete/twilio?"
+            f"redirect_state={query['redirect_state']}",
+        )
+        self.assertEqual(
+            query["redirect_state"], self.strategy.session_get("twilio_state")
+        )
+
+    def test_missing_account_sid_fails(self) -> None:
+        self.strategy.set_request_data({}, self.backend)
+
+        with self.assertRaisesRegex(AuthFailed, "Missing AccountSid"):
+            self.backend.complete()
+
+    def test_complete_rejects_missing_redirect_state(self) -> None:
+        self.backend.start()
+        data = {"AccountSid": ACCOUNT_SID}
+        self.strategy.set_request_data(data, self.backend)
+
+        with self.assertRaises(AuthMissingParameter):
+            self.backend.complete()
+
+    def test_complete_rejects_mismatched_redirect_state(self) -> None:
+        self.backend.start()
+        self.strategy.set_request_data(
+            {"AccountSid": ACCOUNT_SID, "redirect_state": "invalid-state"},
+            self.backend,
+        )
+
+        with self.assertRaises(AuthStateForbidden):
+            self.backend.complete()
+
+    def test_complete_rejects_orphan_redirect_state(self) -> None:
+        self.strategy.set_request_data(
+            {"AccountSid": ACCOUNT_SID, "redirect_state": "orphan-state"},
+            self.backend,
+        )
+
+        with self.assertRaises(AuthStateMissing):
+            self.backend.complete()
+
+    def test_login(self) -> None:
+        self.do_login()
+
+    def test_complete_accepts_connect_redirect(self) -> None:
+        state = self.backend.get_or_create_state()
+        data = {"AccountSid": ACCOUNT_SID, "redirect_state": state}
+        self.strategy.set_request_data(data, self.backend)
+
+        user = self.backend.complete()
+
+        self.assertEqual(user.username, ACCOUNT_SID)
+        self.assertEqual(self.strategy.session_get("username"), ACCOUNT_SID)


### PR DESCRIPTION
Preserve HTTPS callback URLs and bind Twilio Connect callbacks to the initiating session with redirect_state instead of requiring webhook signatures.
<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
