### PR TITLE
fix(backends): wrap JWT verification errors

### DIFF
--- a/social_core/backends/auth0.py
+++ b/social_core/backends/auth0.py
@@ -5,6 +5,8 @@ https://auth0.com/docs/quickstart/webapp/django/01-login
 
 import jwt
 
+from social_core.exceptions import AuthTokenError
+
 from .oauth import BaseOAuth2
 
 
@@ -36,12 +38,14 @@ class Auth0OAuth2(BaseOAuth2):
         issuer = self.api_path()
         audience = self.setting("KEY")  # CLIENT_ID
         try:
-            # it could be a set of JWKs
-            keys = jwt.PyJWKSet.from_dict(jwks).keys
-        except jwt.PyJWKSetError:
-            # let any error raise from here
-            # try to get single JWK
-            keys = [jwt.PyJWK.from_dict(jwks, "RS256")]
+            try:
+                # it could be a set of JWKs
+                keys = jwt.PyJWKSet.from_dict(jwks).keys
+            except jwt.PyJWKSetError:
+                # try to get single JWK
+                keys = [jwt.PyJWK.from_dict(jwks, "RS256")]
+        except jwt.PyJWTError as error:
+            raise AuthTokenError(self, error) from error
 
         signature_error = None
         for key in keys:
@@ -55,12 +59,14 @@ class Auth0OAuth2(BaseOAuth2):
                 )
             except (jwt.InvalidSignatureError, jwt.InvalidAlgorithmError) as ex:
                 signature_error = ex
+            except jwt.PyJWTError as error:
+                raise AuthTokenError(self, error) from error
             else:
                 break
         else:
             assert signature_error is not None
