### PR TITLE
test: use Base64URL encoding for tampered JWT payloads

### DIFF
--- a/social_core/tests/backends/open_id_connect.py
+++ b/social_core/tests/backends/open_id_connect.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 import datetime
 import json
 from calendar import timegm
@@ -9,6 +8,7 @@ from urllib.parse import urlparse
 
 import jwt
 import responses
+from jwt.utils import base64url_encode
 
 from social_core.backends.open_id_connect import OpenIdConnectAuth
 from social_core.exceptions import AuthTokenError
@@ -199,7 +199,7 @@ class OpenIdConnectTest(
         if tamper_message:
             header, msg, sig = body["id_token"].split(".")
             id_token["sub"] = "1235"
-            msg = base64.encodebytes(json.dumps(id_token).encode()).decode()
+            msg = base64url_encode(json.dumps(id_token).encode()).decode()
             body["id_token"] = f"{header}.{msg}.{sig}"
 
         return json.dumps(body)


### PR DESCRIPTION
PyJWT 2.14 rejects the newlines produced by standard Base64 encoding before checking signatures. Encode tampered payloads as Base64URL so signature tests reach the intended validation.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
