### PR TITLE
fix(backends): honor configurable user ID keys

### DIFF
--- a/social_core/backends/auth0.py
+++ b/social_core/backends/auth0.py
@@ -14,6 +14,7 @@ class Auth0OAuth2(BaseOAuth2):
     """Auth0 OAuth authentication backend"""
 
     name = "auth0"
+    ID_KEY = "user_id"
     DEFAULT_SCOPE = ["openid", "profile", "email"]
     SCOPE_SEPARATOR = " "
     EXTRA_DATA = [("picture", "picture")]
@@ -30,7 +31,7 @@ class Auth0OAuth2(BaseOAuth2):
 
     def get_user_id(self, details, response):
         """Return current user id."""
-        return details["user_id"]
+        return self.get_user_id_from_sources(details)
 
     def get_user_details(self, response):
         # Obtain JWT and the keys to validate the signature
@@ -72,7 +73,7 @@ class Auth0OAuth2(BaseOAuth2):
             raise AuthTokenError(self, signature_error) from signature_error
 
         fullname, first_name, last_name = self.get_user_names(payload["name"])
-        return {
+        details = {
             "username": payload["nickname"],
             "email": payload["email"],
             "email_verified": payload.get("email_verified", False),
@@ -82,3 +83,10 @@ class Auth0OAuth2(BaseOAuth2):
             "picture": payload["picture"],
             "user_id": payload["sub"],
         }
+        id_key = self.id_key()
+        if id_key not in details:
+            user_id = payload.get(id_key)
+            if user_id is None:
+                raise AuthTokenError(self, f"Missing configured user ID claim {id_key}")
+            details[id_key] = user_id
+        return details

--- a/social_core/backends/auth0_openidconnect.py
+++ b/social_core/backends/auth0_openidconnect.py
@@ -51,9 +51,15 @@ class Auth0OpenIdConnectAuth(OpenIdConnectAuth):
 
     def get_user_id(self, details, response):
         """Return current user id."""
-        if self.id_token is not None and self.id_token.get("sub") is not None:
-            return self.id_token["sub"]
-        return details["user_id"]
+        id_key = self.id_key()
+        if id_key == "sub":
+            normalized_details = {"sub": details.get("user_id")}
+            return self.get_user_id_from_sources(
+                self.id_token,
+                normalized_details,
+                id_key=id_key,
+            )
+        return self.get_user_id_from_sources(details, response, self.id_token)
 
     def get_user_details(self, response):
         """Extract user details from Auth0 response"""

--- a/social_core/backends/azuread.py
+++ b/social_core/backends/azuread.py
@@ -44,6 +44,7 @@ from .oauth import BaseOAuth2
 
 class AzureADOAuth2(BaseOAuth2):
     name = "azuread-oauth2"
+    ID_KEY = "upn"
     SCOPE_SEPARATOR = " "
     BASE_URL = "https://{authority_host}/{tenant_id}"
     AUTHORIZATION_URL = "{base_url}/oauth2/authorize"
@@ -122,10 +123,7 @@ class AzureADOAuth2(BaseOAuth2):
 
     def get_user_id(self, details, response):
         """Use upn as unique id"""
-        upn = response.get("upn")
-        if upn is None:
-            raise AuthMissingParameter(self, "upn")
-        return upn
+        return self.get_user_id_from_sources(details, response)
 
     def get_user_details(self, response):
         """Return user details from Azure AD account"""

--- a/social_core/backends/azuread_b2c.py
+++ b/social_core/backends/azuread_b2c.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
 
 class AzureADB2COAuth2(AzureADOAuth2):
     name = "azuread-b2c-oauth2"
+    ID_KEY = "sub"
 
     BASE_URL = "https://{authority_host}/{tenant_name}.onmicrosoft.com"
     AUTHORIZATION_URL = "{base_url}/oauth2/v2.0/authorize"
@@ -137,10 +138,6 @@ class AzureADB2COAuth2(AzureADOAuth2):
         extra_arguments = super().auth_extra_arguments()
         extra_arguments["p"] = self.policy
         return extra_arguments
-
-    def get_user_id(self, details, response):
-        """Use subject (sub) claim as unique id."""
-        return response.get("sub")
 
     def get_user_details(self, response):
         """

--- a/social_core/backends/azuread_tenant.py
+++ b/social_core/backends/azuread_tenant.py
@@ -42,6 +42,7 @@ from .azuread import AzureADOAuth2
 
 class AzureADTenantOAuth2(AzureADOAuth2):
     name = "azuread-tenant-oauth2"
+    ID_KEY = "sub"
     OPENID_CONFIGURATION_URL = "{base_url}/.well-known/openid-configuration{appid}"
     JWKS_URL = "{base_url}/discovery/keys{appid}"
 
@@ -61,10 +62,6 @@ class AzureADTenantOAuth2(AzureADOAuth2):
         return (
             f"?appid={self.setting('KEY')}" if self.setting("KEY") is not None else ""
         )
-
-    def get_user_id(self, details, response):
-        """Use subject (sub) claim as unique id."""
-        return response.get("sub")
 
     def get_id_token_issuer(self, claims: dict[str, Any]) -> str:
         self.validate_configured_tenant(claims)
@@ -92,15 +89,12 @@ class AzureADTenantOAuth2(AzureADOAuth2):
 
 class AzureADV2TenantOAuth2(AzureADTenantOAuth2):
     name = "azuread-v2-tenant-oauth2"
+    ID_KEY = "preferred_username"
     OPENID_CONFIGURATION_URL = "{base_url}/v2.0/.well-known/openid-configuration{appid}"
     AUTHORIZATION_URL = "{base_url}/oauth2/v2.0/authorize"
     ACCESS_TOKEN_URL = "{base_url}/oauth2/v2.0/token"
     JWKS_URL = "{base_url}/discovery/v2.0/keys{appid}"
     DEFAULT_SCOPE = ["openid", "profile", "offline_access"]
-
-    def get_user_id(self, details, response):
-        """Use upn as unique id"""
-        return response.get("preferred_username")
 
     def get_user_details(self, response):
         """Return user details from Azure AD account"""

--- a/social_core/backends/base.py
+++ b/social_core/backends/base.py
@@ -6,7 +6,11 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 
 import requests
 
-from social_core.exceptions import AuthConnectionError, AuthUnknownError
+from social_core.exceptions import (
+    AuthConnectionError,
+    AuthMissingParameter,
+    AuthUnknownError,
+)
 from social_core.registry import REGISTRY
 from social_core.utils import module_member, parse_qs, social_logger, user_agent
 
@@ -30,6 +34,7 @@ class BaseAuth:
     EXTRA_DATA: list[str | tuple[str, str] | tuple[str, str, bool]] | None = None
     GET_ALL_EXTRA_DATA = False
     REQUIRES_EMAIL_VALIDATION = False
+    REQUIRES_USER_ID: bool = False
     SEND_USER_AGENT = True
 
     def __init__(
@@ -229,11 +234,32 @@ class BaseAuth:
         """Return a unique ID for the current user, by default from server
         response or details."""
         id_key = self.id_key()
+        if self.REQUIRES_USER_ID or self.setting("ID_KEY"):
+            return self.get_user_id_from_sources(details, response, id_key=id_key)
         if details:
             user_id = details.get(id_key)
             if user_id:
                 return user_id
         return response.get(id_key)
+
+    def get_user_id_from_sources(
+        self,
+        *sources: Mapping[str, Any] | None,
+        id_key: str | None = None,
+    ):
+        """Return the selected user ID from mappings or fail clearly.
+
+        Sources are searched in order for the configured or explicitly passed
+        ID key. Missing, ``None``, and empty-string values are rejected.
+        """
+        if id_key is None:
+            id_key = self.id_key()
+        for source in sources:
+            if source is not None:
+                user_id = source.get(id_key)
+                if user_id is not None and user_id != "":
+                    return user_id
+        raise AuthMissingParameter(self, id_key)
 
     def get_user_details(self, response) -> dict[str, Any]:
         """Return user details in a known internal structure.

--- a/social_core/backends/behance.py
+++ b/social_core/backends/behance.py
@@ -21,7 +21,7 @@ class BehanceOAuth2(BaseOAuth2):
     REDIRECT_STATE = False
 
     def get_user_id(self, details, response):
-        return response["user"]["id"]
+        return self.get_user_id_from_sources(response.get("user"), details)
 
     def get_user_details(self, response):
         """Return user details from Behance account"""

--- a/social_core/backends/bitbucket.py
+++ b/social_core/backends/bitbucket.py
@@ -28,9 +28,9 @@ class BitbucketOAuth2(BaseOAuth2):
 
     def get_user_id(self, details, response):
         id_key = self.id_key()
-        if self.setting("USERNAME_AS_ID", False):
+        if not self.setting("ID_KEY") and self.setting("USERNAME_AS_ID", False):
             id_key = "username"
-        return response.get(id_key)
+        return self.get_user_id_from_sources(response, details, id_key=id_key)
 
     def get_user_details(self, response):
         """Return user details from Bitbucket account"""

--- a/social_core/backends/cas.py
+++ b/social_core/backends/cas.py
@@ -30,6 +30,7 @@ class CASOpenIdConnectAuth(OpenIdConnectAuth):
     """
 
     name = "cas"
+    ID_KEY = "username"
     STATE_PARAMETER = True
 
     def oidc_endpoint(self):
@@ -39,7 +40,7 @@ class CASOpenIdConnectAuth(OpenIdConnectAuth):
 
     def get_user_id(self, details, response):
         self.log_debug("method: get_user_id, details: %s, %s", details, response)
-        return details.get("username")
+        return super().get_user_id(details, response)
 
     def user_data(self, access_token: str, *args, **kwargs) -> dict[str, Any] | None:
         data = self.get_json(

--- a/social_core/backends/cilogon.py
+++ b/social_core/backends/cilogon.py
@@ -11,6 +11,7 @@ class CILogonOAuth2(BaseOAuth2):
     """
 
     name = "cilogon-oauth2"
+    ID_KEY = "sub"
     AUTHORIZATION_URL = "https://cilogon.org/authorize"
     ACCESS_TOKEN_URL = "https://cilogon.org/oauth2/token"
     DEFAULT_SCOPE = ["openid", "email", "profile", "org.cilogon.userinfo"]
@@ -30,7 +31,8 @@ class CILogonOAuth2(BaseOAuth2):
         """Return user unique id provided by service
         In this case it is a combination of the `sub`
         and `iss` respective values."""
-        return f"{response.get('sub', '')} {response.get('iss', '')}"
+        user_id = self.get_user_id_from_sources(response, details)
+        return f"{user_id} {response.get('iss', '')}"
 
     def get_user_details(self, response):
         """Return user details from CI Logon service"""

--- a/social_core/backends/classlink.py
+++ b/social_core/backends/classlink.py
@@ -11,15 +11,13 @@ class ClasslinkOAuth(BaseOAuth2):
     """
 
     name = "classlink"
+    ID_KEY = "UserId"
+    REQUIRES_USER_ID = True
     AUTHORIZATION_URL = "https://launchpad.classlink.com/oauth2/v2/auth"
     ACCESS_TOKEN_URL = "https://launchpad.classlink.com/oauth2/v2/token"
     DEFAULT_SCOPE = ["profile"]
     REDIRECT_STATE = False
     SCOPE_SEPARATOR = " "
-
-    def get_user_id(self, details, response):
-        """Return user unique id provided by service"""
-        return response["UserId"]
 
     def get_user_details(self, response):
         """Return user details from Classlink account"""

--- a/social_core/backends/clever.py
+++ b/social_core/backends/clever.py
@@ -19,7 +19,7 @@ class CleverOAuth2(BaseOAuth2):
 
     def get_user_id(self, details, response):
         """Return user unique id provided by service"""
-        return response.get("data", {}).get("id")
+        return self.get_user_id_from_sources(response.get("data"), details)
 
     def get_user_type(self, data):
         return next(iter(data.get("data", {}).get("roles", {}).keys()))

--- a/social_core/backends/coinbase.py
+++ b/social_core/backends/coinbase.py
@@ -21,7 +21,7 @@ class CoinbaseOAuth2(BaseOAuth2):
     REDIRECT_STATE = False
 
     def get_user_id(self, details, response):
-        return response["data"]["id"]
+        return self.get_user_id_from_sources(response.get("data"), details)
 
     def get_user_details(self, response):
         """Return user details from Coinbase account"""

--- a/social_core/backends/digitalocean.py
+++ b/social_core/backends/digitalocean.py
@@ -11,6 +11,7 @@ class DigitalOceanOAuth(BaseOAuth2):
     """
 
     name = "digitalocean"
+    ID_KEY = "uuid"
     AUTHORIZATION_URL = "https://cloud.digitalocean.com/v1/oauth/authorize"
     ACCESS_TOKEN_URL = "https://cloud.digitalocean.com/v1/oauth/token"
     SCOPE_SEPARATOR = " "
@@ -18,7 +19,7 @@ class DigitalOceanOAuth(BaseOAuth2):
 
     def get_user_id(self, details, response):
         """Return user unique id provided by service"""
-        return response["account"].get("uuid")
+        return self.get_user_id_from_sources(response.get("account"), details)
 
     def get_user_details(self, response):
         """Return user details from DigitalOcean account"""

--- a/social_core/backends/discourse.py
+++ b/social_core/backends/discourse.py
@@ -13,6 +13,8 @@ from .base import BaseAuth
 
 class DiscourseAuth(BaseAuth):
     name = "discourse"
+    ID_KEY = "email"
+    REQUIRES_USER_ID = True
     EXTRA_DATA = ["username", "name", "avatar_url"]
 
     def auth_url(self) -> str:
@@ -36,9 +38,6 @@ class DiscourseAuth(BaseAuth):
 
     def get_idp_url(self) -> str:
         return f"{self.setting('SERVER_URL')}/session/sso_provider"
-
-    def get_user_id(self, details, response):
-        return response["email"]
 
     def get_user_details(self, response):
         return {

--- a/social_core/backends/disqus.py
+++ b/social_core/backends/disqus.py
@@ -30,7 +30,9 @@ class DisqusOAuth2(BaseOAuth2):
     ]
 
     def get_user_id(self, details, response):
-        return response["response"]["id"]
+        return self.get_user_id_from_sources(
+            response.get("response"), details, response
+        )
 
     def get_user_details(self, response):
         """Return user details from Disqus account"""

--- a/social_core/backends/drip.py
+++ b/social_core/backends/drip.py
@@ -10,11 +10,15 @@ from .oauth import BaseOAuth2
 
 class DripOAuth(BaseOAuth2):
     name = "drip"
+    ID_KEY = "email"
     AUTHORIZATION_URL = "https://www.getdrip.com/oauth/authorize"
     ACCESS_TOKEN_URL = "https://www.getdrip.com/oauth/token"
 
     def get_user_id(self, details, response):
-        return details["email"]
+        id_key = self.id_key()
+        users = response.get("users")
+        user = users[0] if users else None
+        return self.get_user_id_from_sources(user, details, id_key=id_key)
 
     def get_user_details(self, response):
         return {

--- a/social_core/backends/flat.py
+++ b/social_core/backends/flat.py
@@ -12,12 +12,10 @@ class FlatOAuth2(BaseOAuth2):
     """Flat OAuth2"""
 
     name = "flat"
+    REQUIRES_USER_ID = True
     DEFAULT_SCOPE = ["account.public_profile"]
     AUTHORIZATION_URL = "https://flat.io/auth/oauth"
     ACCESS_TOKEN_URL = "https://api.flat.io/oauth/access_token"
-
-    def get_user_id(self, details, response):
-        return response.get("id")
 
     def get_user_details(self, response):
         """Return user details from Flat account"""

--- a/social_core/backends/foursquare.py
+++ b/social_core/backends/foursquare.py
@@ -15,7 +15,8 @@ class FoursquareOAuth2(BaseOAuth2):
     API_VERSION = "20140128"
 
     def get_user_id(self, details, response):
-        return response["response"]["user"]["id"]
+        data = response.get("response") or {}
+        return self.get_user_id_from_sources(data.get("user"), details)
 
     def get_user_details(self, response):
         """Return user details from Foursquare account"""

--- a/social_core/backends/goclio.py
+++ b/social_core/backends/goclio.py
@@ -37,4 +37,4 @@ class GoClioOAuth2(BaseOAuth2):
         )
 
     def get_user_id(self, details, response):
-        return response.get("user", {}).get("id")
+        return self.get_user_id_from_sources(response.get("user"), details)

--- a/social_core/backends/google.py
+++ b/social_core/backends/google.py
@@ -11,8 +11,12 @@ from .oauth import BaseOAuth1, BaseOAuth2
 
 
 class BaseGoogleAuth(BaseAuth):
+    ID_KEY = "email"
+
     def get_user_id(self, details, response):
         """Use google email as unique id"""
+        if self.setting("ID_KEY"):
+            return super().get_user_id(details, response)
         if self.setting("USE_UNIQUE_USER_ID", False):
             if "sub" in response:
                 return response["sub"]

--- a/social_core/backends/google_openidconnect.py
+++ b/social_core/backends/google_openidconnect.py
@@ -17,6 +17,8 @@ class GoogleOpenIdConnect(GoogleOAuth2, OpenIdConnectAuth):
     ID_TOKEN_ISSUER = "accounts.google.com"
 
     def get_user_id(self, details, response):
+        if self.setting("ID_KEY"):
+            return OpenIdConnectAuth.get_user_id(self, details, response)
         if self.setting("USE_UNIQUE_USER_ID", False) and self.id_token is not None:
             return self.id_token.get("sub")
         return super().get_user_id(details, response)

--- a/social_core/backends/instagram.py
+++ b/social_core/backends/instagram.py
@@ -14,8 +14,7 @@ class InstagramOAuth2(BaseOAuth2):
     ACCESS_TOKEN_URL = "https://api.instagram.com/oauth/access_token"
 
     def get_user_id(self, details, response):
-        user = response.get("user") or {}
-        return user.get("id")
+        return self.get_user_id_from_sources(response.get("user"), details)
 
     def get_user_details(self, response):
         """Return user details from Instagram account"""

--- a/social_core/backends/kakao.py
+++ b/social_core/backends/kakao.py
@@ -20,7 +20,12 @@ class KakaoOAuth2(BaseOAuth2):
     ]
 
     def get_user_id(self, details, response):
