### PR TITLE
fix(line): validate oauth state on callback

### DIFF
--- a/social_core/backends/line.py
+++ b/social_core/backends/line.py
@@ -54,6 +54,7 @@ class LineOAuth2(BaseOAuth2):
     def auth_complete(self, *args, **kwargs):
         """Completes login process, must return user instance"""
         self.process_error(self.data)
+        self.validate_state()
 
         try:
             response = self.request_access_token(

--- a/social_core/tests/backends/test_line.py
+++ b/social_core/tests/backends/test_line.py
@@ -1,0 +1,57 @@
+import json
+from typing import cast
+
+import responses
+
+from social_core.utils import get_querystring, parse_qs
+
+from .oauth import BaseAuthUrlTestMixin, OAuth2StateTestMixin, OAuth2Test
+
+
+class LineOAuth2Test(OAuth2Test, OAuth2StateTestMixin, BaseAuthUrlTestMixin):
+    backend_path = "social_core.backends.line.LineOAuth2"
+    user_data_url = "https://api.line.me/v2/profile"
+    expected_username = "U4af4980629"
+    access_token_body = json.dumps(
+        {
+            "access_token": "access-token",
+            "expires_in": 2592000,
+            "refresh_token": "refresh-token",
+            "token_type": "Bearer",
+        }
+    )
+    user_data_body = json.dumps(
+        {
+            "userId": "U4af4980629",
+            "displayName": "LINE taro",
+            "pictureUrl": "https://profile.line-scdn.net/abcdefghijklmn",
+            "statusMessage": "Hello, LINE!",
+        }
+    )
+
+    def test_login(self) -> None:
+        self.do_login()
+
+    def test_access_token_request_uses_authorization_redirect_uri(self) -> None:
+        self.do_login()
+
+        auth_request = next(
+            r.request
+            for r in responses.calls
+            if cast("str", r.request.url).startswith(self.backend.authorization_url())
+        )
+        token_request = next(
+            r.request
+            for r in responses.calls
+            if cast("str", r.request.url).startswith(self.backend.access_token_url())
+        )
+
+        auth_redirect_uri = get_querystring(cast("str", auth_request.url))[
+            "redirect_uri"
+        ]
+        token_redirect_uri = parse_qs(token_request.body)["redirect_uri"]
+
+        self.assertEqual(token_redirect_uri, auth_redirect_uri)
+
+    def test_partial_pipeline(self) -> None:
+        self.do_partial_pipeline()


### PR DESCRIPTION
Validate the returned LINE OAuth state before exchanging authorization codes to prevent login CSRF. Add regression coverage for LINE state handling and redirect URI consistency.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
