### PR TITLE
fix(coinbase): preserve default email access

### DIFF
--- a/social_core/backends/coinbase.py
+++ b/social_core/backends/coinbase.py
@@ -13,7 +13,7 @@ API_VERSION = "2022-01-06"
 class CoinbaseOAuth2(BaseOAuth2):
     name = "coinbase"
     SCOPE_SEPARATOR = ","
-    DEFAULT_SCOPE = ["wallet:user:read"]
+    DEFAULT_SCOPE = ["wallet:user:read", "wallet:user:email"]
     AUTHORIZATION_URL = "https://login.coinbase.com/oauth2/auth"
     ACCESS_TOKEN_URL = "https://login.coinbase.com/oauth2/token"
     REVOKE_TOKEN_URL = "https://login.coinbase.com/oauth2/revoke"

--- a/social_core/tests/backends/test_coinbase.py
+++ b/social_core/tests/backends/test_coinbase.py
@@ -49,7 +49,8 @@ class CoinbaseOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
             "https://login.coinbase.com/oauth2/revoke",
         )
         self.assertEqual(
-            get_querystring(self.backend.auth_url())["scope"], "wallet:user:read"
+            get_querystring(self.backend.auth_url())["scope"],
+            "wallet:user:read,wallet:user:email",
         )
 
     def test_configured_scopes_use_commas_and_include_default(self) -> None:
@@ -57,7 +58,7 @@ class CoinbaseOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
             {
                 "SOCIAL_AUTH_COINBASE_SCOPE": [
                     "wallet:accounts:read",
-                    "wallet:user:email",
+                    "wallet:addresses:read",
                 ]
             }
         )
@@ -66,7 +67,8 @@ class CoinbaseOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
 
         self.assertEqual(
             scope,
-            "wallet:accounts:read,wallet:user:email,wallet:user:read",
+            "wallet:accounts:read,wallet:addresses:read,"
+            "wallet:user:read,wallet:user:email",
         )
 
     def test_default_scope_can_be_ignored(self) -> None:
@@ -127,3 +129,9 @@ class CoinbaseOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
                 "client_secret": "a-secret-key",
             },
         )
+
+    def test_revoke_token_can_be_disabled(self) -> None:
+        self.strategy.set_settings({"SOCIAL_AUTH_COINBASE_REVOKE_TOKEN_URL": ""})
+
+        self.assertIsNone(self.backend.revoke_token("foobar", "uid"))
+        self.assertEqual(len(responses.calls), 0)


### PR DESCRIPTION
Coinbase protects email behind a separate scope, so request it by default to retain compatibility with email-dependent pipelines. Cover disabled token revocation while updating the scope tests.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
