### PR TITLE
feat(utils): add ALLOWED_REDIRECT_SCHEMES for native app redirects

### DIFF
--- a/social_core/actions.py
+++ b/social_core/actions.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import quote
 
 from .utils import (
+    get_allowed_redirect_schemes,
     partial_pipeline_result,
     sanitize_redirect,
     setting_url,
@@ -42,9 +43,9 @@ def _sanitize_redirect_url(backend: BaseAuth, url: str) -> str:
             *cast("list[str]", backend.setting("ALLOWED_REDIRECT_HOSTS", [])),
             backend.strategy.request_host(),
         ]
-        sanitized_url = sanitize_redirect(allowed_hosts, url) or backend.setting(
-            "LOGIN_REDIRECT_URL"
-        )
+        sanitized_url = sanitize_redirect(
+            allowed_hosts, url, get_allowed_redirect_schemes(backend)
+        ) or backend.setting("LOGIN_REDIRECT_URL")
         if sanitized_url is None:
             raise ValueError("Disallowed URL")
         url = cast("str", sanitized_url)
@@ -97,7 +98,9 @@ def do_auth(backend: BaseAuth, redirect_name: str = "next") -> HttpResponseProto
                 *cast("list[str]", backend.setting("ALLOWED_REDIRECT_HOSTS", [])),
                 backend.strategy.request_host(),
             ]
-            redirect_uri = sanitize_redirect(allowed_hosts, redirect_uri)
+            redirect_uri = sanitize_redirect(
+                allowed_hosts, redirect_uri, get_allowed_redirect_schemes(backend)
+            )
         backend.strategy.session_set(
             redirect_name, redirect_uri or backend.setting("LOGIN_REDIRECT_URL")
         )
@@ -241,7 +244,9 @@ def do_disconnect(
                 backend.strategy.request_host(),
             ]
             url = (
-                sanitize_redirect(allowed_hosts, url)
+                sanitize_redirect(
+                    allowed_hosts, url, get_allowed_redirect_schemes(backend)
+                )
                 or backend.setting("DISCONNECT_REDIRECT_URL")
                 or backend.setting("LOGIN_REDIRECT_URL")
             )