-        return response["id"]
+        return self.get_user_id_from_sources(
+            response,
+            response.get("properties"),
+            response.get("kakao_account"),
+            details,
+        )
 
     def get_user_details(self, response):
         """Return user details from Kakao account"""

--- a/social_core/backends/kick.py
+++ b/social_core/backends/kick.py
@@ -12,6 +12,8 @@ class KickOAuth2(BaseOAuth2PKCE):
     """Kick OAuth2 authentication backend"""
 
     name = "kick"
+    ID_KEY = "user_id"
+    REQUIRES_USER_ID = True
     HOSTNAME = "id.kick.com"
     API_HOSTNAME = "api.kick.com"
     AUTHORIZATION_URL = f"https://{HOSTNAME}/oauth/authorize"
@@ -28,12 +30,6 @@ class KickOAuth2(BaseOAuth2PKCE):
         ("token_type", "token_type"),
         ("scope", "scope"),
     ]
-
-    def get_user_id(self, details, response):
-        """
-        Use Kick user id as unique id
-        """
-        return response.get("user_id")
 
     def get_user_details(self, response):
         """Return user details from Kick account"""

--- a/social_core/backends/lastfm.py
+++ b/social_core/backends/lastfm.py
@@ -16,6 +16,8 @@ class LastFmAuth(BaseAuth):
     """
 
     name = "lastfm"
+    ID_KEY = "name"
+    REQUIRES_USER_ID = True
     AUTH_URL = "https://www.last.fm/api/auth/?api_key={api_key}"
     EXTRA_DATA = [("key", "session_key")]
 
@@ -47,11 +49,6 @@ class LastFmAuth(BaseAuth):
 
         kwargs.update({"response": response["session"], "backend": self})
         return self.strategy.authenticate(*args, **kwargs)
-
-    def get_user_id(self, details, response):
-        """Return a unique ID for the current user, by default from server
-        response."""
-        return response.get("name")
 
     def get_user_details(self, response):
         fullname, first_name, last_name = self.get_user_names(response["name"])

--- a/social_core/backends/loginradius.py
+++ b/social_core/backends/loginradius.py
@@ -96,4 +96,5 @@ class LoginRadiusAuth(BaseOAuth2):
         """Return a unique ID for the current user, by default from server
         response. Since LoginRadius handles multiple providers, we need to
         distinguish them to prevent conflicts."""
-        return f"{response.get('Provider')}-{response.get(self.id_key())}"
+        user_id = self.get_user_id_from_sources(response, details)
+        return f"{response.get('Provider')}-{user_id}"

--- a/social_core/backends/mapmyfitness.py
+++ b/social_core/backends/mapmyfitness.py
@@ -12,6 +12,7 @@ class MapMyFitnessOAuth2(BaseOAuth2):
     """MapMyFitness OAuth authentication backend"""
 
     name = "mapmyfitness"
+    REQUIRES_USER_ID = True
     AUTHORIZATION_URL = "https://www.mapmyfitness.com/v7.0/oauth2/authorize"
     ACCESS_TOKEN_URL = "https://oauth2-api.mapmyapi.com/v7.0/oauth2/access_token"
     REQUEST_TOKEN_METHOD = "POST"
@@ -23,9 +24,6 @@ class MapMyFitnessOAuth2(BaseOAuth2):
     def auth_headers(self):
         key = self.get_key_and_secret()[0]
         return {"Api-Key": key}
-
-    def get_user_id(self, details, response):
-        return response["id"]
 
     def get_user_details(self, response):
         first = response.get("first_name", "")

--- a/social_core/backends/mediawiki.py
+++ b/social_core/backends/mediawiki.py
@@ -31,6 +31,7 @@ class MediaWiki(BaseOAuth1):
     """
 
     name = "mediawiki"
