### PR TITLE
fix(coinbase): modernize OAuth integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - OpenID Connect backends now validate ID tokens returned during token refresh
   and reject changes to the authenticated identity.
 
+### Fixed
+
+- Updated the Coinbase backend to use current OAuth endpoints, scopes, API
+  versioning, and token revocation parameters.
+- HTTP 403 responses from authentication providers now raise `AuthForbidden`.
+
 ## [5.0.2](https://github.com/python-social-auth/social-core/releases/tag/5.0.2) - 2026-06-26
 
 ### Security

--- a/social_core/backends/coinbase.py
+++ b/social_core/backends/coinbase.py
@@ -3,18 +3,21 @@ Coinbase OAuth2 backend, docs at:
     https://python-social-auth.readthedocs.io/en/latest/backends/coinbase.html
 """
 
-from typing import Any
+from typing import Any, cast
 
 from .oauth import BaseOAuth2
+
+API_VERSION = "2022-01-06"
 
 
 class CoinbaseOAuth2(BaseOAuth2):
     name = "coinbase"
-    SCOPE_SEPARATOR = "+"
-    DEFAULT_SCOPE = ["user", "balance"]
-    AUTHORIZATION_URL = "https://www.coinbase.com/oauth/authorize"
-    ACCESS_TOKEN_URL = "https://api.coinbase.com/oauth/token"
-    REVOKE_TOKEN_URL = "https://api.coinbase.com/oauth/revoke"
+    SCOPE_SEPARATOR = ","
+    DEFAULT_SCOPE = ["wallet:user:read"]
+    AUTHORIZATION_URL = "https://login.coinbase.com/oauth2/auth"
+    ACCESS_TOKEN_URL = "https://login.coinbase.com/oauth2/token"
+    REVOKE_TOKEN_URL = "https://login.coinbase.com/oauth2/revoke"
+    USER_DATA_URL = "https://api.coinbase.com/v2/user"
     REDIRECT_STATE = False
 
     def get_user_id(self, details, response):
@@ -38,6 +41,28 @@ class CoinbaseOAuth2(BaseOAuth2):
     def user_data(self, access_token: str, *args, **kwargs) -> dict[str, Any] | None:
         """Loads user data from service"""
         return self.get_json(
-            "https://api.coinbase.com/v2/user",
-            headers={"Authorization": f"Bearer {access_token}"},
+            self.USER_DATA_URL,
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "CB-VERSION": cast("str", self.setting("API_VERSION", API_VERSION)),
+            },
         )
+
+    def revoke_token_params(self, token, uid) -> dict[str, str]:
+        client_id, client_secret = self.get_key_and_secret()
+        return {
+            "token": token,
+            "client_id": client_id,
+            "client_secret": client_secret,
+        }
+
+    def revoke_token(self, token, uid):
+        if revoke_token_url := self.revoke_token_url(token, uid):
+            response = self.request(
+                revoke_token_url,
+                headers=self.revoke_token_headers(token, uid),
+                data=self.revoke_token_params(token, uid),
+                method=self.REVOKE_TOKEN_METHOD,
+            )
+            return self.process_revoke_token_response(response)
+        return None

--- a/social_core/tests/backends/test_coinbase.py
+++ b/social_core/tests/backends/test_coinbase.py
@@ -1,5 +1,10 @@
 import json
 
+import responses
+
+from social_core.backends.coinbase import API_VERSION
+from social_core.utils import get_querystring, parse_qs
+
 from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
@@ -29,3 +34,96 @@ class CoinbaseOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
 
     def test_partial_pipeline(self) -> None:
         self.do_partial_pipeline()
+
+    def test_current_oauth_configuration(self) -> None:
+        self.assertEqual(
+            self.backend.authorization_url(),
+            "https://login.coinbase.com/oauth2/auth",
+        )
+        self.assertEqual(
+            self.backend.access_token_url(),
+            "https://login.coinbase.com/oauth2/token",
+        )
+        self.assertEqual(
+            self.backend.revoke_token_url("token", "uid"),
+            "https://login.coinbase.com/oauth2/revoke",
+        )
+        self.assertEqual(
+            get_querystring(self.backend.auth_url())["scope"], "wallet:user:read"
+        )
+
+    def test_configured_scopes_use_commas_and_include_default(self) -> None:
+        self.strategy.set_settings(
+            {
+                "SOCIAL_AUTH_COINBASE_SCOPE": [
+                    "wallet:accounts:read",
+                    "wallet:user:email",
+                ]
+            }
+        )
+
+        scope = get_querystring(self.backend.auth_url())["scope"]
+
+        self.assertEqual(
+            scope,
+            "wallet:accounts:read,wallet:user:email,wallet:user:read",
+        )
+
+    def test_default_scope_can_be_ignored(self) -> None:
+        self.strategy.set_settings(
+            {
+                "SOCIAL_AUTH_COINBASE_SCOPE": ["wallet:user:email"],
+                "SOCIAL_AUTH_COINBASE_IGNORE_DEFAULT_SCOPE": True,
+            }
+        )
+
+        self.assertEqual(
+            get_querystring(self.backend.auth_url())["scope"], "wallet:user:email"
+        )
+
+    def test_user_data_sends_api_version(self) -> None:
+        responses.add(
+            responses.GET,
+            self.backend.USER_DATA_URL,
+            body=self.user_data_body,
+            content_type="application/json",
+        )
+
+        self.backend.user_data("foobar")
+
+        request = responses.calls[-1].request
+        self.assertEqual(request.headers["Authorization"], "Bearer foobar")
+        self.assertEqual(request.headers["CB-VERSION"], API_VERSION)
+
+    def test_user_data_api_version_can_be_overridden(self) -> None:
+        self.strategy.set_settings({"SOCIAL_AUTH_COINBASE_API_VERSION": "2026-01-01"})
+        responses.add(
+            responses.GET,
+            self.backend.USER_DATA_URL,
+            body=self.user_data_body,
+            content_type="application/json",
+        )
+
+        self.backend.user_data("foobar")
+
+        self.assertEqual(
+            responses.calls[-1].request.headers["CB-VERSION"], "2026-01-01"
+        )
+
+    def test_revoke_token_sends_required_parameters_in_body(self) -> None:
+        responses.add(responses.POST, self.backend.REVOKE_TOKEN_URL, status=200)
+
+        revoked = self.backend.revoke_token("foobar", "uid")
+
+        request = responses.calls[-1].request
+        request_data = parse_qs(request.body)
+        self.assertTrue(revoked)
+        self.assertEqual(request.url, self.backend.REVOKE_TOKEN_URL)
+        self.assertEqual(
+            request_data,
+            {
+                "token": "foobar",
+                "client_id": "a-key",
+                "client_secret": "a-secret-key",
+            },
+        )

--- a/social_core/tests/test_utils.py
+++ b/social_core/tests/test_utils.py
@@ -3,7 +3,10 @@ import unittest
 from typing import TYPE_CHECKING, cast
 from unittest.mock import Mock, patch
 
+import requests
+
 from social_core.backends.base import BaseAuth
+from social_core.exceptions import AuthForbidden
 from social_core.pipeline.utils import partial_prepare
 from social_core.utils import (
     PARTIAL_PIPELINE_ALLOW_EXTERNAL_RESUME,
@@ -12,6 +15,7 @@ from social_core.utils import (
     PARTIAL_TOKEN_PENDING_SESSION_NAME,
     PARTIAL_TOKEN_SESSION_NAME,
     build_absolute_uri,
+    handle_http_errors,
     is_url,
     partial_pipeline_data,
     partial_pipeline_result,
@@ -731,6 +735,25 @@ class GetKeyAndSecretBasicAuthTest(unittest.TestCase):
             expected = b"Basic " + base64.b64encode(b"test_key:test_secret")
             self.assertEqual(result, expected)
             self.assertIsInstance(result, bytes)
+
+
+class HandleHttpErrorsTest(unittest.TestCase):
+    def test_unauthorized_and_forbidden_raise_auth_forbidden(self) -> None:
+        backend = BaseAuth(TestStrategy(TestStorage))
+
+        @handle_http_errors
+        def fail(_backend, error):
+            raise error
+
+        for status_code in (401, 403):
+            with self.subTest(status_code=status_code):
+                response = Mock(status_code=status_code, text="Access denied")
+                error = requests.HTTPError(response=response)
+
+                with self.assertRaises(AuthForbidden) as context:
+                    fail(backend, error)
+
+                self.assertIs(context.exception.__cause__, error)
 
 
 class IdKeyConfigurabilityTest(unittest.TestCase):

--- a/social_core/utils.py
+++ b/social_core/utils.py
@@ -505,7 +505,7 @@ def handle_http_errors(func):
 
             if err.response.status_code == 400:
                 raise AuthCanceled(args[0], response=err.response) from err
-            if err.response.status_code == 401:
+            if err.response.status_code in (401, 403):
                 raise AuthForbidden(args[0]) from err
             if err.response.status_code == 503:
                 raise AuthUnreachableProvider(args[0]) from err


### PR DESCRIPTION
Coinbase's legacy OAuth contract and unversioned user requests can cause otherwise valid logins to fail with 403 responses. Adopt the current endpoints, scopes, version header, and revocation parameters, and treat provider 403s as authentication failures.

Closes #1036

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
