### PR TITLE
fix(backends): request required Auth0 OIDC scopes

### DIFF
--- a/social_core/backends/auth0.py
+++ b/social_core/backends/auth0.py
@@ -14,6 +14,7 @@ class Auth0OAuth2(BaseOAuth2):
     """Auth0 OAuth authentication backend"""
 
     name = "auth0"
+    DEFAULT_SCOPE = ["openid", "profile", "email"]
     SCOPE_SEPARATOR = " "
     EXTRA_DATA = [("picture", "picture")]
 
@@ -34,6 +35,8 @@ class Auth0OAuth2(BaseOAuth2):
     def get_user_details(self, response):
         # Obtain JWT and the keys to validate the signature
         id_token = response.get("id_token")
+        if id_token is None:
+            raise AuthTokenError(self, "Missing id_token in Auth0 token response")
         jwks = self.get_json(self.api_path(".well-known/jwks.json"))
         issuer = self.api_path()
         audience = self.setting("KEY")  # CLIENT_ID

--- a/social_core/tests/backends/test_auth0.py
+++ b/social_core/tests/backends/test_auth0.py
@@ -5,6 +5,7 @@ import jwt
 import responses
 
 from social_core.exceptions import AuthTokenError
+from social_core.utils import get_querystring
 
 from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
@@ -75,6 +76,32 @@ class Auth0OAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
 
     def test_login(self) -> None:
         self.do_login()
+
+    def test_default_scope(self) -> None:
+        self.assertEqual(
+            get_querystring(self.backend.auth_url())["scope"],
+            "openid profile email",
+        )
+
+    def test_custom_scope_is_combined_with_default_scope(self) -> None:
+        self.strategy.set_settings({"SOCIAL_AUTH_AUTH0_SCOPE": ["custom"]})
+
+        self.assertEqual(
+            get_querystring(self.backend.auth_url())["scope"],
+            "custom openid profile email",
+        )
+
+    def test_missing_id_token_raises_auth_token_error(self) -> None:
+        with (
+            patch.object(self.backend, "get_json") as get_json,
+            self.assertRaisesRegex(
+                AuthTokenError,
+                "Token error: Missing id_token in Auth0 token response",
+            ),
+        ):
+            self.backend.get_user_details({})
+
+        get_json.assert_not_called()
 
     def test_invalid_signature_raises_auth_token_error(self) -> None:
         assert self.access_token_body is not None


### PR DESCRIPTION
Auth0 only returns an ID token when the openid scope is requested, while the legacy backend requires that token for user details. Request the standard identity scopes by default and report a clear error when the token is absent.

Closes #901

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
