### PR TITLE
Stop sending access_token as a refresh_token

### DIFF
--- a/social_core/backends/paypal.py
+++ b/social_core/backends/paypal.py
@@ -19,6 +19,7 @@ class PayPalOAuth2(BaseOAuth2):
     DEFAULT_SCOPE = ["openid", "profile"]
     REFRESH_TOKEN_METHOD = "POST"
     REDIRECT_STATE = False
+    EXTRA_DATA = [("refresh_token", "refresh_token")]
 
     def user_data(self, access_token: str, *args, **kwargs) -> dict[str, Any] | None:
         auth_header = {"Authorization": f"Bearer {access_token}"}

--- a/social_core/backends/zoom.py
+++ b/social_core/backends/zoom.py
@@ -16,7 +16,10 @@ class ZoomOAuth2(BaseOAuth2):
     DEFAULT_SCOPE = ["user:read"]
     REFRESH_TOKEN_METHOD = "POST"
     REDIRECT_STATE = False
-    EXTRA_DATA = [("expires_in", "expires_in")]
+    EXTRA_DATA = [
+        ("expires_in", "expires_in"),
+        ("refresh_token", "refresh_token"),
+    ]
 
     def user_data(self, access_token: str, *args, **kwargs) -> dict[str, Any] | None:
         return self.get_json(

--- a/social_core/storage.py
+++ b/social_core/storage.py
@@ -67,9 +67,11 @@ class UserMixin:
         return self.extra_data.get("access_token")
 
     def refresh_token(self, strategy: BaseStrategy, *args, **kwargs) -> None:
-        token = self.extra_data.get("refresh_token") or self.extra_data.get(
-            "access_token"
-        )
+        # A refresh_token is only sent by some providers, and only for some
+        # grant types (RFC 6749 section 4.1.4). Falling back to access_token
+        # here would send it to the token endpoint as a refresh_token, which
+        # the authorization server correctly rejects.
+        token = self.extra_data.get("refresh_token")
         backend = self.get_backend_instance(strategy)
         refresh_token = getattr(backend, "refresh_token", None) if backend else None
         if token and callable(refresh_token):

--- a/social_core/tests/backends/test_azuread.py
+++ b/social_core/tests/backends/test_azuread.py
@@ -131,6 +131,7 @@ class AzureADOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
         return json.dumps(
             {
                 "access_token": "foobar",
+                "refresh_token": "foobar-refresh-token",
                 "token_type": "bearer",
                 "id_token": self.build_id_token(**id_token_overrides),
                 "expires_in": self.EXPIRES_IN,

--- a/social_core/tests/backends/test_azuread_b2c.py
+++ b/social_core/tests/backends/test_azuread_b2c.py
@@ -137,6 +137,7 @@ class AzureADB2COAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     ) -> str:
         body = {
             "token_type": "bearer",
+            "refresh_token": "foobar-refresh-token",
             "id_token": id_token or self.build_id_token(**overrides),
             "expires_in": self.EXPIRES_IN,
             "expires_on": self.EXPIRES_ON,

--- a/social_core/tests/test_storage.py
+++ b/social_core/tests/test_storage.py
@@ -1,5 +1,6 @@
 import unittest
 from typing import cast
+from unittest.mock import MagicMock
 
 from social_core.storage import (
     AssociationMixin,
@@ -79,6 +80,44 @@ class BrokenUserTests(unittest.TestCase):
     def test_disconnect(self) -> None:
         with self.assertRaisesRegex(NotImplementedError, NOT_IMPLEMENTED_MSG):
             self.user.disconnect(BrokenUser())
+
+
+class UserMixinRefreshTokenTests(unittest.TestCase):
+    def _make_user(self, extra_data: dict) -> BrokenUser:
+        user = BrokenUser()
+        user.extra_data = extra_data
+        user.user = User("foobar")
+        user.uid = "1"
+        return user
+
+    def _make_strategy(self, backend: MagicMock) -> MagicMock:
+        strategy = MagicMock(spec=BrokenStrategy)
+        strategy.get_backend.return_value = backend
+        return strategy
+
+    def test_does_not_send_access_token_as_refresh_token(self) -> None:
+        # No refresh_token was ever issued: refresh_token() must not send
+        # the access_token to the provider in its place.
+        user = self._make_user({"access_token": "the-access-token"})
+        backend = MagicMock()
+        strategy = self._make_strategy(backend)
+
+        user.refresh_token(cast("BaseStrategy", strategy))
+
+        backend.refresh_token.assert_not_called()
+
+    def test_sends_the_actual_refresh_token(self) -> None:
+        user = self._make_user(
+            {"access_token": "the-access-token", "refresh_token": "the-refresh-token"}
+        )
+        backend = MagicMock()
+        backend.refresh_token.return_value = {"access_token": "new-token"}
+        backend.extra_data.return_value = {"access_token": "new-token"}
+        strategy = self._make_strategy(backend)
+
+        user.refresh_token(cast("BaseStrategy", strategy))
+
+        backend.refresh_token.assert_called_once_with("the-refresh-token")
 
 
 class BrokenAssociationTests(unittest.TestCase):


### PR DESCRIPTION
Fixes #826.

refresh_token() fell back to access_token when no refresh_token was stored, sending it to the token endpoint as if it were one. A refresh_token is optional per RFC 6749 4.1.4, and providers reject a request carrying the wrong kind of token. This always failed with a 401 instead of doing nothing.

Removed the fallback. This also exposed that Zoom and PayPal never actually saved a real refresh_token in the first place, since it wasn't listed in their EXTRA_DATA. Refresh never had a chance to work for those two even with a correct fallback removed. Added it there.

The AzureAD and AzureADB2C tests build their own mocked login response and it didn't include a refresh_token. Their test_refresh_token tests broke once the fallback was gone. Updated those fixtures to match what the providers actually return.

Added tests for the fixed fallback in test_storage.py. Ran the full test suite (1152 passed, 176 skipped, 8 xfailed) and ruff.