-            # raise last esception found during iteration
-            raise signature_error
+            # raise the last exception found during iteration
+            raise AuthTokenError(self, signature_error) from signature_error
 
         fullname, first_name, last_name = self.get_user_names(payload["name"])
         return {

--- a/social_core/backends/exacttarget.py
+++ b/social_core/backends/exacttarget.py
@@ -65,7 +65,7 @@ class ExactTargetOAuth2(BaseOAuth2):
         _key, secret = self.get_key_and_secret()
         try:  # Decode the token, using the Application Signature from settings
             decoded = jwt.decode(token, secret, algorithms=["HS256"])
-        except jwt.DecodeError as error:
+        except jwt.PyJWTError as error:
             # Wrong signature, fail authentication
             raise AuthCanceled(self) from error
         kwargs.update({"response": {"token": decoded}, "backend": self})

--- a/social_core/backends/keycloak.py
+++ b/social_core/backends/keycloak.py
@@ -3,6 +3,7 @@ from typing import Any, cast
 import jwt
 
 from social_core.backends.oauth import BaseOAuth2
+from social_core.exceptions import AuthTokenError
 
 
 class KeycloakOAuth2(BaseOAuth2):  # pylint: disable=abstract-method
@@ -118,13 +119,16 @@ class KeycloakOAuth2(BaseOAuth2):  # pylint: disable=abstract-method
         the user information in the access_token.
         """
 
-        return jwt.decode(
-            access_token,
-            key=self.public_key(),
-            algorithms=self.algorithm(),
-            audience=self.audience(),
-            leeway=cast("int", self.setting("JWT_LEEWAY", default=0)),
-        )
+        try:
+            return jwt.decode(
+                access_token,
+                key=self.public_key(),
+                algorithms=self.algorithm(),
+                audience=self.audience(),
+                leeway=cast("int", self.setting("JWT_LEEWAY", default=0)),
+            )
+        except jwt.PyJWTError as error:
+            raise AuthTokenError(self, error) from error
 
     def get_user_details(self, response):
         """Map fields in user_data into Django User fields"""

--- a/social_core/backends/mediawiki.py
+++ b/social_core/backends/mediawiki.py
@@ -140,7 +140,7 @@ class MediaWiki(BaseOAuth1):
                 algorithms=["HS256"],
                 leeway=self.LEEWAY,
             )
-        except jwt.InvalidTokenError as exception:
+        except jwt.PyJWTError as exception:
             raise AuthException(
                 self,
                 f"An error occurred while trying to read json content: {exception}",

--- a/social_core/backends/open_id_connect.py
+++ b/social_core/backends/open_id_connect.py
@@ -315,14 +315,16 @@ class OpenIdConnectAuth(BaseOAuth2PKCE):
         """
         client_id, _client_secret = self.get_key_and_secret()
 
-        key = self.find_valid_key(id_token)
+        try:
+            key = self.find_valid_key(id_token)
+        except PyJWTError as error:
+            raise AuthTokenError(self, str(error)) from error
 
         if not key:
             raise AuthTokenError(self, "Signature verification failed")
 
-        rsakey = jwt.PyJWK(key)
-
         try:
+            rsakey = jwt.PyJWK(key)
             claims = jwt.decode(
                 id_token,
                 rsakey.key,

--- a/social_core/backends/ping.py
+++ b/social_core/backends/ping.py
@@ -45,16 +45,19 @@ class PingOpenIdConnect(OpenIdConnectAuth):
         """
         client_id, _client_secret = self.get_key_and_secret()
 
-        key = self.find_valid_key(id_token)
+        try:
+            key = self.find_valid_key(id_token)
+        except PyJWTError as error:
+            raise AuthTokenError(self, str(error)) from error
 
         if not key:
             raise AuthTokenError(self, "Signature verification failed")
 
         if "alg" not in key:
             key["alg"] = "RS256"
-        rsakey = jwt.PyJWK(key)
 
         try:
+            rsakey = jwt.PyJWK(key)
             claims = jwt.decode(
                 id_token,
                 rsakey.key,

--- a/social_core/tests/backends/test_auth0.py
+++ b/social_core/tests/backends/test_auth0.py
@@ -1,7 +1,10 @@
 import json
+from unittest.mock import patch
 
 import jwt
 import responses
+
+from social_core.exceptions import AuthTokenError
 
 from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
@@ -72,6 +75,33 @@ class Auth0OAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
 
     def test_login(self) -> None:
         self.do_login()
+
+    def test_invalid_signature_raises_auth_token_error(self) -> None:
+        assert self.access_token_body is not None
+        id_token = json.loads(self.access_token_body)["id_token"]
+        header, payload, _signature = id_token.split(".")
+
+        with (
+            patch.object(
+                self.backend, "get_json", return_value={"keys": [JWK_PUBLIC_KEY]}
+            ),
+            self.assertRaises(AuthTokenError) as context,
+        ):
+            self.backend.get_user_details({"id_token": f"{header}.{payload}.AAAA"})
+
+        self.assertIsInstance(context.exception.__cause__, jwt.InvalidSignatureError)
+
+    def test_invalid_jwk_raises_auth_token_error(self) -> None:
+        assert self.access_token_body is not None
+        id_token = json.loads(self.access_token_body)["id_token"]
+
+        with (
+            patch.object(self.backend, "get_json", return_value={}),
+            self.assertRaises(AuthTokenError) as context,
+        ):
+            self.backend.get_user_details({"id_token": id_token})
+
+        self.assertIsInstance(context.exception.__cause__, jwt.PyJWTError)
 
     def test_partial_pipeline(self) -> None:
         self.do_partial_pipeline()

--- a/social_core/tests/backends/test_exacttarget.py
+++ b/social_core/tests/backends/test_exacttarget.py
@@ -1,0 +1,28 @@
+from unittest.mock import patch
+
+import jwt
+
+from social_core.exceptions import AuthCanceled
+
+from .base import BaseBackendTest
+
+
+class ExactTargetOAuth2Test(BaseBackendTest):
+    backend_path = "social_core.backends.exacttarget.ExactTargetOAuth2"
+
+    def extra_settings(self) -> dict[str, str | list[str]]:
+        return {
+            "SOCIAL_AUTH_EXACTTARGET_KEY": "key",
+            "SOCIAL_AUTH_EXACTTARGET_SECRET": "secret",
+        }
+
+    def test_jwt_error_is_wrapped(self) -> None:
+        error = jwt.ExpiredSignatureError("expired")
+
+        with (
+            patch("social_core.backends.exacttarget.jwt.decode", side_effect=error),
+            self.assertRaises(AuthCanceled) as context,
+        ):
+            self.backend.do_auth("token")
+
+        self.assertIs(context.exception.__cause__, error)

--- a/social_core/tests/backends/test_keycloak.py
+++ b/social_core/tests/backends/test_keycloak.py
@@ -5,6 +5,8 @@ import time
 
 import jwt
 
+from social_core.exceptions import AuthTokenError
+
 from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 _PRIVATE_KEY_HEADERLESS = """
@@ -127,6 +129,14 @@ class KeycloakOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
 
     def test_login(self) -> None:
         self.do_login()
+
+    def test_invalid_signature_raises_auth_token_error(self) -> None:
+        header, payload, _signature = _encode(_PAYLOAD).split(".")
+
+        with self.assertRaises(AuthTokenError) as context:
+            self.backend.user_data(f"{header}.{payload}.AAAA")
+
+        self.assertIsInstance(context.exception.__cause__, jwt.InvalidSignatureError)
 
     def test_partial_pipeline(self) -> None:
         self.do_partial_pipeline()

--- a/social_core/tests/backends/test_mediawiki.py
+++ b/social_core/tests/backends/test_mediawiki.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import jwt
+
+from social_core.exceptions import AuthException
+
+from .base import BaseBackendTest
+
+
+class MediaWikiTest(BaseBackendTest):
+    backend_path = "social_core.backends.mediawiki.MediaWiki"
+
+    def extra_settings(self) -> dict[str, str | list[str]]:
+        return {
+            "SOCIAL_AUTH_MEDIAWIKI_KEY": "key",
+            "SOCIAL_AUTH_MEDIAWIKI_SECRET": "secret",
+            "SOCIAL_AUTH_MEDIAWIKI_URL": "https://example.com/wiki",
+        }
+
+    def test_jwt_error_is_wrapped(self) -> None:
+        error = jwt.PyJWKError("invalid key")
+        response = {
+            "access_token": {
+                "oauth_token": b"token",
+                "oauth_token_secret": b"secret",
+            }
+        }
+
+        with (
+            patch.object(
+                self.backend,
+                "request",
+                return_value=SimpleNamespace(content=b"token"),
+            ),
+            patch("social_core.backends.mediawiki.jwt.decode", side_effect=error),
+            self.assertRaises(AuthException) as context,
+        ):
+            self.backend.get_user_details(response)
+
+        self.assertIs(context.exception.__cause__, error)

--- a/social_core/tests/backends/test_open_id_connect.py
+++ b/social_core/tests/backends/test_open_id_connect.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from typing import Protocol, cast
 
+import jwt
 import responses
 
 from social_core.backends.open_id_connect import OpenIdConnectAuth
@@ -175,6 +176,12 @@ class ExampleOpenIdConnectTest(OpenIdConnectTest):
 
     def test_everything_works(self) -> None:
         self.do_login()
+
+    def test_malformed_id_token_raises_auth_token_error(self) -> None:
+        with self.assertRaises(AuthTokenError) as context:
+            self.backend.validate_and_return_id_token("malformed", "access-token")
+
+        self.assertIsInstance(context.exception.__cause__, jwt.PyJWTError)
 
     def test_user_id_comes_from_id_token_when_userinfo_omits_sub(self) -> None:
         user = self.do_login()

--- a/social_core/tests/backends/test_ping.py
+++ b/social_core/tests/backends/test_ping.py
@@ -1,0 +1,26 @@
+from unittest.mock import patch
+
+import jwt
+
+from social_core.exceptions import AuthTokenError
+
+from .base import BaseBackendTest
+
+
+class PingOpenIdConnectTest(BaseBackendTest):
+    backend_path = "social_core.backends.ping.PingOpenIdConnect"
+
+    def extra_settings(self) -> dict[str, str | list[str]]:
+        return {
+            "SOCIAL_AUTH_PING_KEY": "key",
+            "SOCIAL_AUTH_PING_SECRET": "secret",
+        }
+
+    def test_invalid_jwk_raises_auth_token_error(self) -> None:
+        with (
+            patch.object(self.backend, "get_jwks_keys", return_value=[{}]),
+            self.assertRaises(AuthTokenError) as context,
+        ):
+            self.backend.validate_and_return_id_token("token", "access-token")
+
+        self.assertIsInstance(context.exception.__cause__, jwt.PyJWTError)


### PR DESCRIPTION
PyJWT failures could escape from some authentication backends, forcing callers to handle dependency-specific exceptions. Translate them to social-core exceptions while preserving the original cause for diagnosis.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