+    ID_KEY = "userID"
     MEDIAWIKI_URL = "https://meta.wikimedia.org/w/index.php"
     SOCIAL_AUTH_MEDIAWIKI_CALLBACK = "oob"
     LEEWAY = 10.0
@@ -174,7 +175,7 @@ class MediaWiki(BaseOAuth1):
                 f"Replay attack detected: {identity['nonce']} != {request_nonce}",
             )
 
-        return {
+        details = {
             "username": identity["username"],
             "userID": identity["sub"],
             "email": identity.get("email"),
@@ -185,9 +186,16 @@ class MediaWiki(BaseOAuth1):
             "registered": identity.get("registered"),
             "blocked": identity.get("blocked"),
         }
+        id_key = self.id_key()
+        if id_key not in details:
+            user_id = identity.get(id_key)
+            if user_id is None:
+                raise AuthMissingParameter(self, id_key)
+            details[id_key] = user_id
+        return details
 
     def get_user_id(self, details, response):
         """
         Get the unique Mediawiki user ID.
         """
-        return details["userID"]
+        return self.get_user_id_from_sources(details)

--- a/social_core/backends/mendeley.py
+++ b/social_core/backends/mendeley.py
@@ -8,10 +8,8 @@ BASE_EXTRA_DATA = [("profile_id", "profile_id"), ("name", "name"), ("bio", "bio"
 
 
 class MendeleyMixin:
+    REQUIRES_USER_ID = True
     SCOPE_SEPARATOR = "+"
-
-    def get_user_id(self, details, response):
-        return response["id"]
 
     def get_user_details(self, response):
         """Return user details from Mendeley account"""

--- a/social_core/backends/microsoft.py
+++ b/social_core/backends/microsoft.py
@@ -11,6 +11,7 @@ from .oauth import BaseOAuth2
 
 class MicrosoftOAuth2(BaseOAuth2):
     name = "microsoft-graph"
+    REQUIRES_USER_ID = True
     SCOPE_SEPARATOR = " "
     AUTHORIZATION_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
     ACCESS_TOKEN_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
@@ -39,10 +40,6 @@ class MicrosoftOAuth2(BaseOAuth2):
         return self.do_auth(
             response["access_token"], *args, response=response, **kwargs
         )
-
-    def get_user_id(self, details, response):
-        """Use user account id as unique id"""
-        return response.get("id")
 
     def get_user_details(self, response):
         """Return user details from Microsoft online account"""

--- a/social_core/backends/naver.py
+++ b/social_core/backends/naver.py
@@ -7,14 +7,12 @@ class NaverOAuth2(BaseOAuth2):
     """Naver OAuth authentication backend"""
 
     name = "naver"
+    REQUIRES_USER_ID = True
     AUTHORIZATION_URL = "https://nid.naver.com/oauth2.0/authorize"
     ACCESS_TOKEN_URL = "https://nid.naver.com/oauth2.0/token"
     EXTRA_DATA = [
         ("id", "id"),
     ]
-
-    def get_user_id(self, details, response):
-        return response.get("id")
 
     def get_user_details(self, response):
         """Return user details from Naver account"""
@@ -36,7 +34,7 @@ class NaverOAuth2(BaseOAuth2):
 
         data = response.json()
 
-        return {
+        user_data = {
             "id": self._fetch(data, "id"),
             "email": self._fetch(data, "email"),
             "username": self._fetch(data, "name"),
@@ -46,6 +44,10 @@ class NaverOAuth2(BaseOAuth2):
             "birthday": self._fetch(data, "birthday"),
             "profile_image": self._fetch(data, "profile_image"),
         }
+        id_key = self.id_key()
+        if id_key not in user_data:
+            user_data[id_key] = self._fetch(data, id_key)
+        return user_data
 
     def auth_headers(self):
         client_id, client_secret = self.get_key_and_secret()

--- a/social_core/backends/open_id.py
+++ b/social_core/backends/open_id.py
@@ -52,7 +52,11 @@ class OpenIdAuth(BaseAuth):
     _consumer = None
 
     def get_user_id(self, details, response):
-        """Return user unique id provided by service"""
+        """Return the protocol-defined identity URL provided by the service.
+
+        OpenID identity is asserted as a URL rather than a response mapping field,
+        so the configurable ID_KEY does not apply to this backend.
+        """
         return response.identity_url
 
     def get_ax_attributes(self) -> list[tuple[str, str]]:

--- a/social_core/backends/open_id_connect.py
+++ b/social_core/backends/open_id_connect.py
@@ -575,9 +575,14 @@ class OpenIdConnectAuth(BaseOAuth2PKCE):
         return userinfo
 
     def get_user_id(self, details, response):
-        if self.id_key() == "sub" and self.id_token is not None:
-            return self.id_token.get("sub")
-        return super().get_user_id(details, response)
+        id_key = self.id_key()
+        if id_key == "sub":
+            return self.get_user_id_from_sources(
+                self.id_token, details, response, id_key=id_key
+            )
+        return self.get_user_id_from_sources(
+            details, response, self.id_token, id_key=id_key
+        )
 
     def get_user_details(self, response):
         """Return user details from the UserInfo response or ID token."""

--- a/social_core/backends/openshift.py
+++ b/social_core/backends/openshift.py
@@ -12,6 +12,7 @@ from .oauth import BaseOAuth2
 
 class OpenshiftOAuth2(BaseOAuth2):
     name = "openshift"
+    ID_KEY = "uid"
 
     def access_token_url(self):
         return urljoin(append_slash(cast("str", self.setting("URL"))), "oauth/token")
@@ -22,7 +23,7 @@ class OpenshiftOAuth2(BaseOAuth2):
         )
 
     def get_user_id(self, details, response):
-        return response["metadata"]["uid"]
+        return self.get_user_id_from_sources(response.get("metadata"), details)
 
     def get_user_details(self, response):
         """Return user details from openshift account"""

--- a/social_core/backends/orbi.py
+++ b/social_core/backends/orbi.py
@@ -21,9 +21,6 @@ class OrbiOAuth2(BaseOAuth2):
         ("birth", "birth"),
     ]
 
-    def get_user_id(self, details, response):
-        return response.get("id")
-
     def get_user_details(self, response):
         fullname, first_name, last_name = self.get_user_names(
             response.get("name", ""),

--- a/social_core/backends/podio.py
+++ b/social_core/backends/podio.py
@@ -22,7 +22,9 @@ class PodioOAuth2(BaseOAuth2):
     ]
 
     def get_user_id(self, details, response):
-        return response["ref"]["id"]
+        return self.get_user_id_from_sources(
+            response.get("ref"), response.get("user"), details
+        )
 
     def get_user_details(self, response):
         fullname, first_name, last_name = self.get_user_names(

--- a/social_core/backends/pushbullet.py
+++ b/social_core/backends/pushbullet.py
@@ -8,7 +8,7 @@ class PushbulletOAuth2(BaseOAuth2):
 
     name = "pushbullet"
     EXTRA_DATA = [("id", "id")]
-    ID_KEY = "username"
+    ID_KEY = "iden"
     AUTHORIZATION_URL = "https://www.pushbullet.com/authorize"
     REQUEST_TOKEN_URL = "https://api.pushbullet.com/oauth2/token"
     ACCESS_TOKEN_URL = "https://api.pushbullet.com/oauth2/token"
@@ -19,6 +19,7 @@ class PushbulletOAuth2(BaseOAuth2):
 
     def get_user_id(self, details, response):
         auth = f"Basic {base64.b64encode(details['username']).decode()}"
-        return self.get_json(
+        user = self.get_json(
             "https://api.pushbullet.com/v2/users/me", headers={"Authorization": auth}
-        )["iden"]
+        )
+        return self.get_user_id_from_sources(user)

--- a/social_core/backends/qiita.py
+++ b/social_core/backends/qiita.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal
 
-from social_core.exceptions import AuthException
-
 from .oauth import BaseOAuth2
 
 if TYPE_CHECKING:
@@ -23,6 +21,7 @@ class QiitaOAuth2(BaseOAuth2):
     """Qiita OAuth authentication backend"""
 
     name = "qiita"
+    ID_KEY = "id"
 
     AUTHORIZATION_URL = "https://qiita.com/api/v2/oauth/authorize"
     ACCESS_TOKEN_URL = "https://qiita.com/api/v2/access_tokens"
@@ -96,12 +95,8 @@ class QiitaOAuth2(BaseOAuth2):
 
     def get_user_id(self, details, response):
         """Return user id"""
-        user_id = None
-        if self.setting("IDENTIFIED_BY_PERMANENT_ID"):
-            user_id = response.get("permanent_id")
-        else:
-            user_id = response.get("id")
-
-        if user_id is not None:
-            return str(user_id)
-        raise AuthException(self, "failed to get user id")
+        id_key = self.id_key()
+        if not self.setting("ID_KEY") and self.setting("IDENTIFIED_BY_PERMANENT_ID"):
+            id_key = "permanent_id"
+        user_id = self.get_user_id_from_sources(response, details, id_key=id_key)
+        return str(user_id)

--- a/social_core/backends/saml.py
+++ b/social_core/backends/saml.py
@@ -513,6 +513,9 @@ class SAMLAuth(BaseAuth):
         Get the permanent ID for this user from the response.
         We prefix each ID with the name of the IdP so that we can
         connect multiple IdPs to this user.
+
+        SAML identities use the per-IdP ``attr_user_permanent_id`` mapping,
+        rather than the generic configurable ID_KEY.
         """
         idp = self.get_idp(response["idp_name"])
         uid = idp.get_user_permanent_id(response["attributes"])

--- a/social_core/backends/steam.py
+++ b/social_core/backends/steam.py
@@ -22,7 +22,10 @@ class SteamOpenId(OpenIdAuth):
     URL = "https://steamcommunity.com/openid"
 
     def get_user_id(self, details, response):
-        """Return user unique id provided by service"""
+        """Return the validated Steam ID from the asserted OpenID URL.
+
+        The ID is protocol-derived, so the configurable ID_KEY does not apply.
+        """
         return self._user_id(response)
 
     def get_user_details(self, response):

--- a/social_core/backends/stocktwits.py
+++ b/social_core/backends/stocktwits.py
@@ -24,7 +24,7 @@ class StocktwitsOAuth2(BaseOAuth2):
     ]
 
     def get_user_id(self, details, response):
-        return response["user"]["id"]
+        return self.get_user_id_from_sources(response.get("user"), details)
 
     def get_user_details(self, response):
         """Return user details from Stocktwits account"""

--- a/social_core/backends/strava.py
+++ b/social_core/backends/strava.py
@@ -25,7 +25,7 @@ class StravaOAuth(BaseOAuth2):
     ]
 
     def get_user_id(self, details, response):
-        return response["athlete"]["id"]
+        return self.get_user_id_from_sources(response.get("athlete"), details)
 
     def get_user_details(self, response):
         """Return user details from Strava account"""

--- a/social_core/backends/suse.py
+++ b/social_core/backends/suse.py
@@ -8,6 +8,7 @@ from .open_id import OpenIdAuth
 
 class OpenSUSEOpenId(OpenIdAuth):
     name = "opensuse"
+    ID_KEY = "nickname"
     URL = "https://www.opensuse.org/openid/user/"
 
     def get_user_id(self, details, response):
@@ -15,4 +16,4 @@ class OpenSUSEOpenId(OpenIdAuth):
         Return user unique id provided by service. For openSUSE
         the nickname is original.
         """
-        return details["nickname"]
+        return self.get_user_id_from_sources(details)

--- a/social_core/backends/tumblr.py
+++ b/social_core/backends/tumblr.py
@@ -19,7 +19,8 @@ class TumblrOAuth(BaseOAuth1):
     ACCESS_TOKEN_URL = "https://www.tumblr.com/oauth/access_token"
 
     def get_user_id(self, details, response):
-        return response["response"]["user"][self.id_key()]
+        data = response.get("response") or {}
+        return self.get_user_id_from_sources(data.get("user"), details)
 
     def get_user_details(self, response):
         # https://www.tumblr.com/docs/en/api/v2#user-methods

--- a/social_core/backends/twitch.py
+++ b/social_core/backends/twitch.py
@@ -43,17 +43,12 @@ class TwitchOAuth2(BaseOAuth2):
     """Twitch OAuth authentication backend"""
 
     name = "twitch"
-    ID_KEY = "_id"
+    ID_KEY = "id"
+    REQUIRES_USER_ID = True
     AUTHORIZATION_URL = "https://id.twitch.tv/oauth2/authorize"
     ACCESS_TOKEN_URL = "https://id.twitch.tv/oauth2/token"
     DEFAULT_SCOPE = ["user:read:email"]
     REDIRECT_STATE = False
-
-    def get_user_id(self, details, response):
-        """
-        Use twitch user id as unique id
-        """
-        return response.get("id")
 
     def get_user_details(self, response):
         return {

--- a/social_core/backends/ubuntu.py
+++ b/social_core/backends/ubuntu.py
@@ -7,6 +7,7 @@ from .open_id import OpenIdAuth
 
 class UbuntuOpenId(OpenIdAuth):
     name = "ubuntu"
+    ID_KEY = "nickname"
     URL = "https://login.ubuntu.com"
 
     def get_user_id(self, details, response):
@@ -14,4 +15,4 @@ class UbuntuOpenId(OpenIdAuth):
         Return user unique id provided by service. For Ubuntu One
         the nickname should be original.
         """
-        return details["nickname"]
+        return self.get_user_id_from_sources(details)

--- a/social_core/backends/universe.py
+++ b/social_core/backends/universe.py
@@ -21,7 +21,7 @@ class UniverseOAuth2(BaseOAuth2):
     ]
 
     def get_user_id(self, details, response):
-        return response["current_user"][self.id_key()]
+        return self.get_user_id_from_sources(response.get("current_user"), details)
 
     def get_user_details(self, response):
         """Return user details from a Universe account"""

--- a/social_core/backends/untappd.py
+++ b/social_core/backends/untappd.py
@@ -106,7 +106,7 @@ class UntappdOAuth2(BaseOAuth2):
         Return a unique ID for the current user, by default from
         server response.
         """
-        return response["user"].get(self.id_key())
+        return self.get_user_id_from_sources(response.get("user"), details)
 
     def user_data(self, access_token: str, *args, **kwargs) -> dict[str, Any] | None:
         """Loads user data from service"""

--- a/social_core/backends/vend.py
+++ b/social_core/backends/vend.py
@@ -12,6 +12,7 @@ from .oauth import BaseOAuth2
 
 class VendOAuth2(BaseOAuth2):
     name = "vend"
+    ID_KEY = "id"
     AUTHORIZATION_URL = "https://secure.vendhq.com/connect"
     ACCESS_TOKEN_URL = "https://{0}.vendhq.com/api/1.0/token"
     REDIRECT_STATE = False
@@ -34,10 +35,9 @@ class VendOAuth2(BaseOAuth2):
             raise AuthInvalidParameter(self, "domain_prefix")
         return prefix
 
-    def scoped_uid(self, response) -> str:
-        user_id = response.get("id")
-        if user_id in (None, ""):
-            raise AuthMissingParameter(self, "id")
+    def scoped_uid(self, details, response) -> str:
+        id_key = self.id_key()
+        user_id = self.get_user_id_from_sources(response, details, id_key=id_key)
         return f"{self.domain_prefix(response)}:{user_id}"
 
     def access_token_url(self):
@@ -45,7 +45,7 @@ class VendOAuth2(BaseOAuth2):
 
     def get_user_id(self, details, response):
         domain_prefix = self.domain_prefix(response)
-        uid = self.scoped_uid(response)
+        uid = self.scoped_uid(details, response)
         if self.strategy.storage.user.get_social_auth(self.name, uid):
             return uid
 

--- a/social_core/backends/vimeo.py
+++ b/social_core/backends/vimeo.py
@@ -14,7 +14,7 @@ class VimeoOAuth1(BaseOAuth1):
     ACCESS_TOKEN_URL = "https://vimeo.com/oauth/access_token"
 
     def get_user_id(self, details, response):
-        return response.get("person", {}).get("id")
+        return self.get_user_id_from_sources(response.get("person"), details)
 
     def get_user_details(self, response):
         """Return user details from Twitter account"""
@@ -43,6 +43,7 @@ class VimeoOAuth2(BaseOAuth2):
     """Vimeo OAuth2 authentication backend"""
 
     name = "vimeo-oauth2"
+    ID_KEY = "uri"
     AUTHORIZATION_URL = "https://api.vimeo.com/oauth/authorize"
     ACCESS_TOKEN_URL = "https://api.vimeo.com/oauth/access_token"
     REFRESH_TOKEN_URL = "https://api.vimeo.com/oauth/request_token"
@@ -60,10 +61,12 @@ class VimeoOAuth2(BaseOAuth2):
 
     def get_user_id(self, details, response):
         """Return user id"""
-        try:
-            user_id = response.get("user", {})["uri"].split("/")[-1]
-        except KeyError:
-            user_id = None
+        id_key = self.id_key()
+        user_id = self.get_user_id_from_sources(
+            response.get("user"), details, id_key=id_key
+        )
+        if id_key == "uri":
+            return user_id.split("/")[-1]
         return user_id
 
     def get_user_details(self, response):

--- a/social_core/backends/yammer.py
+++ b/social_core/backends/yammer.py
@@ -13,7 +13,9 @@ class YammerOAuth2(BaseOAuth2):
     EXTRA_DATA = [("id", "id"), ("expires", "expires"), ("mugshot_url", "mugshot_url")]
 
     def get_user_id(self, details, response):
-        return response["user"]["id"]
+        return self.get_user_id_from_sources(
+            response.get("user"), details, response.get("access_token")
+        )
 
     def get_user_details(self, response):
         username = response["user"]["name"]

--- a/social_core/backends/yandex.py
+++ b/social_core/backends/yandex.py
@@ -18,10 +18,11 @@ class YandexOpenId(OpenIdAuth):
     """Yandex OpenID authentication backend"""
 
     name = "yandex-openid"
+    ID_KEY = "email"
     URL = "https://openid.yandex.ru"
 
     def get_user_id(self, details, response):
-        return details["email"] or response.identity_url
+        return details.get(self.id_key()) or response.identity_url
 
     def get_user_details(self, response):
         """Generate username from identity url"""

--- a/social_core/backends/zotero.py
+++ b/social_core/backends/zotero.py
@@ -10,6 +10,7 @@ class ZoteroOAuth(BaseOAuth1):
     """Zotero OAuth authorization mechanism"""
 
     name = "zotero"
+    ID_KEY = "userID"
     AUTHORIZATION_URL = "https://www.zotero.org/oauth/authorize"
     REQUEST_TOKEN_URL = "https://www.zotero.org/oauth/request"
     ACCESS_TOKEN_URL = "https://www.zotero.org/oauth/access"
@@ -19,7 +20,10 @@ class ZoteroOAuth(BaseOAuth1):
         Return user unique id provided by service. For Ubuntu One
         the nickname should be original.
         """
-        return details["userID"]
+        id_key = self.id_key()
+        return self.get_user_id_from_sources(
+            response.get("access_token"), details, id_key=id_key
+        )
 
     def get_user_details(self, response):
         """Return user details from Zotero API account"""

--- a/social_core/tests/backends/test_auth0.py
+++ b/social_core/tests/backends/test_auth0.py
@@ -77,6 +77,22 @@ class Auth0OAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
     def test_login(self) -> None:
         self.do_login()
 
+    def test_login_with_configured_token_claim_id(self) -> None:
+        self.strategy.set_settings({"SOCIAL_AUTH_AUTH0_ID_KEY": "sub"})
+
+        user = self.do_login()
+
+        self.assertEqual(user.social[0].uid, "123456")
+
+    def test_missing_configured_token_claim_raises_token_error(self) -> None:
+        self.strategy.set_settings({"SOCIAL_AUTH_AUTH0_ID_KEY": "missing_claim"})
+
+        with self.assertRaisesRegex(
+            AuthTokenError,
+            "Missing configured user ID claim missing_claim",
+        ):
+            self.do_login()
+
     def test_default_scope(self) -> None:
         self.assertEqual(
             get_querystring(self.backend.auth_url())["scope"],

--- a/social_core/tests/backends/test_auth0_openidconnect.py
+++ b/social_core/tests/backends/test_auth0_openidconnect.py
@@ -61,6 +61,11 @@ class Auth0OpenIdConnectTest(OpenIdConnectTest, BaseAuthUrlTestMixin):
             content_type="application/json",
         )
 
+    def get_id_token(self, *args, **kwargs):
+        id_token = super().get_id_token(*args, **kwargs)
+        id_token["custom_id"] = "token-only-identifier"
+        return id_token
+
     def test_domain_configuration(self) -> None:
         """Test that domain-based URLs are constructed correctly"""
         self.assertEqual(
@@ -159,6 +164,15 @@ class Auth0OpenIdConnectTest(OpenIdConnectTest, BaseAuthUrlTestMixin):
             self.backend.get_user_id(details, {"sub": self.user_id}),
             "validated-subject",
         )
+
+    def test_configured_user_id_uses_id_token_claim(self) -> None:
+        self.strategy.set_settings(
+            {"SOCIAL_AUTH_AUTH0_OPENIDCONNECT_ID_KEY": "custom_id"}
+        )
+
+        user = self.do_login()
+
+        self.assertEqual(user.social[0].uid, "token-only-identifier")
 
     def test_everything_works(self) -> None:
         self.do_login()

--- a/social_core/tests/backends/test_azuread.py
+++ b/social_core/tests/backends/test_azuread.py
@@ -266,6 +266,21 @@ class AzureADV2TenantOAuth2Test(AzureADTenantOAuth2Test):
     )
     TOKEN_VERSION = "2.0"
 
+    def test_configurable_id_key(self) -> None:
+        response = {
+            "preferred_username": "mutable@example.com",
+            "sub": "stable-subject",
+        }
+        self.assertEqual(
+            self.backend.get_user_id({}, response),
+            "mutable@example.com",
+        )
+
+        self.strategy.set_settings(
+            {"SOCIAL_AUTH_AZUREAD_V2_TENANT_OAUTH2_ID_KEY": "sub"}
+        )
+        self.assertEqual(self.backend.get_user_id({}, response), "stable-subject")
+
 
 class AzureADOAuth2TokenRequestBodyMixin(TestCase):
     def _token_request_body(self, url_prefix: str) -> dict[str, list[str]]:

--- a/social_core/tests/backends/test_cas.py
+++ b/social_core/tests/backends/test_cas.py
@@ -74,6 +74,13 @@ class CASOpenIdConnectTest(OpenIdConnectTest, BaseAuthUrlTestMixin):
     def test_everything_works(self) -> None:
         self.do_login()
 
+    def test_configured_id_key_uses_raw_attribute(self) -> None:
+        self.strategy.set_settings({"SOCIAL_AUTH_CAS_ID_KEY": "preferred_username"})
+
+        user = self.do_login()
+
+        self.assertEqual(user.social[0].uid, "cartman")
+
     def test_legacy_refresh_requires_reauthentication(self) -> None:
         with self.assertRaisesRegex(AuthTokenError, "reauthentication required"):
             self.backend.validate_legacy_id_token_context(

--- a/social_core/tests/backends/test_drip.py
+++ b/social_core/tests/backends/test_drip.py
@@ -1,5 +1,7 @@
 import json
 
+from social_core.exceptions import AuthMissingParameter
+
 from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
@@ -17,6 +19,33 @@ class DripOAuthTest(OAuth2Test, BaseAuthUrlTestMixin):
 
     def test_login(self) -> None:
         self.do_login()
+
+    def test_login_with_configured_provider_field_id(self) -> None:
+        self.strategy.set_settings({"SOCIAL_AUTH_DRIP_ID_KEY": "name"})
+        self.user_data_body = json.dumps(
+            {"users": [{"email": "other@example.com", "name": "Drip User"}]}
+        )
+
+        user = self.do_login()
+
+        self.assertEqual(user.social[0].uid, "Drip User")
+
+    def test_configured_id_uses_normalized_details_fallback(self) -> None:
+        self.strategy.set_settings({"SOCIAL_AUTH_DRIP_ID_KEY": "fullname"})
+
+        self.assertEqual(
+            self.backend.get_user_id(
+                {"fullname": "Drip User"},
+                {"users": [{"name": "Drip User"}]},
+            ),
+            "Drip User",
+        )
+
+    def test_missing_configured_id_raises_missing_parameter(self) -> None:
+        self.strategy.set_settings({"SOCIAL_AUTH_DRIP_ID_KEY": "missing_id"})
+
+        with self.assertRaisesRegex(AuthMissingParameter, "missing_id"):
+            self.backend.get_user_id({}, {"users": [{}]})
 
     def test_partial_pipeline(self) -> None:
         self.do_partial_pipeline()

--- a/social_core/tests/backends/test_id_key.py
+++ b/social_core/tests/backends/test_id_key.py
@@ -1,0 +1,646 @@
+from types import SimpleNamespace
+from typing import Any
+from unittest import TestCase
+from unittest.mock import Mock
+
+from social_core.exceptions import AuthMissingParameter
+from social_core.tests.models import TestStorage, TestUserSocialAuth, User
+from social_core.tests.strategy import TestStrategy
+from social_core.utils import module_member, setting_name
+
+
+class ConfigurableIdKeyTest(TestCase):
+    direct_response_backends = (
+        "social_core.backends.azuread.AzureADOAuth2",
+        "social_core.backends.azuread_b2c.AzureADB2COAuth2",
+        "social_core.backends.azuread_tenant.AzureADTenantOAuth2",
+        "social_core.backends.azuread_tenant.AzureADV2TenantOAuth2",
+        "social_core.backends.classlink.ClasslinkOAuth",
+        "social_core.backends.discourse.DiscourseAuth",
+        "social_core.backends.flat.FlatOAuth2",
+        "social_core.backends.kakao.KakaoOAuth2",
+        "social_core.backends.kick.KickOAuth2",
+        "social_core.backends.lastfm.LastFmAuth",
+        "social_core.backends.mapmyfitness.MapMyFitnessOAuth2",
+        "social_core.backends.mendeley.MendeleyOAuth2",
+        "social_core.backends.microsoft.MicrosoftOAuth2",
+        "social_core.backends.naver.NaverOAuth2",
+        "social_core.backends.orbi.OrbiOAuth2",
+        "social_core.backends.open_id_connect.OpenIdConnectAuth",
+        "social_core.backends.qiita.QiitaOAuth2",
+        "social_core.backends.twitch.TwitchOAuth2",
+    )
+    details_backends = (
+        "social_core.backends.auth0.Auth0OAuth2",
+        "social_core.backends.cas.CASOpenIdConnectAuth",
+        "social_core.backends.mediawiki.MediaWiki",
+        "social_core.backends.suse.OpenSUSEOpenId",
+        "social_core.backends.ubuntu.UbuntuOpenId",
+        "social_core.backends.yandex.YandexOpenId",
+    )
+    nested_response_backends = (
+        ("social_core.backends.behance.BehanceOAuth2", ("user",)),
+        ("social_core.backends.clever.CleverOAuth2", ("data",)),
+        ("social_core.backends.coinbase.CoinbaseOAuth2", ("data",)),
+        ("social_core.backends.digitalocean.DigitalOceanOAuth", ("account",)),
+        ("social_core.backends.disqus.DisqusOAuth2", ("response",)),
+        ("social_core.backends.foursquare.FoursquareOAuth2", ("response", "user")),
+        ("social_core.backends.goclio.GoClioOAuth2", ("user",)),
+        ("social_core.backends.instagram.InstagramOAuth2", ("user",)),
+        ("social_core.backends.openshift.OpenshiftOAuth2", ("metadata",)),
+        ("social_core.backends.podio.PodioOAuth2", ("ref",)),
+        ("social_core.backends.stocktwits.StocktwitsOAuth2", ("user",)),
+        ("social_core.backends.strava.StravaOAuth", ("athlete",)),
+        ("social_core.backends.tumblr.TumblrOAuth", ("response", "user")),
+        ("social_core.backends.universe.UniverseOAuth2", ("current_user",)),
+        ("social_core.backends.untappd.UntappdOAuth2", ("user",)),
+        ("social_core.backends.vimeo.VimeoOAuth1", ("person",)),
+        ("social_core.backends.yammer.YammerOAuth2", ("user",)),
+    )
+    explicit_default_keys = (
+        ("social_core.backends.auth0.Auth0OAuth2", "user_id"),
+        ("social_core.backends.azuread.AzureADOAuth2", "upn"),
+        ("social_core.backends.azuread_b2c.AzureADB2COAuth2", "sub"),
+        ("social_core.backends.azuread_tenant.AzureADTenantOAuth2", "sub"),
+        (
+            "social_core.backends.azuread_tenant.AzureADV2TenantOAuth2",
+            "preferred_username",
+        ),
+        ("social_core.backends.cas.CASOpenIdConnectAuth", "username"),
+        ("social_core.backends.cilogon.CILogonOAuth2", "sub"),
+        ("social_core.backends.classlink.ClasslinkOAuth", "UserId"),
+        ("social_core.backends.digitalocean.DigitalOceanOAuth", "uuid"),
+        ("social_core.backends.discourse.DiscourseAuth", "email"),
+        ("social_core.backends.drip.DripOAuth", "email"),
+        ("social_core.backends.google.GoogleOAuth2", "email"),
+        ("social_core.backends.kick.KickOAuth2", "user_id"),
+        ("social_core.backends.lastfm.LastFmAuth", "name"),
+        ("social_core.backends.mediawiki.MediaWiki", "userID"),
+        ("social_core.backends.openshift.OpenshiftOAuth2", "uid"),
+        ("social_core.backends.pushbullet.PushbulletOAuth2", "iden"),
+        ("social_core.backends.qiita.QiitaOAuth2", "id"),
+        ("social_core.backends.suse.OpenSUSEOpenId", "nickname"),
+        ("social_core.backends.twitch.TwitchOAuth2", "id"),
+        ("social_core.backends.ubuntu.UbuntuOpenId", "nickname"),
+        ("social_core.backends.vimeo.VimeoOAuth2", "uri"),
+        ("social_core.backends.yandex.YandexOpenId", "email"),
+        ("social_core.backends.zotero.ZoteroOAuth", "userID"),
+    )
+    required_default_id_backends = (
+        "social_core.backends.classlink.ClasslinkOAuth",
+        "social_core.backends.discourse.DiscourseAuth",
+        "social_core.backends.flat.FlatOAuth2",
+        "social_core.backends.kakao.KakaoOAuth2",
+        "social_core.backends.kick.KickOAuth2",
+        "social_core.backends.lastfm.LastFmAuth",
+        "social_core.backends.mapmyfitness.MapMyFitnessOAuth2",
+        "social_core.backends.mendeley.MendeleyOAuth2",
+        "social_core.backends.microsoft.MicrosoftOAuth2",
+        "social_core.backends.naver.NaverOAuth2",
+        "social_core.backends.twitch.TwitchOAuth2",
+    )
+
+    def setUp(self) -> None:
+        User.reset_cache()
+        TestUserSocialAuth.reset_cache()
+
+    def backend(self, path: str, **settings):
+        strategy = TestStrategy(TestStorage)
+        backend_class = module_member(path)
+        backend = backend_class(strategy)
+        strategy.set_settings(
+            {
+                setting_name(backend.name, name): value
+                for name, value in settings.items()
+            }
+        )
+        return backend
+
+    def test_direct_response_overrides_use_configured_key(self) -> None:
+        for path in self.direct_response_backends:
+            with self.subTest(path=path):
+                backend = self.backend(path, ID_KEY="custom_id")
+                self.assertEqual(
+                    backend.get_user_id({}, {"custom_id": "configured"}),
+                    "configured",
+                )
+
+    def test_details_overrides_use_configured_key(self) -> None:
+        for path in self.details_backends:
+            with self.subTest(path=path):
+                backend = self.backend(path, ID_KEY="custom_id")
+                self.assertEqual(
+                    backend.get_user_id(
+                        {"custom_id": "configured"},
+                        SimpleNamespace(identity_url="https://example.com/user"),
+                    ),
+                    "configured",
+                )
+
+    def test_nested_response_overrides_use_configured_key(self) -> None:
+        for path, container_path in self.nested_response_backends:
+            with self.subTest(path=path):
+                response: dict[str, Any] = {"custom_id": "configured"}
+                for container in reversed(container_path):
+                    response = {container: response}
+                backend = self.backend(path, ID_KEY="custom_id")
+                self.assertEqual(backend.get_user_id({}, response), "configured")
+
+    def test_mapping_overrides_use_normalized_details(self) -> None:
+        cases: tuple[tuple[str, str, dict[str, Any]], ...] = (
+            (
+                "social_core.backends.azuread_tenant.AzureADV2TenantOAuth2",
+                "email",
+                {},
+            ),
+            (
+                "social_core.backends.behance.BehanceOAuth2",
+                "fullname",
+                {"user": {}},
+            ),
+            (
+                "social_core.backends.bitbucket.BitbucketOAuth2",
+                "fullname",
+                {},
+            ),
+            (
+                "social_core.backends.clever.CleverOAuth2",
+                "username",
+                {"data": {}},
+            ),
+            (
+                "social_core.backends.coinbase.CoinbaseOAuth2",
+                "fullname",
+                {"data": {}},
+            ),
+            (
+                "social_core.backends.digitalocean.DigitalOceanOAuth",
+                "username",
+                {"account": {}},
+            ),
+            (
+                "social_core.backends.disqus.DisqusOAuth2",
+                "user_id",
+                {"response": {}},
+            ),
+            (
+                "social_core.backends.foursquare.FoursquareOAuth2",
+                "email",
+                {"response": {"user": {}}},
+            ),
+            (
+                "social_core.backends.goclio.GoClioOAuth2",
+                "username",
+                {"user": {}},
+            ),
+            (
+                "social_core.backends.instagram.InstagramOAuth2",
+                "fullname",
+                {"user": {}},
+            ),
+            (
+                "social_core.backends.openshift.OpenshiftOAuth2",
+                "username",
+                {"metadata": {}},
+            ),
+            (
+                "social_core.backends.podio.PodioOAuth2",
+                "email",
+                {"ref": {}, "user": {}},
+            ),
+            (
+                "social_core.backends.qiita.QiitaOAuth2",
+                "fullname",
+                {},
+            ),
+            (
+                "social_core.backends.stocktwits.StocktwitsOAuth2",
+                "fullname",
+                {"user": {}},
+            ),
+            (
+                "social_core.backends.strava.StravaOAuth",
+                "first_name",
+                {"athlete": {}},
+            ),
+            (
+                "social_core.backends.tumblr.TumblrOAuth",
+                "username",
+                {"response": {"user": {}}},
+            ),
+            (
+                "social_core.backends.universe.UniverseOAuth2",
+                "username",
+                {"current_user": {}},
+            ),
+            (
+                "social_core.backends.untappd.UntappdOAuth2",
+                "fullname",
+                {"user": {}},
+            ),
+            (
+                "social_core.backends.vimeo.VimeoOAuth1",
+                "fullname",
+                {"person": {}},
+            ),
+            (
+                "social_core.backends.vimeo.VimeoOAuth2",
+                "fullname",
+                {"user": {}},
+            ),
+            (
+                "social_core.backends.yammer.YammerOAuth2",
+                "email",
+                {"user": {}, "access_token": {}},
+            ),
+        )
+        for path, id_key, response in cases:
+            with self.subTest(path=path):
+                backend = self.backend(path, ID_KEY=id_key)
+                self.assertEqual(
+                    backend.get_user_id({id_key: "configured"}, response),
+                    "configured",
+                )
+
+    def test_podio_uses_configured_user_field(self) -> None:
+        backend = self.backend(
+            "social_core.backends.podio.PodioOAuth2", ID_KEY="user_id"
+        )
+
+        self.assertEqual(
+            backend.get_user_id({}, {"ref": {}, "user": {"user_id": 123}}),
+            123,
+        )
+
+    def test_disqus_uses_configured_token_field(self) -> None:
+        backend = self.backend(
+            "social_core.backends.disqus.DisqusOAuth2", ID_KEY="user_id"
+        )
+
+        self.assertEqual(
+            backend.get_user_id({}, {"response": {}, "user_id": 123}),
+            123,
+        )
+
+    def test_kakao_uses_configured_properties_field(self) -> None:
+        backend = self.backend(
+            "social_core.backends.kakao.KakaoOAuth2", ID_KEY="nickname"
+        )
+
+        self.assertEqual(
+            backend.get_user_id(
+                {"username": "configured"},
+                {"id": 123, "properties": {"nickname": "configured"}},
+            ),
+            "configured",
+        )
+
+    def test_yammer_uses_configured_token_field(self) -> None:
+        backend = self.backend(
+            "social_core.backends.yammer.YammerOAuth2", ID_KEY="user_id"
+        )
+
+        self.assertEqual(
+            backend.get_user_id({}, {"user": {}, "access_token": {"user_id": 123}}),
+            123,
+        )
+
+    def test_declared_default_keys_match_existing_identifiers(self) -> None:
+        for path, expected in self.explicit_default_keys:
+            with self.subTest(path=path):
+                self.assertEqual(self.backend(path).ID_KEY, expected)
+
+    def test_lookup_rejects_missing_default_id(self) -> None:
+        for path in self.required_default_id_backends:
+            with self.subTest(path=path):
+                backend = self.backend(path)
+                with self.assertRaisesRegex(AuthMissingParameter, backend.ID_KEY):
+                    backend.get_user_id({}, {})
+
+    def test_inherited_lookup_uses_normalized_details(self) -> None:
+        backend = self.backend(
+            "social_core.backends.mendeley.MendeleyOAuth2",
+            ID_KEY="profile_id",
+        )
+
+        self.assertEqual(
+            backend.get_user_id({"profile_id": "configured"}, {"id": "provider"}),
+            "configured",
+        )
+
+    def test_configured_key_wins_over_legacy_selectors(self) -> None:
+        cases = (
+            (
+                "social_core.backends.bitbucket.BitbucketOAuth2",
+                "USERNAME_AS_ID",
+                {"custom_id": "configured", "username": "legacy"},
+            ),
+            (
+                "social_core.backends.google.GoogleOAuth2",
+                "USE_UNIQUE_USER_ID",
+                {"custom_id": "configured", "sub": "legacy"},
+            ),
+            (
+                "social_core.backends.qiita.QiitaOAuth2",
+                "IDENTIFIED_BY_PERMANENT_ID",
+                {"custom_id": "configured", "permanent_id": "legacy"},
+            ),
+        )
+        for path, legacy_setting, response in cases:
+            with self.subTest(path=path):
+                backend = self.backend(
+                    path,
+                    ID_KEY="custom_id",
+                    **{legacy_setting: True},
+                )
+                self.assertEqual(backend.get_user_id({}, response), "configured")
+
+    def test_legacy_selectors_apply_without_configured_key(self) -> None:
+        cases = (
+            (
+                "social_core.backends.bitbucket.BitbucketOAuth2",
+                "USERNAME_AS_ID",
+                {"uuid": "default", "username": "legacy"},
+                "legacy",
+            ),
+            (
+                "social_core.backends.google.GoogleOAuth2",
+                "USE_UNIQUE_USER_ID",
+                {"sub": "legacy"},
+                "legacy",
+            ),
+            (
+                "social_core.backends.qiita.QiitaOAuth2",
+                "IDENTIFIED_BY_PERMANENT_ID",
+                {"id": "default", "permanent_id": 123},
+                "123",
+            ),
+        )
+        for path, legacy_setting, response, expected in cases:
+            with self.subTest(path=path):
+                backend = self.backend(path, **{legacy_setting: True})
+                self.assertEqual(backend.get_user_id({}, response), expected)
+
+    def test_google_openidconnect_configured_key_wins_over_legacy_selector(
+        self,
+    ) -> None:
+        backend = self.backend(
+            "social_core.backends.google_openidconnect.GoogleOpenIdConnect",
+            ID_KEY="custom_id",
+            USE_UNIQUE_USER_ID=True,
+        )
+        backend.id_token = {"sub": "validated-subject"}
+
+        self.assertEqual(
+            backend.get_user_id({"custom_id": "configured"}, {}),
+            "configured",
+        )
+
+    def test_openidconnect_uses_configured_id_token_claim(self) -> None:
+        backend = self.backend(
+            "social_core.backends.open_id_connect.OpenIdConnectAuth",
+            ID_KEY="custom_id",
+        )
+        backend.id_token = {"custom_id": "token-only-identifier"}
+
+        self.assertEqual(
+            backend.get_user_id({}, {}),
+            "token-only-identifier",
+        )
+
+    def test_auth0_openidconnect_preserves_validated_subject(self) -> None:
+        backend = self.backend(
+            "social_core.backends.auth0_openidconnect.Auth0OpenIdConnectAuth"
+        )
+        backend.id_token = {"sub": "validated-subject"}
+        self.assertEqual(
+            backend.get_user_id({"user_id": "response-subject"}, {}),
+            "validated-subject",
+        )
+
+        backend = self.backend(
+            "social_core.backends.auth0_openidconnect.Auth0OpenIdConnectAuth",
+            ID_KEY="custom_id",
+        )
+        backend.id_token = {"sub": "validated-subject"}
+        self.assertEqual(
+            backend.get_user_id({"custom_id": "configured"}, {}),
+            "configured",
+        )
+
+        backend = self.backend(
+            "social_core.backends.auth0_openidconnect.Auth0OpenIdConnectAuth"
+        )
+        self.assertEqual(
+            backend.get_user_id({"user_id": "response-subject"}, {}),
+            "response-subject",
+        )
+
+    def test_composite_overrides_preserve_scoping(self) -> None:
+        backend = self.backend(
+            "social_core.backends.cilogon.CILogonOAuth2", ID_KEY="custom_id"
+        )
+        self.assertEqual(
+            backend.get_user_id({}, {"custom_id": "configured", "iss": "issuer"}),
+            "configured issuer",
+        )
+
+        backend = self.backend(
+            "social_core.backends.loginradius.LoginRadiusAuth", ID_KEY="custom_id"
+        )
+        self.assertEqual(
+            backend.get_user_id(
+                {}, {"custom_id": "configured", "Provider": "provider"}
+            ),
+            "provider-configured",
+        )
+
+        backend = self.backend(
+            "social_core.backends.vend.VendOAuth2", ID_KEY="custom_id"
+        )
+        self.assertEqual(
+            backend.get_user_id(
+                {},
+                {
+                    "custom_id": "configured",
+                    "domain_prefix": "shop",
+                    "id": "legacy",
+                },
+            ),
+            "shop:configured",
+        )
+
+    def test_composite_overrides_use_normalized_details(self) -> None:
+        cases: tuple[tuple[str, str, dict[str, str], dict[str, str], str], ...] = (
+            (
+                "social_core.backends.cilogon.CILogonOAuth2",
+                "fullname",
+                {"fullname": "configured"},
+                {"iss": "issuer"},
+                "configured issuer",
+            ),
+            (
+                "social_core.backends.loginradius.LoginRadiusAuth",
+                "email",
+                {"email": "configured"},
+                {"Provider": "provider"},
+                "provider-configured",
+            ),
+            (
+                "social_core.backends.vend.VendOAuth2",
+                "username",
+                {"username": "configured"},
+                {"domain_prefix": "shop", "id": "legacy"},
+                "shop:configured",
+            ),
+        )
+        for path, id_key, details, response, expected in cases:
+            with self.subTest(path=path):
+                backend = self.backend(path, ID_KEY=id_key)
+                self.assertEqual(
+                    backend.get_user_id(details, response),
+                    expected,
+                )
+
+    def test_transformed_and_remote_overrides_use_configured_key(self) -> None:
+        backend = self.backend(
+            "social_core.backends.vimeo.VimeoOAuth2", ID_KEY="custom_id"
+        )
+        self.assertEqual(
+            backend.get_user_id({}, {"user": {"custom_id": "/users/configured"}}),
+            "/users/configured",
+        )
+        backend = self.backend("social_core.backends.vimeo.VimeoOAuth2")
+        self.assertEqual(
+            backend.get_user_id({}, {"user": {"uri": "/users/default"}}),
+            "default",
+        )
+
+        backend = self.backend(
+            "social_core.backends.pushbullet.PushbulletOAuth2", ID_KEY="custom_id"
+        )
+        backend.get_json = Mock(return_value={"custom_id": "configured"})
+        self.assertEqual(
+            backend.get_user_id({"username": b"access-token"}, {}),
+            "configured",
+        )
+
+    def test_configured_keys_preserve_missing_identifier_validation(self) -> None:
+        cases: tuple[tuple[str, dict[str, str]], ...] = (
+            ("social_core.backends.azuread.AzureADOAuth2", {}),
+            ("social_core.backends.vend.VendOAuth2", {"domain_prefix": "shop"}),
+        )
+        for path, response in cases:
+            with self.subTest(path=path):
+                backend = self.backend(path, ID_KEY="custom_id")
+                with self.assertRaises(AuthMissingParameter):
+                    backend.get_user_id({}, response)
+
+    def test_mapping_overrides_reject_missing_configured_key(self) -> None:
+        direct_backends = self.direct_response_backends
+        details_backends = tuple(
+            path
+            for path in self.details_backends
+            if path != "social_core.backends.yandex.YandexOpenId"
+        )
+        for path in (*direct_backends, *details_backends):
+            with self.subTest(path=path):
+                backend = self.backend(path, ID_KEY="missing_id")
+                with self.assertRaisesRegex(AuthMissingParameter, "missing_id"):
+                    backend.get_user_id({}, {})
+
+        for path, container_path in self.nested_response_backends:
+            with self.subTest(path=path):
+                response: dict[str, Any] = {}
+                for container in reversed(container_path):
+                    response = {container: response}
+                backend = self.backend(path, ID_KEY="missing_id")
+                with self.assertRaisesRegex(AuthMissingParameter, "missing_id"):
+                    backend.get_user_id({}, response)
+
+    def test_special_overrides_reject_missing_configured_key(self) -> None:
+        cases: tuple[tuple[str, dict[str, Any], dict[str, Any]], ...] = (
+            ("social_core.backends.bitbucket.BitbucketOAuth2", {}, {}),
+            ("social_core.backends.cilogon.CILogonOAuth2", {}, {"iss": "issuer"}),
+            ("social_core.backends.google.GoogleOAuth2", {}, {}),
+            (
+                "social_core.backends.google_openidconnect.GoogleOpenIdConnect",
+                {},
+                {},
+            ),
+            (
+                "social_core.backends.auth0_openidconnect.Auth0OpenIdConnectAuth",
+                {},
+                {},
+            ),
+            (
+                "social_core.backends.loginradius.LoginRadiusAuth",
+                {},
+                {"Provider": "provider"},
+            ),
+            ("social_core.backends.qiita.QiitaOAuth2", {}, {}),
+            ("social_core.backends.vimeo.VimeoOAuth2", {}, {"user": {}}),
+        )
+        for path, details, response in cases:
+            with self.subTest(path=path):
+                backend = self.backend(path, ID_KEY="missing_id")
+                with self.assertRaisesRegex(AuthMissingParameter, "missing_id"):
+                    backend.get_user_id(details, response)
+
+        backend = self.backend(
+            "social_core.backends.pushbullet.PushbulletOAuth2",
+            ID_KEY="missing_id",
+        )
+        backend.get_json = Mock(return_value={})
+        with self.assertRaisesRegex(AuthMissingParameter, "missing_id"):
+            backend.get_user_id({"username": b"access-token"}, {})
+
+    def test_yandex_preserves_identity_url_fallback_for_missing_key(self) -> None:
+        identity_url = "https://provider.example/users/123"
+        backend = self.backend(
+            "social_core.backends.yandex.YandexOpenId",
+            ID_KEY="missing_id",
+        )
+
+        self.assertEqual(
+            backend.get_user_id({}, SimpleNamespace(identity_url=identity_url)),
+            identity_url,
+        )
+
+    def test_protocol_derived_identifiers_ignore_configured_key(self) -> None:
+        identity_url = "https://provider.example/users/123"
+        backend = self.backend(
+            "social_core.backends.open_id.OpenIdAuth", ID_KEY="custom_id"
+        )
+        self.assertEqual(
+            backend.get_user_id({}, SimpleNamespace(identity_url=identity_url)),
+            identity_url,
+        )
+
+        backend = self.backend(
+            "social_core.backends.steam.SteamOpenId", ID_KEY="custom_id"
+        )
+        steam_url = "https://steamcommunity.com/openid/id/123"
+        self.assertEqual(
+            backend.get_user_id({}, SimpleNamespace(identity_url=steam_url)),
+            "123",
+        )
+
+    def test_saml_identifier_uses_idp_mapping(self) -> None:
+        try:
+            backend = self.backend(
+                "social_core.backends.saml.SAMLAuth", ID_KEY="custom_id"
+            )
+        except ImportError:  # pragma: no cover
+            self.skipTest("python3-saml is not installed")
+        idp = Mock()
+        idp.name = "idp"
+        idp.get_user_permanent_id.return_value = "permanent-id"
+        backend.get_idp = Mock(return_value=idp)
+
+        self.assertEqual(
+            backend.get_user_id(
+                {}, {"idp_name": "idp", "attributes": {"custom_id": "ignored"}}
+            ),
+            "idp:permanent-id",
+        )

--- a/social_core/tests/backends/test_mediawiki.py
+++ b/social_core/tests/backends/test_mediawiki.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import jwt
 
-from social_core.exceptions import AuthException
+from social_core.exceptions import AuthException, AuthMissingParameter
 
 from .base import BaseBackendTest
 
@@ -39,3 +39,42 @@ class MediaWikiTest(BaseBackendTest):
             self.backend.get_user_details(response)
 
         self.assertIs(context.exception.__cause__, error)
+
+    def test_configured_id_key_preserves_identity_claim(self) -> None:
+        self.strategy.set_settings({"SOCIAL_AUTH_MEDIAWIKI_ID_KEY": "sub"})
+        response = {
+            "access_token": {
+                "oauth_token": b"token",
+                "oauth_token_secret": b"secret",
+            }
+        }
+        request = SimpleNamespace(headers={"Authorization": 'oauth_nonce="nonce"'})
+        request_response = SimpleNamespace(content=b"token", request=request)
+        identity = {
+            "iss": "https://example.com/wiki",
+            "iat": 0,
+            "nonce": "nonce",
+            "username": "user",
+            "sub": "stable-subject",
+            "email": "user@example.com",
+        }
+
+        with (
+            patch.object(self.backend, "request", return_value=request_response),
+            patch("social_core.backends.mediawiki.jwt.decode", return_value=identity),
+        ):
+            details = self.backend.get_user_details(response)
+            self.assertEqual(
+                self.backend.get_user_id(details, response),
+                "stable-subject",
+            )
+            self.strategy.set_settings({"SOCIAL_AUTH_MEDIAWIKI_ID_KEY": "email"})
+            email_details = self.backend.get_user_details(response)
+            self.strategy.set_settings(
+                {"SOCIAL_AUTH_MEDIAWIKI_ID_KEY": "missing_claim"}
+            )
+            with self.assertRaisesRegex(AuthMissingParameter, "missing_claim"):
+                self.backend.get_user_details(response)
+
+        self.assertEqual(details["sub"], "stable-subject")
+        self.assertEqual(email_details["email"], "user@example.com")

--- a/social_core/tests/backends/test_naver.py
+++ b/social_core/tests/backends/test_naver.py
@@ -1,5 +1,7 @@
 import json
 
+from social_core.exceptions import AuthMissingParameter
+
 from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
@@ -34,6 +36,29 @@ class NaverOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):
 
     def test_login(self) -> None:
         self.do_login()
+
+    def test_login_with_configured_provider_field_id(self) -> None:
+        self.strategy.set_settings({"SOCIAL_AUTH_NAVER_ID_KEY": "mobile"})
+        self.user_data_body = json.dumps(
+            {
+                "response": {
+                    "id": "32742776",
+                    "email": "openapi@naver.com",
+                    "name": "foobar",
+                    "mobile": "010-1234-5678",
+                }
+            }
+        )
+
+        user = self.do_login()
+
+        self.assertEqual(user.social[0].uid, "010-1234-5678")
+
+    def test_missing_configured_provider_field_id(self) -> None:
+        self.strategy.set_settings({"SOCIAL_AUTH_NAVER_ID_KEY": "mobile"})
+
+        with self.assertRaisesRegex(AuthMissingParameter, "mobile"):
+            self.do_login()
 
     def test_partial_pipeline(self) -> None:
         self.do_partial_pipeline()

--- a/social_core/tests/backends/test_yandex.py
+++ b/social_core/tests/backends/test_yandex.py
@@ -1,12 +1,24 @@
 import json
+from types import SimpleNamespace
 
 from social_core.backends.yandex import YandexOpenId
+from social_core.tests.models import TestStorage
+from social_core.tests.strategy import TestStrategy
 
 from .oauth import BaseAuthUrlTestMixin, OAuth2Test
 
 
 def test_yandex_openid_url_uses_https() -> None:
     assert YandexOpenId.URL == "https://openid.yandex.ru"
+
+
+def test_yandex_openid_configured_key_preserves_identity_url_fallback() -> None:
+    strategy = TestStrategy(TestStorage)
+    strategy.set_settings({"SOCIAL_AUTH_YANDEX_OPENID_ID_KEY": "custom_id"})
+    backend = YandexOpenId(strategy)
+    response = SimpleNamespace(identity_url="https://openid.yandex.ru/user")
+
+    assert backend.get_user_id({}, response) == response.identity_url
 
 
 class YandexOAuth2Test(OAuth2Test, BaseAuthUrlTestMixin):

--- a/social_core/tests/backends/test_zotero.py
+++ b/social_core/tests/backends/test_zotero.py
@@ -1,5 +1,7 @@
 from urllib.parse import urlencode
 
+from social_core.exceptions import AuthMissingParameter
+
 from .oauth import OAuth1AuthUrlTestMixin, OAuth1Test
 
 
@@ -24,6 +26,39 @@ class ZoteroOAuth1Test(OAuth1Test, OAuth1AuthUrlTestMixin):
 
     def test_login(self) -> None:
         self.do_login()
+
+    def test_login_with_configured_access_token_id(self) -> None:
+        self.strategy.set_settings({"SOCIAL_AUTH_ZOTERO_ID_KEY": "custom_id"})
+        self.access_token_body = urlencode(
+            {
+                "oauth_token": "foobar",
+                "oauth_token_secret": "rodgsNDK4hLJU1504Atk131G",
+                "userID": "123456_abcdef",
+                "username": "FooBar",
+                "custom_id": "configured",
+            }
+        )
+
+        user = self.do_login()
+
+        self.assertEqual(user.social[0].uid, "configured")
+
+    def test_configured_id_uses_normalized_details_fallback(self) -> None:
+        self.strategy.set_settings({"SOCIAL_AUTH_ZOTERO_ID_KEY": "custom_id"})
+
+        self.assertEqual(
+            self.backend.get_user_id(
+                {"custom_id": "normalized"},
+                {"access_token": {}},
+            ),
+            "normalized",
+        )
+
+    def test_missing_configured_id_raises_missing_parameter(self) -> None:
+        self.strategy.set_settings({"SOCIAL_AUTH_ZOTERO_ID_KEY": "missing_id"})
+
+        with self.assertRaisesRegex(AuthMissingParameter, "missing_id"):
+            self.backend.get_user_id({}, {"access_token": {}})
 
     def test_partial_pipeline(self) -> None:
         self.do_partial_pipeline()

--- a/social_core/tests/test_utils.py
+++ b/social_core/tests/test_utils.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 import requests
 
 from social_core.backends.base import BaseAuth
-from social_core.exceptions import AuthForbidden
+from social_core.exceptions import AuthForbidden, AuthMissingParameter
 from social_core.pipeline.utils import partial_prepare
 from social_core.utils import (
     PARTIAL_PIPELINE_ALLOW_EXTERNAL_RESUME,
@@ -799,3 +799,25 @@ class IdKeyConfigurabilityTest(unittest.TestCase):
 
         self.assertEqual(result, "12345")
         strategy.setting.assert_called_with("ID_KEY", default=None, backend=backend)
+
+    def test_get_user_id_rejects_missing_id_key(self) -> None:
+        for configured_id_key, requires_user_id in (
+            ("missing_id", False),
+            (None, True),
+        ):
+            strategy = Mock()
+            strategy.setting = Mock(return_value=configured_id_key)
+            backend = BaseAuth(strategy=strategy)
+            backend.ID_KEY = "missing_id"
+            backend.REQUIRES_USER_ID = requires_user_id
+
+            for response in ({}, {"missing_id": None}, {"missing_id": ""}):
+                with (
+                    self.subTest(
+                        configured_id_key=configured_id_key,
+                        requires_user_id=requires_user_id,
+                        response=response,
+                    ),
+                    self.assertRaisesRegex(AuthMissingParameter, "missing_id"),
+                ):
+                    backend.get_user_id({}, response)


### PR DESCRIPTION
Several get_user_id() overrides bypassed id_key(), causing configured identifiers to be silently ignored. Use the selected key while preserving backend-specific scoping, validation, and protocol-derived identities.

Fixes #1951

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