--- a/social_core/actions.py
+++ b/social_core/actions.py
@@ -5,6 +5,7 @@ from urllib.parse import quote
 
 from .utils import (
     get_allowed_redirect_schemes,
+    is_private_use_redirect,
     partial_pipeline_result,
     sanitize_redirect,
     setting_url,
@@ -233,10 +234,18 @@ def do_disconnect(
         )
 
     if isinstance(response, dict):
-        url: str | None = backend.strategy.absolute_uri(
+        allowed_schemes = get_allowed_redirect_schemes(backend)
+        candidate = (
             backend.strategy.request_data().get(redirect_name, "")
             or backend.setting("DISCONNECT_REDIRECT_URL")
             or backend.setting("LOGIN_REDIRECT_URL")
+        )
+        # absolute_uri() only preserves http and https, so an allowed
+        # private-use scheme has to bypass it to survive intact.
+        url: str | None = (
+            cast("str", candidate)
+            if is_private_use_redirect(cast("str | None", candidate), allowed_schemes)
+            else backend.strategy.absolute_uri(cast("str | None", candidate))
         )
         if backend.setting("SANITIZE_REDIRECTS", True):
             allowed_hosts = [
@@ -244,9 +253,7 @@ def do_disconnect(
                 backend.strategy.request_host(),
             ]
             url = (
-                sanitize_redirect(
-                    allowed_hosts, url, get_allowed_redirect_schemes(backend)
-                )
+                sanitize_redirect(allowed_hosts, url, allowed_schemes)
                 or backend.setting("DISCONNECT_REDIRECT_URL")
                 or backend.setting("LOGIN_REDIRECT_URL")
             )

--- a/social_core/tests/actions/test_disconnect.py
+++ b/social_core/tests/actions/test_disconnect.py
@@ -30,6 +30,61 @@ class DisconnectActionTest(BaseActionTest):
         do_disconnect(self.backend, user)
         self.assertEqual(len(user.social), 0)
 
+    def test_disconnect_redirects_to_allowed_private_use_scheme(self) -> None:
+        deeplink = "com.example.app://oauth2redirect"
+        self.strategy.set_settings(
+            {
+                "SOCIAL_AUTH_DISCONNECT_REDIRECT_URL": deeplink,
+                "SOCIAL_AUTH_ALLOWED_REDIRECT_SCHEMES": [
+                    "http",
+                    "https",
+                    "com.example.app",
+                ],
+            }
+        )
+        self.do_login()
+        user = cast("User", User.get(self.expected_username))
+        user.password = "password"
+        redirect = do_disconnect(self.backend, user)
+        self.assertEqual(redirect.url, deeplink)
+
+    def test_disconnect_ignores_disallowed_scheme_from_request(self) -> None:
+        self.strategy.set_settings(
+            {
+                "SOCIAL_AUTH_DISCONNECT_REDIRECT_URL": "/disconnected",
+                "SOCIAL_AUTH_ALLOWED_REDIRECT_SCHEMES": [
+                    "http",
+                    "https",
+                    "com.example.app",
+                ],
+            }
+        )
+        self.do_login()
+        user = cast("User", User.get(self.expected_username))
+        user.password = "password"
+        self.strategy.set_request_data({"next": "com.evil.app://steal"}, self.backend)
+        redirect = do_disconnect(self.backend, user)
+        self.assertNotEqual(redirect.url, "com.evil.app://steal")
+
+    def test_disconnect_keeps_allowed_scheme_from_request(self) -> None:
+        deeplink = "com.example.app://oauth2redirect"
+        self.strategy.set_settings(
+            {
+                "SOCIAL_AUTH_DISCONNECT_REDIRECT_URL": "/disconnected",
+                "SOCIAL_AUTH_ALLOWED_REDIRECT_SCHEMES": [
+                    "http",
+                    "https",
+                    "com.example.app",
+                ],
+            }
+        )
+        self.do_login()
+        user = cast("User", User.get(self.expected_username))
+        user.password = "password"
+        self.strategy.set_request_data({"next": deeplink}, self.backend)
+        redirect = do_disconnect(self.backend, user)
+        self.assertEqual(redirect.url, deeplink)
+
     def test_disconnect_with_association_id(self) -> None:
         self.do_login()
         user = cast("User", User.get(self.expected_username))

--- a/social_core/tests/test_utils.py
+++ b/social_core/tests/test_utils.py
@@ -147,6 +147,18 @@ class SanitizeRedirectAllowedSchemesTest(unittest.TestCase):
         for url in ["///evil.com", "/\\evil.com", "/path/\n"]:
             self.assertEqual(sanitize_redirect(["myapp.com"], url, self.schemes), None)
 
+    def test_scheme_matching_is_case_insensitive(self) -> None:
+        url = "com.example.app://oauth2redirect"
+        self.assertEqual(
+            sanitize_redirect(["myapp.com"], url, {"Com.Example.App"}), url
+        )
+        self.assertEqual(
+            sanitize_redirect(
+                ["myapp.com"], "COM.EXAMPLE.APP://oauth2redirect", {"com.example.app"}
+            ),
+            "COM.EXAMPLE.APP://oauth2redirect",
+        )
+
     def test_restricting_schemes_blocks_web_urls(self) -> None:
         self.assertEqual(
             sanitize_redirect(
@@ -180,6 +192,18 @@ class IsUrlTest(unittest.TestCase):
 
     def test_malformed_web_scheme_not_promoted(self) -> None:
         self.assertEqual(is_url("http:evil.example/path", {"http", "https"}), False)
+
+    def test_malformed_url_does_not_raise(self) -> None:
+        for value in ["foo://[bad", "com.example.app://[::1", "foo://["]:
+            self.assertEqual(is_url(value, {"foo", "com.example.app"}), False)
+
+    def test_scheme_matching_is_case_insensitive(self) -> None:
+        self.assertEqual(
+            is_url("com.example.app://oauth2redirect", {"Com.Example.App"}), True
+        )
+        self.assertEqual(
+            is_url("COM.EXAMPLE.APP://oauth2redirect", {"com.example.app"}), True
+        )
 
 
 class UserIsAuthenticatedTest(unittest.TestCase):

--- a/social_core/tests/test_utils.py
+++ b/social_core/tests/test_utils.py
@@ -12,6 +12,7 @@ from social_core.utils import (
     PARTIAL_TOKEN_PENDING_SESSION_NAME,
     PARTIAL_TOKEN_SESSION_NAME,
     build_absolute_uri,
+    is_url,
     partial_pipeline_data,
     partial_pipeline_result,
     sanitize_redirect,
@@ -102,6 +103,83 @@ class SanitizeRedirectTest(unittest.TestCase):
             ),
             None,
         )
+
+
+class SanitizeRedirectAllowedSchemesTest(unittest.TestCase):
+    schemes = ("http", "https", "com.example.app")
+
+    def test_allowed_private_use_scheme(self) -> None:
+        for url in [
+            "com.example.app://oauth2redirect",
+            "com.example.app:/oauth2redirect",
+            "com.example.app://oauth2redirect?code=1234",
+        ]:
+            self.assertEqual(sanitize_redirect(["myapp.com"], url, self.schemes), url)
+
+    def test_allowed_scheme_ignores_host_allowlist(self) -> None:
+        url = "com.example.app://not-a-real-host/path"
+        self.assertEqual(sanitize_redirect(["myapp.com"], url, self.schemes), url)
+
+    def test_scheme_not_in_allowlist(self) -> None:
+        for url in [
+            "com.other.app://oauth2redirect",
+            "javascript://myapp.com/%0Aalert(1)",
+            "ftp://myapp.com/path",
+        ]:
+            self.assertEqual(sanitize_redirect(["myapp.com"], url, self.schemes), None)
+
+    def test_web_urls_still_checked_against_hosts(self) -> None:
+        self.assertEqual(
+            sanitize_redirect(["myapp.com"], "http://myapp.com/path/", self.schemes),
+            "http://myapp.com/path/",
+        )
+        self.assertEqual(
+            sanitize_redirect(["myapp.com"], "http://notmyapp.com/path/", self.schemes),
+            None,
+        )
+
+    def test_relative_redirect_still_allowed(self) -> None:
+        self.assertEqual(
+            sanitize_redirect(["myapp.com"], "/path/", self.schemes), "/path/"
+        )
+
+    def test_evil_urls_still_rejected(self) -> None:
+        for url in ["///evil.com", "/\\evil.com", "/path/\n"]:
+            self.assertEqual(sanitize_redirect(["myapp.com"], url, self.schemes), None)
+
+    def test_restricting_schemes_blocks_web_urls(self) -> None:
+        self.assertEqual(
+            sanitize_redirect(
+                ["myapp.com"], "http://myapp.com/path/", ("com.example.app",)
+            ),
+            None,
+        )
+
+
+class IsUrlTest(unittest.TestCase):
+    def test_web_urls(self) -> None:
+        for value in ["http://myapp.com/", "https://myapp.com/", "/path/"]:
+            self.assertEqual(is_url(value), True)
+
+    def test_non_urls(self) -> None:
+        for value in [None, "LOGIN_REDIRECT_URL", "com.example.app://oauth2redirect"]:
+            self.assertEqual(is_url(value), False)
+
+    def test_allowed_private_use_scheme(self) -> None:
+        self.assertEqual(
+            is_url("com.example.app://oauth2redirect", {"com.example.app"}), True
+        )
+
+    def test_scheme_not_in_allowlist(self) -> None:
+        self.assertEqual(
+            is_url("com.other.app://oauth2redirect", {"com.example.app"}), False
+        )
+
+    def test_setting_names_are_not_urls(self) -> None:
+        self.assertEqual(is_url("LOGIN_REDIRECT_URL", {"com.example.app"}), False)
+
+    def test_malformed_web_scheme_not_promoted(self) -> None:
+        self.assertEqual(is_url("http:evil.example/path", {"http", "https"}), False)
 
 
 class UserIsAuthenticatedTest(unittest.TestCase):

--- a/social_core/utils.py
+++ b/social_core/utils.py
@@ -96,6 +96,11 @@ def setting_name(*names: str) -> str:
     return to_setting_name(*((SETTING_PREFIX, *names)))
 
 
+def normalize_redirect_schemes(schemes: Collection[str]) -> set[str]:
+    """URI schemes are case-insensitive, and urlparse lowercases them."""
+    return {scheme.lower() for scheme in schemes}
+
+
 def sanitize_redirect(
     hosts: list[str],
     redirect_to: str | Any,
@@ -123,7 +128,9 @@ def sanitize_redirect(
         return None
 
     schemes = (
-        DEFAULT_REDIRECT_SCHEMES if allowed_schemes is None else set(allowed_schemes)
+        set(DEFAULT_REDIRECT_SCHEMES)
+        if allowed_schemes is None
+        else normalize_redirect_schemes(allowed_schemes)
     )
 
     try:
@@ -431,13 +438,35 @@ def constant_time_compare(val1: str | bytes, val2: str | bytes) -> bool:
 
 
 def get_allowed_redirect_schemes(backend: BaseAuth) -> set[str]:
-    return {
-        scheme.lower()
-        for scheme in cast(
+    return normalize_redirect_schemes(
+        cast(
             "Collection[str]",
             backend.setting("ALLOWED_REDIRECT_SCHEMES", DEFAULT_REDIRECT_SCHEMES),
         )
-    }
+    )
+
+
+def is_private_use_redirect(
+    value: str | None, allowed_schemes: Collection[str] | None = None
+) -> bool:
+    """
+    Whether ``value`` uses a non-web scheme that has been explicitly allowed.
+
+    URI construction helpers such as ``build_absolute_uri`` only preserve http
+    and https, so callers must check this before turning a redirect candidate
+    into an absolute URI.
+    """
+    if not value or not isinstance(value, str) or not allowed_schemes:
+        return False
+    try:
+        scheme = urlparse(value).scheme
+    except ValueError:
+        return False
+    return (
+        bool(scheme)
+        and scheme not in DEFAULT_REDIRECT_SCHEMES
+        and scheme in normalize_redirect_schemes(allowed_schemes)
+    )
 
 
 def is_url(value: str | None, allowed_schemes: Collection[str] | None = None) -> bool:
@@ -445,14 +474,7 @@ def is_url(value: str | None, allowed_schemes: Collection[str] | None = None) ->
         return False
     if value.startswith(("http://", "https://", "/")):
         return True
-    if allowed_schemes is None:
-        return False
-    scheme = urlparse(value).scheme
-    return (
-        bool(scheme)
-        and scheme not in DEFAULT_REDIRECT_SCHEMES
-        and scheme in allowed_schemes
-    )
+    return is_private_use_redirect(value, allowed_schemes)
 
 
 def setting_url(backend: BaseAuth, *names: str | None) -> str | None:

--- a/social_core/utils.py
+++ b/social_core/utils.py
@@ -26,11 +26,15 @@ from .exceptions import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     from .backends.base import BaseAuth
     from .storage import PartialMixin, UserProtocol
     from .strategy import BaseStrategy, HttpResponseProtocol
 
 SETTING_PREFIX = "SOCIAL_AUTH"
+
+DEFAULT_REDIRECT_SCHEMES = ("http", "https")
 
 PARTIAL_TOKEN_SESSION_NAME = "partial_pipeline_token"
 PARTIAL_TOKEN_PENDING_SESSION_NAME = "partial_pipeline_pending_token"
@@ -92,12 +96,20 @@ def setting_name(*names: str) -> str:
     return to_setting_name(*((SETTING_PREFIX, *names)))
 
 
-def sanitize_redirect(hosts: list[str], redirect_to: str | Any) -> str | None:
+def sanitize_redirect(
+    hosts: list[str],
+    redirect_to: str | Any,
+    allowed_schemes: Collection[str] | None = None,
+) -> str | None:
     """
     Given a list of hostnames and an untrusted URL to redirect to,
     this method tests it to make sure it isn't garbage/harmful
     and returns it, else returns None, similar as how's it done
     on django.contrib.auth.views.
+
+    ``allowed_schemes`` defaults to http and https. Deployments that need to
+    hand control back to a native application can add a private-use URI scheme
+    (RFC 8252) through the ``ALLOWED_REDIRECT_SCHEMES`` setting.
     """
     # Avoid redirect on evil URLs like ///evil.com and URLs containing
     # backslashes or control characters that browsers may normalize.
@@ -110,20 +122,29 @@ def sanitize_redirect(hosts: list[str], redirect_to: str | Any) -> str | None:
     ):
         return None
 
+    schemes = (
+        DEFAULT_REDIRECT_SCHEMES if allowed_schemes is None else set(allowed_schemes)
+    )
+
     try:
         parsed_url = urlparse(redirect_to)
-        if parsed_url.scheme and parsed_url.scheme not in {"http", "https"}:
-            return None
-        if parsed_url.scheme and not parsed_url.netloc:
-            return None
+        scheme = parsed_url.scheme
+        if scheme:
+            if scheme not in schemes:
+                return None
+            if scheme not in DEFAULT_REDIRECT_SCHEMES:
+                # A private-use URI scheme is registered by a single native
+                # application, so the scheme itself is the trust boundary and
+                # the host allowlist does not apply.
+                return redirect_to
+            if not parsed_url.netloc:
+                return None
         # Don't redirect to a host that's not in the list
         netloc = parsed_url.netloc or hosts[0]
     except (IndexError, TypeError, AttributeError, ValueError):
         return None
 
-    if netloc in hosts:
-        return redirect_to
-    return None
+    return redirect_to if netloc in hosts else None
 
 
 def user_is_authenticated(user: UserProtocol | None) -> bool:
@@ -409,19 +430,41 @@ def constant_time_compare(val1: str | bytes, val2: str | bytes) -> bool:
     return hmac.compare_digest(val1, val2)
 
 
-def is_url(value: str | None) -> bool:
-    return value is not None and value.startswith(("http://", "https://", "/"))
+def get_allowed_redirect_schemes(backend: BaseAuth) -> set[str]:
+    return {
+        scheme.lower()
+        for scheme in cast(
+            "Collection[str]",
+            backend.setting("ALLOWED_REDIRECT_SCHEMES", DEFAULT_REDIRECT_SCHEMES),
+        )
+    }
+
+
+def is_url(value: str | None, allowed_schemes: Collection[str] | None = None) -> bool:
+    if value is None:
+        return False
+    if value.startswith(("http://", "https://", "/")):
+        return True
+    if allowed_schemes is None:
+        return False
+    scheme = urlparse(value).scheme
+    return (
+        bool(scheme)
+        and scheme not in DEFAULT_REDIRECT_SCHEMES
+        and scheme in allowed_schemes
+    )
 
 
 def setting_url(backend: BaseAuth, *names: str | None) -> str | None:
+    allowed_schemes = get_allowed_redirect_schemes(backend)
     for name in names:
         # Name can actually None, value or setting name
         if not name:
             continue
-        if is_url(name):
+        if is_url(name, allowed_schemes):
             return name
         value = backend.setting(name)
-        if is_url(value):
+        if is_url(value, allowed_schemes):
             return value
     return None
 


### PR DESCRIPTION
Closes #1892.

## Problem

There is no supported way to redirect to a private-use URI scheme ([RFC 8252 §7.1](https://datatracker.ietf.org/doc/html/rfc8252#section-7.1)) at the end of the auth flow, which is how a native app receives an OAuth response. Two places reject them: `is_url()` (so `setting_url()` returns `None` and `do_complete()` raises) and `sanitize_redirect()` (which restricts schemes to http/https since 4.8.7).

## Approach

Adds an `ALLOWED_REDIRECT_SCHEMES` setting mirroring the existing `ALLOWED_REDIRECT_HOSTS`, defaulting to `("http", "https")`.

- `sanitize_redirect()` and `is_url()` take an optional `allowed_schemes` argument; omitted, behaviour is unchanged.
- `setting_url()` reads the setting from the backend and passes it down.
- The three `sanitize_redirect()` call sites in `actions.py` pass it through `get_allowed_redirect_schemes()`.

When a URL uses an explicitly allowlisted non-web scheme, the host allowlist is skipped — a private-use scheme is registered by a single native application, so the scheme itself is the trust boundary and `netloc` carries no meaning there. Web URLs are unaffected and still checked against `ALLOWED_REDIRECT_HOSTS`.

## Security

A deployment has to name a scheme before it is accepted, so the 4.8.7 hardening stays in force. Verified against `do_complete()`:

| `ALLOWED_REDIRECT_SCHEMES` | result for `com.example.app://oauth2redirect` |
| --- | --- |
| unset | `ValueError: By this point URL has to have been set` (unchanged) |
| `("http", "https", "com.example.app")` | redirects to the deep link |
| `("http", "https", "com.other.app")` | `ValueError` — the allowlist is not a blanket bypass |

The existing `test_invalid_non_web_scheme_redirect` passes untouched, which pins the default.

## Tests

Adds `SanitizeRedirectAllowedSchemesTest` and `IsUrlTest`: opted-in scheme accepted, non-allowlisted scheme rejected, `javascript:`/`ftp:` still rejected, host checks still applied to web URLs, evil URLs (`///evil.com`, backslash, control characters) still rejected, and restricting the setting can block web URLs too.

Full suite: 1134 passed locally (shopify/saml/google-onetap skipped — optional deps not installed).
