### PR TITLE
fix!: bind partial pipeline resumes to sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Security
 
 - LoginRadius backend now validates callback state to prevent login CSRF.
+- Partial pipeline resume now requires session ownership or explicit external
+  resume confirmation to prevent login CSRF.
 
 ### Removed
 

--- a/social_core/actions.py
+++ b/social_core/actions.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import quote
 
 from .utils import (
-    partial_pipeline_data,
+    partial_pipeline_result,
     sanitize_redirect,
     setting_url,
     user_is_active,
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from .backends.base import BaseAuth
-    from .storage import PipelineUserProtocol, UserMixin, UserProtocol
+    from .storage import PartialMixin, PipelineUserProtocol, UserMixin, UserProtocol
     from .strategy import HttpResponseProtocol
 
 
@@ -49,6 +49,31 @@ def _sanitize_redirect_url(backend: BaseAuth, url: str) -> str:
             raise ValueError("Disallowed URL")
         url = cast("str", sanitized_url)
     return url
+
+
+def _handle_partial(
+    backend: BaseAuth,
+    user: UserProtocol | None,
+    resume_partial: Callable[[PartialMixin], Any],
+    halt_url_names: tuple[str, ...],
+    halt_error: str,
+    *args,
+    **kwargs,
+) -> tuple[bool, Any]:
+    partial = partial_pipeline_result(backend, user, *args, **kwargs)
+    if partial.response is not None:
+        return True, partial.response
+    if partial.partial:
+        response = resume_partial(partial.partial)
+        backend.strategy.clean_partial_pipeline(partial.partial.token)
+        return True, response
+    if partial.halt:
+        halt_url = setting_url(backend, *halt_url_names)
+        if not halt_url:
+            raise ValueError(halt_error)
+        halt_url = _sanitize_redirect_url(backend, halt_url)
+        return True, backend.strategy.redirect(halt_url)
+    return False, None
 
 
 def do_auth(backend: BaseAuth, redirect_name: str = "next") -> HttpResponseProtocol:
@@ -93,11 +118,19 @@ def do_complete(
     partial_user = user if is_authenticated else None
     authenticated_user: UserProtocol | HttpResponseProtocol | None = partial_user
 
-    partial = partial_pipeline_data(backend, partial_user, *args, **kwargs)
-    if partial:
-        authenticated_user = backend.continue_pipeline(partial)
-        # clean partial data after usage
-        backend.strategy.clean_partial_pipeline(partial.token)
+    partial_handled, partial_response = _handle_partial(
+        backend,
+        partial_user,
+        backend.continue_pipeline,
+        ("LOGIN_ERROR_URL", "LOGIN_URL"),
+        "By this point URL has to have been set",
+        *args,
+        **kwargs,
+    )
+    if partial_handled:
+        authenticated_user = cast(
+            "UserProtocol | HttpResponseProtocol | None", partial_response
+        )
     else:
         authenticated_user = backend.complete(
             *args, user=authenticated_user, redirect_name=redirect_name, **kwargs
@@ -173,13 +206,24 @@ def do_disconnect(
     *args,
     **kwargs,
 ):
-    partial = partial_pipeline_data(backend, user, *args, **kwargs)
-    if partial:
+    response: dict | HttpResponseProtocol
+
+    def resume_disconnect(partial: PartialMixin):
         if association_id and not partial.kwargs.get("association_id"):
             partial.extend_kwargs({"association_id": association_id})
-        response = backend.disconnect(*partial.args, **partial.kwargs)
-        # clean partial data after usage
-        backend.strategy.clean_partial_pipeline(partial.token)
+        return backend.disconnect(*partial.args, **partial.kwargs)
+
+    partial_handled, partial_response = _handle_partial(
+        backend,
+        user,
+        resume_disconnect,
+        ("DISCONNECT_REDIRECT_URL", "LOGIN_REDIRECT_URL"),
+        "Disallowed URL",
+        *args,
+        **kwargs,
+    )
+    if partial_handled:
+        response = cast("dict | HttpResponseProtocol", partial_response)
     else:
         response = backend.disconnect(
             *args, user=user, association_id=association_id, **kwargs

--- a/social_core/pipeline/mail.py
+++ b/social_core/pipeline/mail.py
@@ -4,13 +4,13 @@ from typing import TYPE_CHECKING, cast
 
 from social_core.exceptions import InvalidEmail
 
-from .partial import partial
+from .partial import partial_step
 
 if TYPE_CHECKING:
     from social_core.backends.base import BaseAuth
 
 
-@partial
+@partial_step(save_to_session=True, allow_external_resume=True)
 def mail_validation(backend: BaseAuth, details, is_new=False, *args, **kwargs):
     requires_validation = backend.REQUIRES_EMAIL_VALIDATION or backend.setting(
         "FORCE_EMAIL_VALIDATION", False
@@ -19,7 +19,9 @@ def mail_validation(backend: BaseAuth, details, is_new=False, *args, **kwargs):
         is_new or backend.setting("PASSWORDLESS", False)
     )
     if requires_validation and send_validation:
-        data = backend.strategy.request_data()
+        # External partial resumes may replay the original validation-link data
+        # after a local confirmation request.
+        data = kwargs.get("request") or backend.strategy.request_data()
         if "verification_code" in data:
             backend.strategy.session_pop("email_validation_address")
             if not backend.strategy.validate_email(

--- a/social_core/pipeline/partial.py
+++ b/social_core/pipeline/partial.py
@@ -1,11 +1,14 @@
 from functools import wraps
 
-from social_core.utils import PARTIAL_TOKEN_SESSION_NAME
+from social_core.utils import (
+    PARTIAL_PIPELINE_ALLOW_EXTERNAL_RESUME,
+    PARTIAL_TOKEN_SESSION_NAME,
+)
 
 from .utils import partial_prepare
 
 
-def partial_step(save_to_session):
+def partial_step(save_to_session, allow_external_resume=False):
     """Wraps func to behave like a partial pipeline step, any output
     that's not None or {} will be considered a response object and
     will be returned to user.
@@ -21,6 +24,9 @@ def partial_step(save_to_session):
     The token is also stored in the session under the
     PARTIAL_TOKEN_SESSION_NAME (partial_pipeline_token) key when the
     save_to_session parameter is True.
+
+    Set allow_external_resume=True only for flows that intentionally resume
+    from an external validation link, such as email validation.
     """
 
     def decorator(func):
@@ -43,6 +49,9 @@ def partial_step(save_to_session):
             )
 
             if not isinstance(out, dict):
+                current_partial.data[PARTIAL_PIPELINE_ALLOW_EXTERNAL_RESUME] = (
+                    allow_external_resume
+                )
                 strategy.storage.partial.store(current_partial)
                 if save_to_session:
                     strategy.session_set(

--- a/social_core/strategy.py
+++ b/social_core/strategy.py
@@ -12,7 +12,14 @@ from .exceptions import (
 from .pipeline import DEFAULT_AUTH_PIPELINE, DEFAULT_DISCONNECT_PIPELINE
 from .pipeline.utils import partial_load
 from .store import OpenIdSessionWrapper, OpenIdStore
-from .utils import PARTIAL_TOKEN_SESSION_NAME, module_member, setting_name
+from .utils import (
+    PARTIAL_TOKEN_PENDING_CONFIRMATION_SESSION_NAME,
+    PARTIAL_TOKEN_PENDING_REQUEST_SESSION_NAME,
+    PARTIAL_TOKEN_PENDING_SESSION_NAME,
+    PARTIAL_TOKEN_SESSION_NAME,
+    module_member,
+    setting_name,
+)
 
 if TYPE_CHECKING:
     from .backends.base import BaseAuth
@@ -132,6 +139,26 @@ class BaseStrategy:
         current_token_in_session = self.session_get(PARTIAL_TOKEN_SESSION_NAME)
         if current_token_in_session == token:
             self.session_pop(PARTIAL_TOKEN_SESSION_NAME)
+        pending_token_in_session = self.session_get(PARTIAL_TOKEN_PENDING_SESSION_NAME)
+        if pending_token_in_session == token:
+            self.session_pop(PARTIAL_TOKEN_PENDING_SESSION_NAME)
+            self.session_pop(PARTIAL_TOKEN_PENDING_REQUEST_SESSION_NAME)
+            self.session_pop(PARTIAL_TOKEN_PENDING_CONFIRMATION_SESSION_NAME)
+
+    def partial_pipeline_external_resume_confirmation(
+        self,
+        backend: BaseAuth,
+        partial: PartialMixin,
+        request_data: dict[str, Any],
+    ) -> HttpResponseProtocol | None:
+        return None
+
+    def partial_pipeline_external_resume_confirmed(
+        self,
+        backend: BaseAuth,
+        request_data: dict[str, Any],
+    ) -> bool:
+        return False
 
     def openid_store(self) -> OpenIdStore:
         return OpenIdStore(self)

--- a/social_core/tests/actions/test_login.py
+++ b/social_core/tests/actions/test_login.py
@@ -1,8 +1,15 @@
 from typing import TYPE_CHECKING, cast
+from unittest.mock import patch
 
+from social_core.actions import do_complete
+from social_core.backends.base import BaseAuth
 from social_core.backends.oauth import BaseOAuth2
-from social_core.tests.models import TestUserSocialAuth, User
-from social_core.utils import PARTIAL_TOKEN_SESSION_NAME
+from social_core.tests.models import TestPartial, TestUserSocialAuth, User
+from social_core.utils import (
+    PARTIAL_PIPELINE_ALLOW_EXTERNAL_RESUME,
+    PARTIAL_TOKEN_PENDING_SESSION_NAME,
+    PARTIAL_TOKEN_SESSION_NAME,
+)
 
 from .actions import BaseActionTest
 
@@ -32,6 +39,16 @@ class BackendThatControlsRedirect(BaseOAuth2):
         # Put the redirect URL in the session state, as this is where the `do_complete` action looks for it.
         self.strategy.session_set(kwargs["redirect_name"], "/after-login")
         return kwargs["user"]
+
+
+class PartialTokenBackend(BaseAuth):
+    name = "partial-token"
+
+    def auth_url(self) -> str:
+        return "/auth"
+
+    def auth_complete(self, *args, **kwargs):
+        raise AssertionError("Unexpected backend completion")
 
 
 class LoginActionTest(BaseActionTest):
@@ -91,6 +108,51 @@ class LoginActionTest(BaseActionTest):
             partial.data["backend"] = "foobar"
 
         self.do_login_with_partial_pipeline(before_complete)
+
+    def test_complete_rejects_cross_session_partial_token(self) -> None:
+        def unexpected_login(*args, **kwargs) -> None:
+            raise AssertionError("Unexpected login")
+
+        TestPartial.reset_cache()
+        self.addCleanup(TestPartial.reset_cache)
+        backend = PartialTokenBackend(self.strategy)
+        self.strategy.set_settings({"SOCIAL_AUTH_LOGIN_ERROR_URL": "/error"})
+        partial = TestPartial.prepare(backend.name, 0, {"args": [], "kwargs": {}})
+        partial.token = "attacker-token"
+        partial.save()
+        self.strategy.set_request_data({"partial_token": partial.token}, backend)
+
+        redirect = do_complete(backend, login=unexpected_login)
+
+        self.assertEqual(redirect.url, "/error")
+        self.assertIsNone(self.strategy.session_get("username"))
+        self.assertIsNotNone(TestPartial.load(partial.token))
+
+    def test_complete_external_partial_requires_confirmation(self) -> None:
+        def unexpected_login(*args, **kwargs) -> None:
+            raise AssertionError("Unexpected login")
+
+        TestPartial.reset_cache()
+        self.addCleanup(TestPartial.reset_cache)
+        backend = PartialTokenBackend(self.strategy)
+        partial = TestPartial.prepare(backend.name, 0, {"args": [], "kwargs": {}})
+        partial.token = "external-token"
+        partial.data[PARTIAL_PIPELINE_ALLOW_EXTERNAL_RESUME] = True
+        partial.save()
+        self.strategy.set_request_data({"partial_token": partial.token}, backend)
+
+        with patch.object(
+            self.strategy,
+            "partial_pipeline_external_resume_confirmation",
+            return_value=self.strategy.redirect("/confirm"),
+        ):
+            redirect = do_complete(backend, login=unexpected_login)
+
+        self.assertEqual(redirect.url, "/confirm")
+        self.assertEqual(
+            self.strategy.session_get(PARTIAL_TOKEN_PENDING_SESSION_NAME),
+            partial.token,
+        )
 
     def test_new_user(self) -> None:
         self.strategy.set_settings({"SOCIAL_AUTH_NEW_USER_REDIRECT_URL": "/new-user"})

--- a/social_core/tests/test_mail.py
+++ b/social_core/tests/test_mail.py
@@ -1,0 +1,88 @@
+import unittest
+from typing import Protocol, cast
+from unittest.mock import Mock, patch
+
+from social_core.pipeline.mail import mail_validation
+from social_core.utils import (
+    PARTIAL_PIPELINE_ALLOW_EXTERNAL_RESUME,
+    PARTIAL_TOKEN_SESSION_NAME,
+)
+
+from .models import TestPartial, TestStorage
+from .strategy import Redirect, TestStrategy
+
+
+class PartialStepWrapper(Protocol):
+    def __call__(
+        self,
+        strategy: TestStrategy,
+        backend: object,
+        pipeline_index: int,
+        *args: object,
+        **kwargs: object,
+    ) -> object: ...
+
+
+def call_partial_step(
+    step: PartialStepWrapper,
+    strategy: TestStrategy,
+    backend: object,
+    pipeline_index: int,
+    **kwargs: object,
+) -> object:
+    return step(strategy, backend, pipeline_index, **kwargs)
+
+
+class MailValidationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        TestPartial.reset_cache()
+
+    def test_mail_validation_partial_allows_external_resume(self) -> None:
+        strategy = TestStrategy(TestStorage)
+        strategy.set_settings({"SOCIAL_AUTH_EMAIL_VALIDATION_URL": "/validate"})
+        mail_validation_wrapper = cast("PartialStepWrapper", mail_validation)
+        backend = Mock()
+        backend.name = "email"
+        backend.strategy = strategy
+        backend.REQUIRES_EMAIL_VALIDATION = True
+
+        with patch.object(strategy, "send_email_validation") as send_email_validation:
+            response = call_partial_step(
+                mail_validation_wrapper,
+                strategy,
+                backend,
+                0,
+                details={"email": "foo@example.com"},
+                is_new=True,
+            )
+
+        assert isinstance(response, Redirect)
+        self.assertEqual(response.url, "/validate")
+        token = cast("str", strategy.session_get(PARTIAL_TOKEN_SESSION_NAME))
+        partial = TestPartial.load(token)
+        self.assertIsNotNone(partial)
+        assert partial is not None
+        self.assertTrue(partial.data[PARTIAL_PIPELINE_ALLOW_EXTERNAL_RESUME])
+        send_email_validation.assert_called_once_with(backend, "foo@example.com", token)
+
+    def test_mail_validation_uses_partial_request_data(self) -> None:
+        strategy = TestStrategy(TestStorage)
+        mail_validation_wrapper = cast("PartialStepWrapper", mail_validation)
+        backend = Mock()
+        backend.name = "email"
+        backend.strategy = strategy
+        backend.REQUIRES_EMAIL_VALIDATION = True
+
+        with patch.object(strategy, "validate_email", return_value=True) as validate:
+            response = call_partial_step(
+                mail_validation_wrapper,
+                strategy,
+                backend,
+                0,
+                details={"email": "foo@example.com"},
+                is_new=True,
+                request={"verification_code": "123456"},
+            )
+
+        self.assertEqual(response, {})
+        validate.assert_called_once_with("foo@example.com", "123456")

--- a/social_core/tests/test_partial.py
+++ b/social_core/tests/test_partial.py
@@ -2,7 +2,10 @@ import unittest
 from unittest.mock import Mock, patch
 
 from social_core.pipeline.partial import partial, partial_step
-from social_core.utils import PARTIAL_TOKEN_SESSION_NAME
+from social_core.utils import (
+    PARTIAL_PIPELINE_ALLOW_EXTERNAL_RESUME,
+    PARTIAL_TOKEN_SESSION_NAME,
+)
 
 
 class PartialDecoratorTestCase(unittest.TestCase):
@@ -10,6 +13,7 @@ class PartialDecoratorTestCase(unittest.TestCase):
         super().setUp()
         self.mock_current_partial_token = Mock()
         self.mock_current_partial = Mock(token=self.mock_current_partial_token)
+        self.mock_current_partial.data = {}
 
         self.mock_strategy = Mock()
         self.mock_backend = Mock()
@@ -49,6 +53,32 @@ class PartialDecoratorTestCase(unittest.TestCase):
             self.assertEqual(
                 (PARTIAL_TOKEN_SESSION_NAME, self.mock_current_partial_token),
                 self.mock_session_set.call_args[0],
+            )
+            self.assertFalse(
+                self.mock_current_partial.data[PARTIAL_PIPELINE_ALLOW_EXTERNAL_RESUME]
+            )
+
+    def test_allow_external_resume(self) -> None:
+        # GIVEN
+        expected_response = Mock()
+
+        @partial_step(save_to_session=True, allow_external_resume=True)
+        def decorated_func(*args, **kwargs):
+            return expected_response
+
+        # WHEN
+        with patch(
+            "social_core.pipeline.partial.partial_prepare",
+            return_value=self.mock_current_partial,
+        ):
+            response = decorated_func(
+                self.mock_strategy, self.mock_backend, self.mock_pipeline_index
+            )
+
+            # THEN
+            self.assertEqual(expected_response, response)
+            self.assertTrue(
+                self.mock_current_partial.data[PARTIAL_PIPELINE_ALLOW_EXTERNAL_RESUME]
             )
 
     def test_not_to_save_to_session(self) -> None:

--- a/social_core/tests/test_utils.py
+++ b/social_core/tests/test_utils.py
@@ -6,8 +6,14 @@ from unittest.mock import Mock, patch
 from social_core.backends.base import BaseAuth
 from social_core.pipeline.utils import partial_prepare
 from social_core.utils import (
+    PARTIAL_PIPELINE_ALLOW_EXTERNAL_RESUME,
+    PARTIAL_TOKEN_PENDING_CONFIRMATION_SESSION_NAME,
+    PARTIAL_TOKEN_PENDING_REQUEST_SESSION_NAME,
+    PARTIAL_TOKEN_PENDING_SESSION_NAME,
+    PARTIAL_TOKEN_SESSION_NAME,
     build_absolute_uri,
     partial_pipeline_data,
+    partial_pipeline_result,
     sanitize_redirect,
     slugify,
     user_is_active,
@@ -210,6 +216,30 @@ class PartialPrepareTest(unittest.TestCase):
         )
 
 
+class CleanPartialPipelineTest(unittest.TestCase):
+    def test_clean_partial_pipeline_clears_pending_external_resume(self) -> None:
+        strategy = TestStrategy(TestStorage)
+        partial = TestPartial.prepare("test-backend", 0, {"args": [], "kwargs": {}})
+        partial.token = "external-token"
+        partial.save()
+        strategy.session_set(PARTIAL_TOKEN_PENDING_SESSION_NAME, partial.token)
+        strategy.session_set(PARTIAL_TOKEN_PENDING_CONFIRMATION_SESSION_NAME, "nonce")
+        strategy.session_set(
+            PARTIAL_TOKEN_PENDING_REQUEST_SESSION_NAME, {"verification_code": "123456"}
+        )
+
+        strategy.clean_partial_pipeline(partial.token)
+
+        self.assertIsNone(TestPartial.load(partial.token))
+        self.assertIsNone(strategy.session_get(PARTIAL_TOKEN_PENDING_SESSION_NAME))
+        self.assertIsNone(
+            strategy.session_get(PARTIAL_TOKEN_PENDING_REQUEST_SESSION_NAME)
+        )
+        self.assertIsNone(
+            strategy.session_get(PARTIAL_TOKEN_PENDING_CONFIRMATION_SESSION_NAME)
+        )
+
+
 class PartialPipelineData(unittest.TestCase):
     def test_returns_partial_when_uid_and_email_do_match(self) -> None:
         email = "foo@example.com"
@@ -223,6 +253,158 @@ class PartialPipelineData(unittest.TestCase):
         self.assertIn(key, partial.kwargs)
         self.assertEqual(partial.kwargs[key], val)
         self.assertEqual(backend.strategy.clean_partial_pipeline.call_count, 0)
+
+    def test_returns_partial_when_request_token_matches_session_id(self) -> None:
+        backend = self._backend(request_data={"partial_token": "session-token"})
+        partial = partial_pipeline_data(backend)
+        self.assertIsNotNone(partial)
+        backend.strategy.partial_load.assert_called_once_with("session-token")
+
+    def test_request_token_without_session_match_is_halted(self) -> None:
+        backend = self._backend(
+            request_data={"partial_token": "attacker-token"},
+            session_id="session-token",
+            partial_id="attacker-token",
+        )
+        result = partial_pipeline_result(backend)
+        self.assertIsNone(result.partial)
+        self.assertIsNone(result.response)
+        self.assertTrue(result.halt)
+        self.assertEqual(backend.strategy.clean_partial_pipeline.call_count, 0)
+
+    def test_external_resume_stores_pending_token_and_returns_confirmation(
+        self,
+    ) -> None:
+        response = object()
+        backend = self._backend(
+            request_data={
+                "partial_token": "external-token",
+                "verification_code": "123456",
+            },
+            session_id=None,
+            partial_id="external-token",
+            partial_data={PARTIAL_PIPELINE_ALLOW_EXTERNAL_RESUME: True},
+        )
+        backend.strategy.partial_pipeline_external_resume_confirmation.return_value = (
+            response
+        )
+
+        result = partial_pipeline_result(backend)
+
+        self.assertIsNone(result.partial)
+        self.assertEqual(result.response, response)
+        self.assertFalse(result.halt)
+        backend.strategy.partial_pipeline_external_resume_confirmation.assert_called_once()
+        backend.strategy.session_set.assert_any_call(
+            PARTIAL_TOKEN_PENDING_SESSION_NAME, "external-token"
+        )
+        backend.strategy.session_set.assert_any_call(
+            PARTIAL_TOKEN_PENDING_REQUEST_SESSION_NAME,
+            {"partial_token": "external-token", "verification_code": "123456"},
+        )
+
+    def test_external_resume_stores_plain_pending_request_data(self) -> None:
+        class MultiValueDict(dict):
+            def get(self, key, default=None):
+                value = super().get(key, default)
+                if isinstance(value, list):
+                    return value[-1]
+                return value
+
+            def dict(self):
+                return {key: values[-1] for key, values in self.items()}
+
+        class QueryDict(MultiValueDict):
+            pass
+
+        response = object()
+        backend = self._backend(
+            request_data=QueryDict(
+                {
+                    "partial_token": ["external-token"],
+                    "verification_code": ["123456"],
+                }
+            ),
+            session_id=None,
+            partial_id="external-token",
+            partial_data={PARTIAL_PIPELINE_ALLOW_EXTERNAL_RESUME: True},
+        )
+        backend.strategy.partial_pipeline_external_resume_confirmation.return_value = (
+            response
+        )
+
+        partial_pipeline_result(backend)
+
+        backend.strategy.session_set.assert_any_call(
+            PARTIAL_TOKEN_PENDING_REQUEST_SESSION_NAME,
+            {"partial_token": "external-token", "verification_code": "123456"},
+        )
+
+    def test_external_resume_without_confirmation_handler_halts(self) -> None:
+        backend = self._backend(
+            request_data={"partial_token": "external-token"},
+            session_id=None,
+            partial_id="external-token",
+            partial_data={PARTIAL_PIPELINE_ALLOW_EXTERNAL_RESUME: True},
+        )
+
+        result = partial_pipeline_result(backend)
+
+        self.assertIsNone(result.partial)
+        self.assertIsNone(result.response)
+        self.assertTrue(result.halt)
+        self.assertEqual(backend.strategy.session_set.call_count, 0)
+
+    def test_unconfirmed_external_resume_halts(self) -> None:
+        backend = self._backend(
+            request_data={"partial_pipeline_confirm": "1"},
+            session_id=None,
+            pending_resume={
+                "token": "external-token",
+                "request": {
+                    "partial_token": "external-token",
+                    "verification_code": "123456",
+                },
+            },
+            partial_id="external-token",
+            partial_data={PARTIAL_PIPELINE_ALLOW_EXTERNAL_RESUME: True},
+        )
+        backend.strategy.partial_pipeline_external_resume_confirmed.return_value = False
+
+        result = partial_pipeline_result(backend)
+
+        self.assertIsNone(result.partial)
+        self.assertIsNone(result.response)
+        self.assertTrue(result.halt)
+
+    def test_confirmed_external_resume_uses_pending_request_data(self) -> None:
+        backend = self._backend(
+            request_data={"partial_pipeline_confirm": "1"},
+            session_id=None,
+            pending_resume={
+                "token": "external-token",
+                "request": {
+                    "partial_token": "external-token",
+                    "verification_code": "123456",
+                },
+            },
+            partial_id="external-token",
+            partial_data={PARTIAL_PIPELINE_ALLOW_EXTERNAL_RESUME: True},
+        )
+
+        result = partial_pipeline_result(backend, request=object())
+
+        self.assertIsNotNone(result.partial)
+        assert result.partial is not None
+        self.assertEqual(
+            result.partial.kwargs["request"]["partial_token"], "external-token"
+        )
+        self.assertEqual(
+            result.partial.kwargs["request"]["verification_code"], "123456"
+        )
+        self.assertEqual(
+            result.partial.kwargs["request"]["partial_pipeline_confirm"], "1"
+        )
 
     def test_clean_pipeline_when_uid_does_not_match(self) -> None:
         backend = self._backend({"uid": "foo@example.com"})
@@ -268,21 +450,53 @@ class PartialPipelineData(unittest.TestCase):
         self.assertEqual(partial.kwargs[key], val)
         self.assertEqual(backend.strategy.clean_partial_pipeline.call_count, 0)
 
-    def _backend(self, session_kwargs=None):
+    def _backend(
+        self,
+        session_kwargs=None,
+        request_data=None,
+        session_id: str | None = "session-token",
+        pending_resume=None,
+        partial_id="session-token",
+        partial_data=None,
+        settings=None,
+    ):
         backend = Mock()
         backend.ID_KEY = "email"
         backend.name = "mock-backend"
         backend.id_key.return_value = "email"
+        settings = settings or {}
+
+        def setting(name, default=None):
+            return settings.get(name, default)
 
         strategy = Mock()
         strategy.request = None
-        strategy.request_data.return_value = {}
-        strategy.session_get.return_value = object()
-        strategy.partial_load.return_value = TestPartial.prepare(
+        strategy.request_data.return_value = request_data or {}
+        strategy.to_session_value.side_effect = lambda value: value
+        strategy.from_session_value.side_effect = lambda value: value
+        session_values = {
+            PARTIAL_TOKEN_SESSION_NAME: session_id,
+            PARTIAL_TOKEN_PENDING_SESSION_NAME: (pending_resume or {}).get("token"),
+            PARTIAL_TOKEN_PENDING_REQUEST_SESSION_NAME: (pending_resume or {}).get(
+                "request"
+            ),
+        }
+        strategy.session_get.side_effect = lambda name, default=None: (
+            session_values.get(name, default)
+        )
+        partial = TestPartial.prepare(
             backend.name, 0, {"args": [], "kwargs": session_kwargs or {}}
         )
+        partial.token = partial_id
+        if partial_data:
+            partial.data.update(partial_data)
+        strategy.partial_load.return_value = partial
+        strategy.redirect.return_value = Mock()
+        strategy.partial_pipeline_external_resume_confirmation.return_value = None
+        strategy.partial_pipeline_external_resume_confirmed.return_value = True
 
         backend.strategy = strategy
+        backend.setting.side_effect = setting
         return backend
 
 

--- a/social_core/utils.py
+++ b/social_core/utils.py
@@ -7,6 +7,7 @@ import logging
 import re
 import time
 import unicodedata
+from dataclasses import dataclass
 from importlib import import_module
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import parse_qs as battery_parse_qs
@@ -15,6 +16,7 @@ from urllib.parse import unquote, urlencode, urlparse, urlunparse
 import requests
 
 import social_core
+from social_core.pipeline.utils import is_dict_type, to_plain_dict
 
 from .exceptions import (
     AuthCanceled,
@@ -26,14 +28,34 @@ from .exceptions import (
 if TYPE_CHECKING:
     from .backends.base import BaseAuth
     from .storage import PartialMixin, UserProtocol
-    from .strategy import BaseStrategy
+    from .strategy import BaseStrategy, HttpResponseProtocol
 
 SETTING_PREFIX = "SOCIAL_AUTH"
 
 PARTIAL_TOKEN_SESSION_NAME = "partial_pipeline_token"
+PARTIAL_TOKEN_PENDING_SESSION_NAME = "partial_pipeline_pending_token"
+PARTIAL_TOKEN_PENDING_REQUEST_SESSION_NAME = "partial_pipeline_pending_request"
+PARTIAL_TOKEN_PENDING_CONFIRMATION_SESSION_NAME = (
+    "partial_pipeline_pending_confirmation"
+)
+PARTIAL_PIPELINE_ALLOW_EXTERNAL_RESUME = "allow_external_resume"
 
 
 social_logger = logging.getLogger("social")
+
+
+@dataclass
+class PartialPipelineResult:
+    partial: PartialMixin | None = None
+    response: HttpResponseProtocol | None = None
+    halt: bool = False
+
+
+@dataclass
+class PartialPipelineSelection:
+    token: str | None = None
+    owns_token: bool = False
+    pending_resume: bool = False
 
 
 def module_member(name):
@@ -170,6 +192,170 @@ def drop_lists(value):
     return out
 
 
+def _partial_pipeline_matches_request(
+    backend: BaseAuth, partial: PartialMixin | None, request_data: dict[str, Any]
+) -> bool:
+    if not partial or partial.backend != backend.name:
+        return False
+
+    # Normally when resuming a pipeline, request_data will be empty. We only
+    # need to check for a uid match if new data was provided (i.e. if current
+    # request specifies the ID_KEY).
+    id_key = backend.id_key()
+    if id_key and id_key in request_data:
+        id_from_partial = partial.kwargs.get("uid")
+        id_from_request = request_data.get(id_key)
+
+        return id_from_partial == id_from_request
+
+    return True
+
+
+def _extend_partial_pipeline(
+    partial: PartialMixin,
+    request_data: dict[str, Any],
+    user: UserProtocol | None,
+    kwargs: dict[str, Any],
+) -> PartialMixin:
+    if user:  # don't update user if it's None
+        kwargs.setdefault("user", user)
+    kwargs["request"] = request_data
+    partial.extend_kwargs(kwargs)
+    return partial
+
+
+def _select_partial_pipeline_token(
+    request_token: str | None,
+    session_token: str | None,
+    pending_token: str | None,
+    confirmation_requested: bool,
+) -> PartialPipelineSelection:
+    if request_token and request_token == session_token:
+        return PartialPipelineSelection(token=request_token, owns_token=True)
+
+    if confirmation_requested and pending_token:
+        selected_token = request_token or pending_token
+        pending_resume = selected_token == pending_token
+        return PartialPipelineSelection(
+            token=selected_token,
+            owns_token=pending_resume,
+            pending_resume=pending_resume,
+        )
+
+    if request_token:
+        return PartialPipelineSelection(token=request_token)
+
+    return PartialPipelineSelection(token=session_token, owns_token=bool(session_token))
+
+
+def _confirmed_partial_pipeline_request_data(
+    backend: BaseAuth,
+    request_data: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not backend.strategy.partial_pipeline_external_resume_confirmed(
+        backend, request_data
+    ):
+        return None
+
+    pending_request_data = backend.strategy.from_session_value(
+        backend.strategy.session_get(PARTIAL_TOKEN_PENDING_REQUEST_SESSION_NAME, {})
+        or {}
+    )
+    return {**pending_request_data, **request_data}
+
+
+def _external_partial_pipeline_result(
+    backend: BaseAuth,
+    partial: PartialMixin,
+    selected_token: str,
+    request_data: dict[str, Any],
+) -> PartialPipelineResult:
+    response = backend.strategy.partial_pipeline_external_resume_confirmation(
+        backend, partial, request_data
+    )
+    if response is None:
+        return PartialPipelineResult(halt=True)
+
+    backend.strategy.session_set(PARTIAL_TOKEN_PENDING_SESSION_NAME, selected_token)
+    backend.strategy.session_set(
+        PARTIAL_TOKEN_PENDING_REQUEST_SESSION_NAME,
+        backend.strategy.to_session_value(
+            to_plain_dict(request_data) if is_dict_type(request_data) else request_data
+        ),
+    )
+    return PartialPipelineResult(response=response)
+
+
+def partial_pipeline_result(
+    backend: BaseAuth,
+    user: UserProtocol | None = None,
+    partial_token: str | None = None,
+    *args,
+    **kwargs,
+) -> PartialPipelineResult:
+    request_data = backend.strategy.request_data()
+
+    partial_argument_name = backend.setting(
+        "PARTIAL_PIPELINE_TOKEN_NAME", "partial_token"
+    )
+    request_token = cast(
+        "str | None", partial_token or request_data.get(partial_argument_name)
+    )
+    session_token = backend.strategy.session_get(PARTIAL_TOKEN_SESSION_NAME, None)
+    pending_token = backend.strategy.session_get(
+        PARTIAL_TOKEN_PENDING_SESSION_NAME, None
+    )
+
+    confirmation_parameter = backend.setting(
+        "PARTIAL_PIPELINE_EXTERNAL_RESUME_CONFIRMATION_PARAMETER",
+        "partial_pipeline_confirm",
+    )
+    confirmation_requested = (
+        bool(confirmation_parameter) and confirmation_parameter in request_data
+    )
+
+    selection = _select_partial_pipeline_token(
+        request_token=request_token,
+        session_token=session_token,
+        pending_token=pending_token,
+        confirmation_requested=confirmation_requested,
+    )
+    if not selection.token:
+        return PartialPipelineResult()
+
+    result = PartialPipelineResult(halt=bool(request_token or confirmation_requested))
+    effective_request_data = request_data
+    if selection.pending_resume:
+        confirmed_request_data = _confirmed_partial_pipeline_request_data(
+            backend, request_data
+        )
+        if confirmed_request_data is None:
+            return PartialPipelineResult(halt=True)
+        effective_request_data = confirmed_request_data
+
+    partial: PartialMixin | None = backend.strategy.partial_load(selection.token)
+    partial_matches = _partial_pipeline_matches_request(
+        backend, partial, effective_request_data
+    )
+    if partial and partial_matches:
+        if selection.owns_token:
+            result = PartialPipelineResult(
+                partial=_extend_partial_pipeline(
+                    partial, effective_request_data, user, kwargs
+                )
+            )
+        elif partial.data.get(PARTIAL_PIPELINE_ALLOW_EXTERNAL_RESUME):
+            result = _external_partial_pipeline_result(
+                backend, partial, selection.token, effective_request_data
+            )
+        else:
+            result = PartialPipelineResult(halt=True)
+    elif selection.owns_token:
+        backend.strategy.clean_partial_pipeline(selection.token)
+
+    return result
+
+
 def partial_pipeline_data(
     backend: BaseAuth,
     user: UserProtocol | None = None,
@@ -177,44 +363,9 @@ def partial_pipeline_data(
     *args,
     **kwargs,
 ) -> PartialMixin | None:
-    request_data = backend.strategy.request_data()
-
-    partial_argument_name = backend.setting(
-        "PARTIAL_PIPELINE_TOKEN_NAME", "partial_token"
-    )
-    partial_token = (
-        partial_token
-        or request_data.get(partial_argument_name)
-        or backend.strategy.session_get(PARTIAL_TOKEN_SESSION_NAME, None)
-    )
-
-    if partial_token:
-        partial: PartialMixin | None = backend.strategy.partial_load(partial_token)
-        partial_matches_request = False
-
-        if partial and partial.backend == backend.name:
-            partial_matches_request = True
-
-            # Normally when resuming a pipeline, request_data will be empty. We
-            # only need to check for a uid match if new data was provided (i.e.
-            # if current request specifies the ID_KEY).
-            id_key = backend.id_key()
-            if id_key and id_key in request_data:
-                id_from_partial = partial.kwargs.get("uid")
-                id_from_request = request_data.get(id_key)
-
-                if id_from_partial != id_from_request:
-                    partial_matches_request = False
-
-        if partial and partial_matches_request:
-            if user:  # don't update user if it's None
-                kwargs.setdefault("user", user)
-            kwargs.setdefault("request", request_data)
-            partial.extend_kwargs(kwargs)
-            return partial
-        backend.strategy.clean_partial_pipeline(partial_token)
-        return None
-    return None
+    return partial_pipeline_result(
+        backend, user, partial_token, *args, **kwargs
+    ).partial
 
 
 def build_absolute_uri(host_url: str, path: str | None = None) -> str:


### PR DESCRIPTION
Require same-session ownership before resuming partial tokens by default.

Add explicit external resume confirmation hooks for flows such as e-mail validation.

BREAKING CHANGE: Applications that resume partial pipelines from external links must mark those steps with allow_external_resume and implement Strategy confirmation hooks.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
