### PR TITLE
fix(oidc): preserve Ping validation on refresh

### DIFF
--- a/social_core/backends/ping.py
+++ b/social_core/backends/ping.py
@@ -38,11 +38,8 @@ class PingOpenIdConnect(OpenIdConnectAuth):
                 return key
         return None
 
-    def validate_and_return_id_token(self, id_token, access_token):
-        """
-        Validates the id_token according to the steps at
-        http://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation.
-        """
+    def decode_and_validate_id_token(self, id_token, access_token):
+        """Validate a Ping ID token's signature and self-contained claims."""
         client_id, _client_secret = self.get_key_and_secret()
 
         try:
@@ -77,7 +74,9 @@ class PingOpenIdConnect(OpenIdConnectAuth):
         except PyJWTError as error:
             raise AuthTokenError(self, "Invalid signature") from error
 
-        self.validate_claims(claims)
+        self.validate_authorized_party(claims, client_id)
+        if not self.validate_at_hash(claims, access_token, key):
+            raise AuthTokenError(self, "Invalid access token")
 
         return claims
 

--- a/social_core/tests/backends/test_ping.py
+++ b/social_core/tests/backends/test_ping.py
@@ -1,6 +1,8 @@
+import time
 from unittest.mock import patch
 
 import jwt
+from jwt import InvalidAudienceError
 
 from social_core.exceptions import AuthTokenError
 
@@ -24,3 +26,58 @@ class PingOpenIdConnectTest(BaseBackendTest):
             self.backend.validate_and_return_id_token("token", "access-token")
 
         self.assertIsInstance(context.exception.__cause__, jwt.PyJWTError)
+
+    def test_refresh_uses_ping_id_token_decoder(self) -> None:
+        with (
+            patch.object(
+                self.backend,
+                "find_valid_key",
+                return_value={"alg": "RS256"},
+            ),
+            patch.object(
+                self.backend,
+                "id_token_issuer",
+                return_value="https://issuer.example",
+            ),
+            patch("social_core.backends.ping.jwt.PyJWK"),
+            patch(
+                "social_core.backends.ping.jwt.decode",
+                side_effect=InvalidAudienceError,
+            ),
+            self.assertRaises(AuthTokenError) as context,
+        ):
+            self.backend.validate_and_return_refresh_id_token(
+                "token",
+                "access-token",
+            )
+
+        self.assertEqual(context.exception.args, ("Invalid audience",))
+
+    def test_refresh_retains_common_id_token_validation(self) -> None:
+        claims = {
+            "aud": "key",
+            "azp": "key",
+            "at_hash": "invalid",
+            "iat": int(time.time()),
+        }
+        with (
+            patch.object(
+                self.backend,
+                "find_valid_key",
+                return_value={"alg": "RS256"},
+            ),
+            patch.object(
+                self.backend,
+                "id_token_issuer",
+                return_value="https://issuer.example",
+            ),
+            patch("social_core.backends.ping.jwt.PyJWK"),
+            patch("social_core.backends.ping.jwt.decode", return_value=claims),
+            self.assertRaises(AuthTokenError) as context,
+        ):
+            self.backend.validate_and_return_refresh_id_token(
+                "token",
+                "access-token",
+            )
+
+        self.assertEqual(context.exception.args, ("Invalid access token",))


### PR DESCRIPTION
Route Ping's provider-specific ID token decoding through the shared hook so refreshed tokens cannot bypass it. Retain the common authorized-party and access-token hash checks.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
